### PR TITLE
Use ASCII dash in CLI APP_HELP to avoid encoding artifacts

### DIFF
--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -1,0 +1,5 @@
+from vexor.text import Messages
+
+
+def test_app_help_uses_ascii_dash():
+    assert Messages.APP_HELP == "Vexor - A vector-powered CLI for semantic search over files."

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -12,7 +12,7 @@ class Styles:
 
 
 class Messages:
-    APP_HELP = "Vexor – A vector-powered CLI for semantic search over files."
+    APP_HELP = "Vexor - A vector-powered CLI for semantic search over files."
     HELP_QUERY = "Text used to semantically match files."
     HELP_SEARCH_PATH = "Root directory whose search will be performed."
     HELP_SEARCH_TOP = "Number of results to display."


### PR DESCRIPTION
  ## Why
  Some terminals may render non-ASCII dash characters with encoding artifacts.

  ## What changed
  - Replace `Messages.APP_HELP` en dash with ASCII hyphen in `vexor/text.py`
  - Add `tests/unit/test_text.py` with regression test for `Messages.APP_HELP`

  ## Validation
  - `python -m compileall vexor tests/unit/test_text.py`