### PR TITLE
chore(release): bump version to 0.24.0

### DIFF
--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "A vector-powered CLI for semantic search over files (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -30,7 +30,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.23.2"
+__version__ = "0.24.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
## Release 0.24.0

Merging this PR triggers the publish workflow: PyPI release, GitHub release with standalone binaries.

### Highlights

- **feat(mcp)**: built-in MCP stdio server (`vexor mcp`) — semantic search as a native tool in Claude Code, Codex, Cursor, Windsurf, Zed, and any MCP client. Zero new dependencies. See `docs/mcp.md`.
- **BREAKING**: requires Python 3.10+. Python 3.9 is EOL and was already broken at import time (`dataclass(slots=True)`); this is truth-in-labeling only.
- **ci**: Conventional Commits enforced on PR titles.

### Post-release checklist

- [ ] Submit to the official MCP registry and awesome-mcp-servers lists
- [ ] Verify `pip install vexor==0.24.0 && vexor mcp` on a clean environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)