### PR TITLE
feat: MCP registry publishing, env-based setup, and update notices

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vexor",
       "source": "./plugins/vexor",
-      "description": "A vector-powered CLI for semantic search over files (Vexor skill bundle).",
+      "description": "A semantic search engine for files and code (Vexor skill bundle).",
       "category": "developer-tools",
       "tags": ["search", "indexing", "cli"],
       "strict": true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -404,6 +404,74 @@ jobs:
           files: release/*
           body_path: release_notes.md
 
+  publish_mcp_registry:
+    name: Publish to MCP registry
+    needs:
+      - prepare_release
+      - publish_pypi
+    if: >-
+      needs.prepare_release.outputs.release_changed == 'true' &&
+      !contains(needs.prepare_release.outputs.version, 'a') &&
+      !contains(needs.prepare_release.outputs.version, 'b') &&
+      !contains(needs.prepare_release.outputs.version, 'rc')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync server.json version
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare_release.outputs.version }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+
+          version = os.environ["VERSION"]
+          path = pathlib.Path("server.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+          data["version"] = version
+          for package in data.get("packages", []):
+              package["version"] = version
+          path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+          print(f"server.json synced to {version}")
+          PY
+
+      - name: Wait for PyPI to serve the release
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare_release.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            if curl -fsS "https://pypi.org/pypi/vexor/${VERSION}/json" > /dev/null; then
+              echo "PyPI serves vexor ${VERSION}."
+              exit 0
+            fi
+            echo "Waiting for PyPI (${attempt}/30)..."
+            sleep 10
+          done
+          echo "PyPI did not serve vexor ${VERSION} in time." >&2
+          exit 1
+
+      - name: Install mcp-publisher
+        shell: bash
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Publish to MCP registry
+        shell: bash
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
   publish_pypi:
     name: Publish to PyPI
     needs: prepare_release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -463,8 +463,17 @@ jobs:
 
       - name: Install mcp-publisher
         shell: bash
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
+          MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          archive="mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${archive}" \
+            -o "${archive}"
+          echo "${MCP_PUBLISHER_SHA256}  ${archive}" | sha256sum --check --strict
+          tar xzf "${archive}" mcp-publisher
 
       - name: Publish to MCP registry
         shell: bash

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Skill source: [`plugins/vexor/skills/vexor-cli`](https://github.com/scarletkc/ve
 
 ## MCP Server
 
+<!-- mcp-name: io.github.scarletkc/vexor -->
+
 Vexor ships a built-in [MCP](https://modelcontextprotocol.io) stdio server, so any MCP-capable agent (Claude Code, Codex, Cursor, Windsurf, Zed, ...) can use semantic file search as a native tool:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -125,20 +125,25 @@ claude mcp add vexor -- vexor mcp   # Claude Code
 codex mcp add vexor -- vexor mcp    # Codex
 ```
 
-Or configure manually in any MCP client:
+Or configure manually in any MCP client, optionally supplying the API key
+and any config overrides via `env` (no `vexor init` needed):
 
 ```json
 {
   "mcpServers": {
     "vexor": {
       "command": "vexor",
-      "args": ["mcp"]
+      "args": ["mcp"],
+      "env": {
+        "VEXOR_API_KEY": "sk-...",
+        "VEXOR_CONFIG_JSON": "{\"provider\": \"gemini\", \"rerank\": \"bm25\"}"
+      }
     }
   }
 }
 ```
 
-The server exposes two tools: `vexor_search` (semantic file search; auto-indexes on first use) and `vexor_index` (explicit index warm-up). No extra dependencies are required. See [`docs/mcp.md`](https://github.com/scarletkc/vexor/tree/main/docs/mcp.md) for tool schemas and client setup details.
+The server exposes two tools: `vexor_search` (semantic file search) and `vexor_index` (explicit index warm-up). No extra dependencies are required. See [`docs/mcp.md`](https://github.com/scarletkc/vexor/tree/main/docs/mcp.md) for tool schemas, environment variables, and client setup details.
 
 ## Configuration
 
@@ -178,6 +183,7 @@ Config stored in `~/.vexor/config.json`.
 vexor config --set-api-key "YOUR_KEY"
 ```
 Or via environment: `VEXOR_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENAI_API_KEY`, or `VOYAGE_API_KEY`.
+Any config field can also be injected as a JSON object via `VEXOR_CONFIG_JSON` (useful for MCP client configs and CI), merged over `~/.vexor/config.json`.
 
 ### Rerank
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Config stored in `~/.vexor/config.json`.
 ```bash
 vexor config --set-api-key "YOUR_KEY"
 ```
-Or via environment: `VEXOR_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENAI_API_KEY`, or `VOYAGE_API_KEY`.
+Or via environment: `VEXOR_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENAI_API_KEY`, or `VOYAGE_API_KEY`; `VEXOR_API_KEY` takes precedence over a stored key.
 Any config field can also be injected as a JSON object via `VEXOR_CONFIG_JSON` (useful for MCP client configs and CI), merged over `~/.vexor/config.json`.
 
 ### Rerank

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ vexor config --set-extract-backend auto      # auto|thread|process (default: aut
 vexor config --set-embedding-dimensions 1024 # optional, model/provider dependent
 vexor config --clear-embedding-dimensions    # reset to model default dimension
 vexor config --set-auto-index true          # auto-index before search (default)
+vexor config --set-update-check false       # disable the daily update notice (default: on)
 vexor config --rerank bm25                  # optional BM25 rerank for top-k results
 vexor config --rerank flashrank             # FlashRank rerank (requires optional extra)
 vexor config --rerank remote                # remote rerank via HTTP endpoint

--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ Skill source: [`plugins/vexor/skills/vexor-cli`](https://github.com/scarletkc/ve
 
 <!-- mcp-name: io.github.scarletkc/vexor -->
 
-Vexor ships a built-in [MCP](https://modelcontextprotocol.io) stdio server, so any MCP-capable agent (Claude Code, Codex, Cursor, Windsurf, Zed, ...) can use semantic file search as a native tool:
+> [!NOTE]
+> The Agent Skill and the MCP server provide the same core capability — pick **one** per agent.
+> The skill teaches shell-capable agents (Claude Code, Codex) to drive the full CLI and assumes `vexor` is installed on PATH; the MCP server exposes search as native tools, works in any MCP client (Cursor, Windsurf, Zed, ...), and can bootstrap without prior setup via `uvx` and environment variables.
+
+Vexor ships a built-in [MCP](https://modelcontextprotocol.io) stdio server, so any MCP-capable agent can use semantic file search as a native tool:
 
 ```bash
 claude mcp add vexor -- vexor mcp   # Claude Code

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -48,20 +48,67 @@ codex mcp add vexor -- vexor mcp
 If `vexor` is not on the client's PATH, use an absolute command path, or
 `python` with `"args": ["-m", "vexor", "mcp"]`.
 
+### Provider and API key via client config
+
+Instead of running `vexor init`, Vexor can be configured entirely from the
+MCP client config through environment variables, with credentials and
+configuration kept on separate channels:
+
+- `VEXOR_API_KEY` (secret) — the embedding provider API key (the default
+  provider is `openai`, so the key alone is enough for the common case).
+- `VEXOR_REMOTE_RERANK_API_KEY` (secret) — the remote reranker API key;
+  only needed when `rerank` is set to `remote`.
+- `VEXOR_CONFIG_JSON` (non-secret) — any other Vexor config as a JSON
+  object, merged over `~/.vexor/config.json`. Accepts the same fields as
+  the config file: `provider`, `model`, `base_url`, `rerank`,
+  `embedding_dimensions`, `auto_index`, and so on. Credential fields
+  (`api_key`, `remote_rerank.api_key`) are rejected with a clear error so
+  secrets stay on the dedicated variables above.
+
+```json
+{
+  "mcpServers": {
+    "vexor": {
+      "command": "vexor",
+      "args": ["mcp"],
+      "env": {
+        "VEXOR_API_KEY": "sk-...",
+        "VEXOR_CONFIG_JSON": "{\"provider\": \"gemini\", \"rerank\": \"bm25\"}"
+      }
+    }
+  }
+}
+```
+
+```toml
+# Codex (~/.codex/config.toml)
+[mcp_servers.vexor]
+command = "vexor"
+args = ["mcp"]
+env = { "VEXOR_API_KEY" = "sk-...", "VEXOR_CONFIG_JSON" = '{"provider": "gemini", "rerank": "bm25"}' }
+```
+
+An invalid `VEXOR_CONFIG_JSON` fails loudly with a clear error instead of
+being silently ignored.
+
 ## Tools
 
 ### `vexor_search`
 
-Semantic file search. Auto-indexes the directory on first use (when
-`auto_index` is enabled, the default) and reuses the index afterwards.
+Semantic file search. Scans recursively and respects `.gitignore` by
+default. When `auto_index` is enabled in the Vexor config (the default), a
+missing or stale index is built automatically; otherwise call `vexor_index`
+first.
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
 | `query` | string | required | Natural-language description of the file/code you want |
-| `path` | string | server default path | Directory to search |
-| `top` | integer | 5 | Number of results (1–50) |
+| `path` | string | server default path | Directory to search; absolute, or relative to the server's default path |
+| `top` | integer | 5 | Number of results (1–50; out-of-range values are rejected) |
 | `mode` | string | `auto` | Index mode (`auto`/`name`/`head`/`brief`/`full`/`code`/`outline`) |
-| `include_hidden` | boolean | false | Include hidden files |
+| `include_hidden` | boolean | false | Include dot-prefixed files and directories such as `.github` |
+| `respect_gitignore` | boolean | true | Honor `.gitignore` rules; set false to scan ignored files |
+| `recursive` | boolean | true | Recurse into subdirectories; set false for top level only |
 | `extensions` | string[] | – | Only include these extensions, e.g. `[".py", ".md"]` |
 | `exclude_patterns` | string[] | – | Gitignore-style patterns to exclude |
 
@@ -92,19 +139,26 @@ Returns JSON text:
 ### `vexor_index`
 
 Build or refresh the index for a directory (optional warm-up; searching
-auto-indexes when needed). Accepts the same arguments as `vexor_search`
-except `query` and `top`. Returns `{path, mode, status, files_indexed}` where
-`status` is `stored`, `up_to_date`, or `empty`.
+auto-indexes when `auto_index` is enabled). Accepts the same arguments as
+`vexor_search` except `query` and `top`. Returns
+`{path, mode, status, files_indexed}` where `status` is `stored`,
+`up_to_date`, or `empty`.
 
 ## Behavior notes
 
 - Transport is newline-delimited JSON-RPC 2.0 over stdio; supported protocol
   versions: `2025-06-18`, `2025-03-26`, `2024-11-05`.
+- Both tools declare an `outputSchema` and return `structuredContent`
+  alongside the JSON text payload (MCP 2025-06-18; older clients ignore the
+  extra fields).
+- Relative `path` arguments resolve against the server's default path
+  (`--path`, or the server's working directory).
 - Index cache keys follow the same rules as the CLI (see "Cache Behavior" in
   the README): tool calls with the same path/mode/filters share indexes with
   CLI usage.
 - Execution failures (missing directory, provider errors, missing API key)
   are returned as tool results with `isError: true` so the agent can
-  self-correct; malformed arguments are rejected as JSON-RPC errors.
+  self-correct; malformed arguments (wrong types, out-of-range `top`,
+  unknown mode) are rejected as JSON-RPC `-32602` errors.
 - The server writes exactly one startup line to stderr and never writes
   non-protocol output to stdout.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -54,10 +54,12 @@ Instead of running `vexor init`, Vexor can be configured entirely from the
 MCP client config through environment variables, with credentials and
 configuration kept on separate channels:
 
-- `VEXOR_API_KEY` (secret) — the embedding provider API key (the default
-  provider is `openai`, so the key alone is enough for the common case).
+- `VEXOR_API_KEY` (secret) — the embedding provider API key; takes precedence
+  over a key stored in `~/.vexor/config.json` (the default provider is
+  `openai`, so the key alone is enough for the common case).
 - `VEXOR_REMOTE_RERANK_API_KEY` (secret) — the remote reranker API key;
-  only needed when `rerank` is set to `remote`.
+  takes precedence over a stored reranker key and is only needed when
+  `rerank` is set to `remote`.
 - `VEXOR_CONFIG_JSON` (non-secret) — any other Vexor config as a JSON
   object, merged over `~/.vexor/config.json`. Accepts the same fields as
   the config file: `provider`, `model`, `base_url`, `rerank`,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -48,6 +48,24 @@ codex mcp add vexor -- vexor mcp
 If `vexor` is not on the client's PATH, use an absolute command path, or
 `python` with `"args": ["-m", "vexor", "mcp"]`.
 
+### Running via uvx (no install)
+
+MCP clients can also launch Vexor without installing it, using
+`"command": "uvx", "args": ["vexor", "mcp"]`. Notes for this mode:
+
+- Configuration, index caches, and downloaded models live under `~/.vexor`,
+  so they persist across uvx's ephemeral environments. CLI commands from
+  error messages work with a prefix: `uvx vexor init`, `uvx vexor config --show`.
+- uvx caches the resolved environment and does **not** auto-upgrade; use
+  `uvx vexor@latest mcp` to always run the newest release, or refresh
+  explicitly with `uvx --refresh vexor`. `vexor update --upgrade` applies
+  to PATH installs, not uvx environments.
+- Local (offline) models need the `local` extra, which the default
+  environment does not include — launch with
+  `"command": "uvx", "args": ["--from", "vexor[local]", "vexor", "mcp"]`
+  and set up the model once via
+  `uvx --from "vexor[local]" vexor local --setup`.
+
 ### Provider and API key via client config
 
 Instead of running `vexor init`, Vexor can be configured entirely from the
@@ -164,3 +182,7 @@ auto-indexes when `auto_index` is enabled). Accepts the same arguments as
   unknown mode) are rejected as JSON-RPC `-32602` errors.
 - The server writes exactly one startup line to stderr and never writes
   non-protocol output to stdout.
+- On startup a background thread checks PyPI for a newer release (cached
+  for 24 hours in `~/.vexor/update_check.json`, 5-second timeout, silent on
+  failure) and prints a one-line notice to stderr when an update exists.
+  Set `VEXOR_NO_UPDATE_CHECK=1` to disable the check entirely.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -185,4 +185,7 @@ auto-indexes when `auto_index` is enabled). Accepts the same arguments as
 - On startup a background thread checks PyPI for a newer release (cached
   for 24 hours in `~/.vexor/update_check.json`, 5-second timeout, silent on
   failure) and prints a one-line notice to stderr when an update exists.
-  Set `VEXOR_NO_UPDATE_CHECK=1` to disable the check entirely.
+  Disable it with `vexor config --set-update-check false`, or set
+  `VEXOR_NO_UPDATE_CHECK=1` as a hard off switch. The same daily notice
+  (and the same 24h cache) also applies to interactive CLI usage, where it
+  only appears when stderr is a terminal.

--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vexor",
   "version": "0.24.0",
-  "description": "A vector-powered CLI for semantic search over files (Vexor skill bundle).",
+  "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"
   },

--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vexor"
-description = "A vector-powered CLI for semantic search over files."
+description = "A semantic search engine for files and code."
 readme = "README.md"
 authors = [{ name = "scarletkc" }]
 license = { text = "MIT" }

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -68,6 +68,7 @@ def _parse_args(argv: list[str]) -> tuple[str, bool]:
 def _run(*, version: str, update_gui: bool, repo_root: Path) -> int:
     package_init = repo_root / "vexor" / "__init__.py"
     plugin_manifest = repo_root / "plugins" / "vexor" / ".claude-plugin" / "plugin.json"
+    mcp_server_manifest = repo_root / "server.json"
 
     _set_python_version(package_init, version)
     _set_plugin_version(plugin_manifest, version)
@@ -75,6 +76,10 @@ def _run(*, version: str, update_gui: bool, repo_root: Path) -> int:
     print(f"Updated version to {version}")
     print(f"- {package_init}")
     print(f"- {plugin_manifest}")
+
+    if mcp_server_manifest.exists():
+        _set_mcp_server_version(mcp_server_manifest, version)
+        print(f"- {mcp_server_manifest}")
 
     if update_gui:
         gui_package_json = repo_root / "gui" / "package.json"
@@ -108,6 +113,14 @@ def _set_python_version(path: Path, version: str) -> None:
 def _set_plugin_version(path: Path, version: str) -> None:
     manifest = json.loads(path.read_text(encoding="utf-8"))
     manifest["version"] = version
+    path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _set_mcp_server_version(path: Path, version: str) -> None:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    manifest["version"] = version
+    for package in manifest.get("packages", []):
+        package["version"] = version
     path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.scarletkc/vexor",
+  "title": "Vexor",
+  "description": "A semantic search engine for files and code.",
+  "repository": {
+    "url": "https://github.com/scarletkc/vexor",
+    "source": "github"
+  },
+  "version": "0.24.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "vexor",
+      "version": "0.24.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "description": "Run the MCP stdio server"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "VEXOR_API_KEY",
+          "description": "Embedding provider API key (optional; providers can also be configured via `vexor init`)",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -31,6 +31,17 @@
           "description": "Embedding provider API key (optional; providers can also be configured via `vexor init`)",
           "isRequired": false,
           "isSecret": true
+        },
+        {
+          "name": "VEXOR_REMOTE_RERANK_API_KEY",
+          "description": "Remote reranker API key (optional; only needed when rerank is set to remote)",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "VEXOR_CONFIG_JSON",
+          "description": "Non-secret Vexor config as a JSON object, e.g. {\"provider\": \"gemini\", \"rerank\": \"bm25\"} (optional; merged over ~/.vexor/config.json; credential fields are rejected, use the dedicated variables)",
+          "isRequired": false
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -28,13 +28,13 @@
       "environmentVariables": [
         {
           "name": "VEXOR_API_KEY",
-          "description": "Embedding provider API key (optional; providers can also be configured via `vexor init`)",
+          "description": "Embedding provider API key (optional; overrides a stored key; providers can also be configured via `vexor init`)",
           "isRequired": false,
           "isSecret": true
         },
         {
           "name": "VEXOR_REMOTE_RERANK_API_KEY",
-          "description": "Remote reranker API key (optional; only needed when rerank is set to remote)",
+          "description": "Remote reranker API key (optional; overrides a stored key; only needed when rerank is set to remote)",
           "isRequired": false,
           "isSecret": true
         },

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -297,3 +297,27 @@ def test_mcp_command_round_trip_over_stdio(monkeypatch, tmp_path):
         "vexor_search",
         "vexor_index",
     ]
+
+
+def test_update_refreshes_notice_cache_for_stable_checks(monkeypatch):
+    runner = CliRunner()
+    written = []
+
+    monkeypatch.setattr("vexor.cli.fetch_latest_pypi_version", lambda *_a, **_kw: "99.0.0")
+    monkeypatch.setattr("vexor.cli.write_update_cache", lambda latest, **_kw: written.append(latest))
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 0
+    assert written == ["99.0.0"]
+
+
+def test_update_pre_release_check_does_not_touch_notice_cache(monkeypatch):
+    runner = CliRunner()
+    written = []
+
+    monkeypatch.setattr("vexor.cli.fetch_latest_pypi_version", lambda *_a, **_kw: "99.0.0rc1")
+    monkeypatch.setattr("vexor.cli.write_update_cache", lambda latest, **_kw: written.append(latest))
+
+    result = runner.invoke(app, ["update", "--pre"])
+    assert result.exit_code == 0
+    assert written == []

--- a/tests/unit/test_bump_version_script.py
+++ b/tests/unit/test_bump_version_script.py
@@ -81,3 +81,49 @@ def test_bump_version_updates_gui_with_normalized_semver(tmp_path: Path):
     lock = json.loads((tmp_path / "gui" / "package-lock.json").read_text(encoding="utf-8"))
     assert lock["version"] == "1.2.3-rc1"
     assert lock["packages"][""]["version"] == "1.2.3-rc1"
+
+
+def test_bump_version_syncs_mcp_server_manifest(tmp_path: Path):
+    bump = _load_bump_version_module()
+
+    (tmp_path / "vexor").mkdir(parents=True)
+    (tmp_path / "plugins" / "vexor" / ".claude-plugin").mkdir(parents=True)
+
+    package_init = tmp_path / "vexor" / "__init__.py"
+    package_init.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+
+    plugin_manifest = tmp_path / "plugins" / "vexor" / ".claude-plugin" / "plugin.json"
+    plugin_manifest.write_text(json.dumps({"version": "0.1.0"}, indent=2) + "\n", encoding="utf-8")
+
+    server_manifest = tmp_path / "server.json"
+    server_manifest.write_text(
+        json.dumps(
+            {"version": "0.1.0", "packages": [{"identifier": "vexor", "version": "0.1.0"}]},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    bump._run(version="1.2.3", update_gui=False, repo_root=tmp_path)
+
+    synced = json.loads(server_manifest.read_text(encoding="utf-8"))
+    assert synced["version"] == "1.2.3"
+    assert synced["packages"][0]["version"] == "1.2.3"
+
+
+def test_bump_version_tolerates_missing_mcp_server_manifest(tmp_path: Path):
+    bump = _load_bump_version_module()
+
+    (tmp_path / "vexor").mkdir(parents=True)
+    (tmp_path / "plugins" / "vexor" / ".claude-plugin").mkdir(parents=True)
+
+    package_init = tmp_path / "vexor" / "__init__.py"
+    package_init.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+
+    plugin_manifest = tmp_path / "plugins" / "vexor" / ".claude-plugin" / "plugin.json"
+    plugin_manifest.write_text(json.dumps({"version": "0.1.0"}, indent=2) + "\n", encoding="utf-8")
+
+    bump._run(version="1.2.3", update_gui=False, repo_root=tmp_path)
+
+    assert '__version__ = "1.2.3"' in package_init.read_text(encoding="utf-8")

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -184,3 +184,61 @@ def test_cli_alias_profile_helpers(monkeypatch, tmp_path):
     assert "vexor" in cli._resolve_alias_command("fish")
     assert "Set-Alias" in cli._resolve_alias_command("powershell")
     assert cli._resolve_alias_command("bash").startswith("alias vx=")
+
+
+def test_should_offer_update_notice_gating(monkeypatch):
+    from vexor import cli as cli_module
+
+    monkeypatch.setattr(cli_module.sys.stderr, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(cli_module, "update_check_enabled", lambda: True)
+
+    assert cli_module.should_offer_update_notice(["search", "q"]) is True
+    assert cli_module.should_offer_update_notice([]) is False
+    assert cli_module.should_offer_update_notice(["mcp"]) is False
+    assert cli_module.should_offer_update_notice(["update"]) is False
+    assert cli_module.should_offer_update_notice(["init"]) is False
+    assert cli_module.should_offer_update_notice(["search", "--help"]) is False
+
+    monkeypatch.setattr(cli_module, "update_check_enabled", lambda: False)
+    assert cli_module.should_offer_update_notice(["search", "q"]) is False
+
+    monkeypatch.setattr(cli_module, "update_check_enabled", lambda: True)
+    monkeypatch.setattr(cli_module.sys.stderr, "isatty", lambda: False, raising=False)
+    assert cli_module.should_offer_update_notice(["search", "q"]) is False
+
+
+def test_print_update_notice_reads_cache_only(monkeypatch):
+    from rich.console import Console
+
+    from vexor import cli as cli_module
+
+    captured = {}
+
+    def fake_check(current, *, allow_network=True, **kw):
+        captured["allow_network"] = allow_network
+        return "9.9.9"
+
+    monkeypatch.setattr(cli_module, "check_for_update", fake_check)
+    import io as io_module
+
+    buffer = io_module.StringIO()
+    cli_module.print_update_notice_if_cached(Console(file=buffer, width=200))
+
+    assert captured["allow_network"] is False
+    assert "9.9.9" in buffer.getvalue()
+    assert "vexor update --upgrade" in buffer.getvalue()
+
+
+def test_print_update_notice_silent_without_cache(monkeypatch):
+    from rich.console import Console
+
+    from vexor import cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module, "check_for_update", lambda current, **kw: None
+    )
+    import io as io_module
+
+    buffer = io_module.StringIO()
+    cli_module.print_update_notice_if_cached(Console(file=buffer, width=200))
+    assert buffer.getvalue() == ""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -721,3 +721,25 @@ def test_config_mutation_does_not_persist_env_overrides(tmp_path, monkeypatch):
     assert effective.provider == "gemini"
     assert effective.model == "gemini-embedding-001"
     assert effective.api_key == "env-key"
+
+
+def test_set_update_check_persists_and_loads(tmp_path, monkeypatch):
+    _prepare_config(tmp_path, monkeypatch)
+
+    config_module.set_update_check(False)
+
+    stored = json.loads(config_module.CONFIG_FILE.read_text(encoding="utf-8"))
+    assert stored["update_check"] is False
+    assert config_module.load_config().update_check is False
+
+    config_module.set_update_check(True)
+    assert config_module.load_config().update_check is True
+
+
+def test_update_check_configurable_via_env_json(tmp_path, monkeypatch):
+    _prepare_config(tmp_path, monkeypatch)
+    monkeypatch.setenv(
+        config_module.ENV_CONFIG_JSON, json.dumps({"update_check": False})
+    )
+
+    assert config_module.load_config().update_check is False

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -553,3 +553,99 @@ def test_api_key_resolution_voyage_and_empty_remote_key(monkeypatch):
 
     monkeypatch.delenv(config_module.REMOTE_RERANK_ENV, raising=False)
     assert config_module.resolve_remote_rerank_api_key(None) is None
+
+
+def test_load_config_env_json_without_file(tmp_path, monkeypatch):
+    _prepare_config(tmp_path, monkeypatch)
+    monkeypatch.setenv(
+        config_module.ENV_CONFIG_JSON,
+        json.dumps(
+            {
+                "provider": "gemini",
+                "model": "gemini-embedding-001",
+                "rerank": "bm25",
+                "embedding_dimensions": 1024,
+            }
+        ),
+    )
+
+    cfg = config_module.load_config()
+
+    assert cfg.provider == "gemini"
+    assert cfg.model == "gemini-embedding-001"
+    assert cfg.rerank == "bm25"
+    assert cfg.embedding_dimensions == 1024
+
+
+def test_load_config_env_json_merges_over_file(tmp_path, monkeypatch):
+    config_file = _prepare_config(tmp_path, monkeypatch)
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(
+        json.dumps({"provider": "openai", "batch_size": 32}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        config_module.ENV_CONFIG_JSON,
+        json.dumps({"provider": "voyageai", "model": "voyage-3"}),
+    )
+
+    cfg = config_module.load_config()
+
+    assert cfg.provider == "voyageai"
+    assert cfg.model == "voyage-3"
+    # Fields absent from the env payload keep their file values.
+    assert cfg.batch_size == 32
+
+
+def test_load_config_env_json_invalid_raises(tmp_path, monkeypatch):
+    _prepare_config(tmp_path, monkeypatch)
+    monkeypatch.setenv(config_module.ENV_CONFIG_JSON, "not json")
+
+    with pytest.raises(ValueError, match="VEXOR_CONFIG_JSON"):
+        config_module.load_config()
+
+
+def test_load_config_env_json_rejects_api_key(tmp_path, monkeypatch):
+    _prepare_config(tmp_path, monkeypatch)
+    monkeypatch.setenv(
+        config_module.ENV_CONFIG_JSON, json.dumps({"api_key": "sk-leak"})
+    )
+
+    with pytest.raises(ValueError, match="VEXOR_API_KEY"):
+        config_module.load_config()
+
+
+def test_load_config_env_json_rejects_remote_rerank_api_key(tmp_path, monkeypatch):
+    _prepare_config(tmp_path, monkeypatch)
+    monkeypatch.setenv(
+        config_module.ENV_CONFIG_JSON,
+        json.dumps(
+            {"remote_rerank": {"base_url": "https://r.example.com", "api_key": "sk-leak"}}
+        ),
+    )
+
+    with pytest.raises(ValueError, match="VEXOR_REMOTE_RERANK_API_KEY"):
+        config_module.load_config()
+
+
+def test_load_config_env_json_allows_non_secret_remote_rerank(tmp_path, monkeypatch):
+    _prepare_config(tmp_path, monkeypatch)
+    monkeypatch.setenv(
+        config_module.ENV_CONFIG_JSON,
+        json.dumps(
+            {
+                "rerank": "remote",
+                "remote_rerank": {
+                    "base_url": "https://r.example.com/v1/rerank",
+                    "model": "bge-reranker-v2-m3",
+                },
+            }
+        ),
+    )
+
+    cfg = config_module.load_config()
+
+    assert cfg.rerank == "remote"
+    assert cfg.remote_rerank is not None
+    assert cfg.remote_rerank.model == "bge-reranker-v2-m3"
+    assert cfg.remote_rerank.api_key is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -158,6 +158,7 @@ def test_normalize_remote_rerank_url_keeps_rerank():
 
 
 def test_resolve_api_key_prefers_config(monkeypatch):
+    monkeypatch.delenv(config_module.ENV_API_KEY, raising=False)
     assert config_module.resolve_api_key("cfg-key", "gemini") == "cfg-key"
 
 
@@ -176,6 +177,44 @@ def test_resolve_api_key_custom_uses_openai_env(monkeypatch):
 def test_resolve_api_key_general_env(monkeypatch):
     monkeypatch.setenv(config_module.ENV_API_KEY, "shared-key")
     assert config_module.resolve_api_key(None, "gemini") == "shared-key"
+
+
+def test_load_config_general_env_overrides_stored_key(tmp_path, monkeypatch):
+    config_file = _prepare_config(tmp_path, monkeypatch)
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(json.dumps({"api_key": "stored-key"}), encoding="utf-8")
+    monkeypatch.setenv(config_module.ENV_API_KEY, "env-key")
+
+    config = config_module.load_config()
+
+    assert config.api_key == "env-key"
+    assert config_module.resolve_api_key(config.api_key, "gemini") == "env-key"
+
+
+def test_load_config_remote_rerank_env_overrides_stored_key(tmp_path, monkeypatch):
+    config_file = _prepare_config(tmp_path, monkeypatch)
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(
+        json.dumps(
+            {
+                "remote_rerank": {
+                    "base_url": "https://rerank.example.com",
+                    "api_key": "stored-rerank-key",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(config_module.REMOTE_RERANK_ENV, "env-rerank-key")
+
+    config = config_module.load_config()
+
+    assert config.remote_rerank is not None
+    assert config.remote_rerank.api_key == "env-rerank-key"
+    assert (
+        config_module.resolve_remote_rerank_api_key(config.remote_rerank.api_key)
+        == "env-rerank-key"
+    )
 
 
 def test_resolve_api_key_legacy_gemini_env(monkeypatch):
@@ -649,3 +688,36 @@ def test_load_config_env_json_allows_non_secret_remote_rerank(tmp_path, monkeypa
     assert cfg.remote_rerank is not None
     assert cfg.remote_rerank.model == "bge-reranker-v2-m3"
     assert cfg.remote_rerank.api_key is None
+
+
+def test_config_mutation_does_not_persist_env_overrides(tmp_path, monkeypatch):
+    config_file = _prepare_config(tmp_path, monkeypatch)
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(
+        json.dumps(
+            {
+                "provider": "openai",
+                "model": "text-embedding-3-small",
+                "batch_size": 32,
+                "api_key": "stored-key",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        config_module.ENV_CONFIG_JSON,
+        json.dumps({"provider": "gemini", "model": "gemini-embedding-001"}),
+    )
+    monkeypatch.setenv(config_module.ENV_API_KEY, "env-key")
+
+    config_module.set_batch_size(7)
+
+    stored = json.loads(config_file.read_text(encoding="utf-8"))
+    assert stored["provider"] == "openai"
+    assert stored["model"] == "text-embedding-3-small"
+    assert stored["batch_size"] == 7
+    assert stored["api_key"] == "stored-key"
+    effective = config_module.load_config()
+    assert effective.provider == "gemini"
+    assert effective.model == "gemini-embedding-001"
+    assert effective.api_key == "env-key"

--- a/tests/unit/test_mcp_service.py
+++ b/tests/unit/test_mcp_service.py
@@ -382,3 +382,60 @@ def test_search_result_paths_outside_base_stay_absolute(tmp_path):
     assert payload["results"][0]["path"] == str(
         Path(tmp_path.anchor) / "elsewhere" / "file.py"
     )
+
+
+def test_emit_update_notice_writes_when_newer(monkeypatch, tmp_path):
+    import vexor.services.mcp_service as mcp_service
+    import vexor.services.system_service as system_service
+
+    monkeypatch.delenv(mcp_service.ENV_NO_UPDATE_CHECK, raising=False)
+    monkeypatch.setattr(
+        system_service, "check_for_update", lambda current, **kw: "99.0.0"
+    )
+    stream = io.StringIO()
+    mcp_service.emit_update_notice(stream)
+    assert "99.0.0" in stream.getvalue()
+    assert "vexor update --upgrade" in stream.getvalue()
+
+
+def test_emit_update_notice_silent_when_current(monkeypatch):
+    import vexor.services.mcp_service as mcp_service
+    import vexor.services.system_service as system_service
+
+    monkeypatch.delenv(mcp_service.ENV_NO_UPDATE_CHECK, raising=False)
+    monkeypatch.setattr(
+        system_service, "check_for_update", lambda current, **kw: None
+    )
+    stream = io.StringIO()
+    mcp_service.emit_update_notice(stream)
+    assert stream.getvalue() == ""
+
+
+def test_emit_update_notice_disabled_by_env(monkeypatch):
+    import vexor.services.mcp_service as mcp_service
+    import vexor.services.system_service as system_service
+
+    monkeypatch.setenv(mcp_service.ENV_NO_UPDATE_CHECK, "1")
+
+    def _explode(current, **kw):
+        raise AssertionError("update check must not run when disabled")
+
+    monkeypatch.setattr(system_service, "check_for_update", _explode)
+    stream = io.StringIO()
+    mcp_service.emit_update_notice(stream)
+    assert stream.getvalue() == ""
+
+
+def test_emit_update_notice_swallows_errors(monkeypatch):
+    import vexor.services.mcp_service as mcp_service
+    import vexor.services.system_service as system_service
+
+    monkeypatch.delenv(mcp_service.ENV_NO_UPDATE_CHECK, raising=False)
+
+    def _boom(current, **kw):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(system_service, "check_for_update", _boom)
+    stream = io.StringIO()
+    mcp_service.emit_update_notice(stream)
+    assert stream.getvalue() == ""

--- a/tests/unit/test_mcp_service.py
+++ b/tests/unit/test_mcp_service.py
@@ -244,6 +244,32 @@ def test_tools_advertise_output_schemas_and_strict_input(tmp_path):
     ]
 
 
+@pytest.mark.parametrize("tool_name", [SEARCH_TOOL, INDEX_TOOL])
+def test_tools_reject_unknown_arguments(tmp_path, tool_name):
+    server, client = make_server(tmp_path)
+    arguments = {"recusive": False}
+    if tool_name == SEARCH_TOOL:
+        arguments["query"] = "q"
+
+    response = server.handle_message(tool_call(tool_name, arguments))
+
+    assert response["error"]["code"] == JSONRPC_INVALID_PARAMS
+    assert "recusive" in response["error"]["message"]
+    assert client.search_calls == []
+    assert client.index_calls == []
+
+
+def test_tool_call_rejects_non_object_arguments_and_name(tmp_path):
+    server, _ = make_server(tmp_path)
+    for params in (
+        {"name": INDEX_TOOL, "arguments": []},
+        {"name": INDEX_TOOL, "arguments": None},
+        {"name": 123, "arguments": {}},
+    ):
+        response = server.handle_message(request("tools/call", params))
+        assert response["error"]["code"] == JSONRPC_INVALID_PARAMS, params
+
+
 def test_search_tool_missing_query_is_invalid_params(tmp_path):
     server, _ = make_server(tmp_path)
     response = server.handle_message(tool_call(SEARCH_TOOL, {}))
@@ -257,6 +283,8 @@ def test_search_tool_rejects_bad_argument_types(tmp_path):
         {"query": "q", "mode": "invalid-mode"},
         {"query": "q", "include_hidden": "yes"},
         {"query": "q", "extensions": [1, 2]},
+        {"query": "q", "extensions": ".py"},
+        {"query": "q", "exclude_patterns": "build/**"},
         {"query": "q", "path": 42},
     ]
     for arguments in cases:

--- a/tests/unit/test_mcp_service.py
+++ b/tests/unit/test_mcp_service.py
@@ -173,12 +173,75 @@ def test_search_tool_returns_ranked_results(tmp_path):
     assert client.search_calls[0]["path"] == tmp_path.resolve()
 
 
-def test_search_tool_defaults_and_clamps_top(tmp_path):
+def test_search_tool_top_defaults_and_rejects_out_of_range(tmp_path):
     server, client = make_server(tmp_path)
     server.handle_message(tool_call(SEARCH_TOOL, {"query": "q"}))
-    server.handle_message(tool_call(SEARCH_TOOL, {"query": "q", "top": 999}))
     assert client.search_calls[0]["top"] == 5
-    assert client.search_calls[1]["top"] == 50
+    for bad_top in (0, 999):
+        response = server.handle_message(
+            tool_call(SEARCH_TOOL, {"query": "q", "top": bad_top})
+        )
+        assert response["error"]["code"] == JSONRPC_INVALID_PARAMS, bad_top
+
+
+def test_search_tool_passes_scan_flags(tmp_path):
+    server, client = make_server(tmp_path)
+    server.handle_message(
+        tool_call(
+            SEARCH_TOOL,
+            {"query": "q", "respect_gitignore": False, "recursive": False},
+        )
+    )
+    call = client.search_calls[0]
+    assert call["respect_gitignore"] is False
+    assert call["recursive"] is False
+    # Defaults when omitted.
+    server.handle_message(tool_call(SEARCH_TOOL, {"query": "q"}))
+    call = client.search_calls[1]
+    assert call["respect_gitignore"] is True
+    assert call["recursive"] is True
+
+
+def test_relative_path_resolves_against_default_path(tmp_path):
+    (tmp_path / "src").mkdir()
+    server, client = make_server(tmp_path)
+    response = server.handle_message(
+        tool_call(SEARCH_TOOL, {"query": "q", "path": "src"})
+    )
+    assert response["result"]["isError"] is False
+    assert client.search_calls[0]["path"] == (tmp_path / "src").resolve()
+
+
+def test_success_results_include_structured_content(tmp_path):
+    server, _ = make_server(tmp_path)
+    response = server.handle_message(tool_call(SEARCH_TOOL, {"query": "q"}))
+    result = response["result"]
+    assert result["structuredContent"] == decode_tool_payload(response)
+    assert result["structuredContent"]["results"][0]["rank"] == 1
+
+
+def test_error_results_omit_structured_content(tmp_path):
+    server, _ = make_server(tmp_path, search_error=RuntimeError("boom"))
+    response = server.handle_message(tool_call(SEARCH_TOOL, {"query": "q"}))
+    assert response["result"]["isError"] is True
+    assert "structuredContent" not in response["result"]
+
+
+def test_tools_advertise_output_schemas_and_strict_input(tmp_path):
+    definitions = build_tool_definitions(tmp_path)
+    for tool in definitions:
+        assert tool["inputSchema"]["additionalProperties"] is False
+        assert "outputSchema" in tool
+    search_tool, index_tool = definitions
+    assert search_tool["inputSchema"]["properties"]["query"]["minLength"] == 1
+    assert "respect_gitignore" in search_tool["inputSchema"]["properties"]
+    assert "recursive" in index_tool["inputSchema"]["properties"]
+    assert search_tool["outputSchema"]["properties"]["results"]["type"] == "array"
+    assert index_tool["outputSchema"]["properties"]["status"]["enum"] == [
+        "stored",
+        "up_to_date",
+        "empty",
+    ]
 
 
 def test_search_tool_missing_query_is_invalid_params(tmp_path):

--- a/tests/unit/test_system_service.py
+++ b/tests/unit/test_system_service.py
@@ -638,3 +638,41 @@ def test_check_for_update_never_raises(tmp_path, monkeypatch):
     monkeypatch.setattr(system_service, "fetch_latest_pypi_version", _boom)
     state_file = tmp_path / "update_check.json"
     assert system_service.check_for_update("0.1.0", state_file=state_file) is None
+
+
+def test_check_for_update_cache_only_mode(tmp_path, monkeypatch):
+    from vexor.services import system_service
+
+    def _no_network(*a, **kw):
+        raise AssertionError("cache-only mode must not touch the network")
+
+    monkeypatch.setattr(system_service, "fetch_latest_pypi_version", _no_network)
+    state_file = tmp_path / "update_check.json"
+
+    # Empty cache: returns None without fetching.
+    assert (
+        system_service.check_for_update(
+            "0.1.0", state_file=state_file, allow_network=False
+        )
+        is None
+    )
+
+    system_service.write_update_cache("9.9.9", state_file=state_file)
+    assert (
+        system_service.check_for_update(
+            "0.1.0", state_file=state_file, allow_network=False
+        )
+        == "9.9.9"
+    )
+
+
+def test_update_check_enabled_env_and_config(monkeypatch):
+    from vexor.config import Config, ENV_NO_UPDATE_CHECK
+    from vexor.services import system_service
+
+    monkeypatch.delenv(ENV_NO_UPDATE_CHECK, raising=False)
+    assert system_service.update_check_enabled(Config()) is True
+    assert system_service.update_check_enabled(Config(update_check=False)) is False
+
+    monkeypatch.setenv(ENV_NO_UPDATE_CHECK, "1")
+    assert system_service.update_check_enabled(Config()) is False

--- a/tests/unit/test_system_service.py
+++ b/tests/unit/test_system_service.py
@@ -576,3 +576,65 @@ def test_git_worktree_dirty_handles_success_clean_and_errors(monkeypatch, tmp_pa
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("git missing")),
     )
     assert system_service.git_worktree_is_dirty(tmp_path) is False
+
+
+def test_check_for_update_returns_newer_and_caches(tmp_path, monkeypatch):
+    from vexor.services import system_service
+
+    calls = []
+
+    def fake_fetch(package, *, timeout=5.0, **kw):
+        calls.append(package)
+        return "9.9.9"
+
+    monkeypatch.setattr(system_service, "fetch_latest_pypi_version", fake_fetch)
+    state_file = tmp_path / "update_check.json"
+
+    latest = system_service.check_for_update("0.1.0", state_file=state_file)
+    assert latest == "9.9.9"
+    assert state_file.exists()
+
+    # Second call within the TTL is served from the cache.
+    latest = system_service.check_for_update("0.1.0", state_file=state_file)
+    assert latest == "9.9.9"
+    assert len(calls) == 1
+
+
+def test_check_for_update_returns_none_when_current(tmp_path, monkeypatch):
+    from vexor.services import system_service
+
+    monkeypatch.setattr(
+        system_service, "fetch_latest_pypi_version", lambda *a, **kw: "0.1.0"
+    )
+    state_file = tmp_path / "update_check.json"
+    assert system_service.check_for_update("0.1.0", state_file=state_file) is None
+    assert system_service.check_for_update("9.9.9", state_file=state_file) is None
+
+
+def test_check_for_update_expired_ttl_refetches(tmp_path, monkeypatch):
+    import json as json_module
+
+    from vexor.services import system_service
+
+    state_file = tmp_path / "update_check.json"
+    state_file.write_text(
+        json_module.dumps({"checked_at": 0, "latest": "0.0.1"}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        system_service, "fetch_latest_pypi_version", lambda *a, **kw: "9.9.9"
+    )
+    latest = system_service.check_for_update(
+        "0.1.0", state_file=state_file, ttl_seconds=60
+    )
+    assert latest == "9.9.9"
+
+
+def test_check_for_update_never_raises(tmp_path, monkeypatch):
+    from vexor.services import system_service
+
+    def _boom(*a, **kw):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(system_service, "fetch_latest_pypi_version", _boom)
+    state_file = tmp_path / "update_check.json"
+    assert system_service.check_for_update("0.1.0", state_file=state_file) is None

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -2,4 +2,4 @@ from vexor.text import Messages
 
 
 def test_app_help_uses_ascii_dash():
-    assert Messages.APP_HELP == "Vexor - A vector-powered CLI for semantic search over files."
+    assert Messages.APP_HELP == "Vexor - A semantic search engine for files and code."

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -30,7 +30,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.24.0"
+__version__ = "0.24.1"
 
 
 def get_version() -> str:

--- a/vexor/cli.py
+++ b/vexor/cli.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 from difflib import get_close_matches
 from enum import Enum
 from pathlib import Path
@@ -60,6 +61,7 @@ from .services.system_service import (
     build_standalone_download_url,
     build_upgrade_commands,
     detect_install_method,
+    check_for_update,
     fetch_latest_pypi_version,
     find_command_on_path,
     git_worktree_is_dirty,
@@ -68,6 +70,8 @@ from .services.system_service import (
     resolve_editor_command,
     run_upgrade_commands,
     run_all_doctor_checks,
+    update_check_enabled,
+    write_update_cache,
 )
 from .services.skill_service import (
     DEFAULT_SKILL_NAME,
@@ -794,6 +798,11 @@ def config(
         "--set-auto-index",
         help=Messages.HELP_SET_AUTO_INDEX,
     ),
+    set_update_check_option: str | None = typer.Option(
+        None,
+        "--set-update-check",
+        help=Messages.HELP_SET_UPDATE_CHECK,
+    ),
     clear_flashrank: bool = typer.Option(
         False,
         "--clear-flashrank",
@@ -908,6 +917,7 @@ def config(
             set_base_url_option is not None,
             clear_base_url,
             set_auto_index_option is not None,
+            set_update_check_option is not None,
             set_rerank_option is not None,
             set_flashrank_model_option is not None,
             set_remote_rerank_url_option is not None,
@@ -1010,6 +1020,13 @@ def config(
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
 
+    update_check: bool | None = None
+    if set_update_check_option is not None:
+        try:
+            update_check = _parse_boolean(set_update_check_option)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+
     effective_embedding_dimensions = set_embedding_dimensions_option
     effective_clear_embedding_dimensions = clear_embedding_dimensions
     if effective_embedding_dimensions == 0:
@@ -1049,6 +1066,7 @@ def config(
         base_url=set_base_url_option,
         clear_base_url=clear_base_url,
         auto_index=auto_index,
+        update_check=update_check,
         rerank=set_rerank_option,
         flashrank_model=set_flashrank_model_option,
         remote_rerank_url=set_remote_rerank_url_option,
@@ -1170,6 +1188,11 @@ def config(
         )
     if updates.embedding_dimensions_cleared:
         console.print(_styled(Messages.INFO_EMBEDDING_DIMENSIONS_CLEARED, Styles.SUCCESS))
+    if updates.update_check_set and update_check is not None:
+        state = "enabled" if update_check else "disabled"
+        console.print(
+            _styled(Messages.INFO_UPDATE_CHECK_SET.format(value=state), Styles.SUCCESS)
+        )
 
     if clear_flashrank:
         cache_dir = flashrank_cache_dir(create=False)
@@ -1255,6 +1278,7 @@ def config(
                     extract_concurrency=cfg.extract_concurrency,
                     extract_backend=cfg.extract_backend,
                     auto_index="yes" if cfg.auto_index else "no",
+                    update_check="yes" if cfg.update_check else "no",
                     rerank=rerank,
                     flashrank_line=flashrank_line,
                     remote_rerank_line=remote_rerank_line,
@@ -1611,6 +1635,7 @@ def update(
     console.print(_styled(Messages.INFO_UPDATE_CURRENT.format(current=__version__), Styles.INFO))
     try:
         latest = fetch_latest_pypi_version("vexor", include_prerelease=pre)
+        write_update_cache(latest)
     except RuntimeError as exc:
         console.print(
             _styled(Messages.ERROR_UPDATE_FETCH.format(reason=str(exc)), Styles.ERROR)
@@ -1950,6 +1975,46 @@ def _resolve_alias_command(shell_name: str | None) -> str:
     return Messages.INFO_ALIAS_VX
 
 
+_UPDATE_NOTICE_SKIP_COMMANDS = {"mcp", "update", "init"}
+_UPDATE_NOTICE_SKIP_FLAGS = {"-h", "--help", "-v", "--version"}
+
+
+def should_offer_update_notice(args: Sequence[str]) -> bool:
+    """Return True when this invocation should surface the update notice."""
+    if not args or args[0] in _UPDATE_NOTICE_SKIP_COMMANDS:
+        return False
+    if any(token in _UPDATE_NOTICE_SKIP_FLAGS for token in args):
+        return False
+    if not sys.stderr.isatty():
+        return False
+    try:
+        return update_check_enabled()
+    except Exception:
+        return False
+
+
+def print_update_notice_if_cached(stderr_console: Console | None = None) -> None:
+    """Print the cached update notice; never touches the network."""
+    latest = check_for_update(__version__, allow_network=False)
+    if not latest:
+        return
+    target = stderr_console if stderr_console is not None else Console(stderr=True)
+    target.print(
+        _styled(
+            Messages.CLI_UPDATE_NOTICE.format(latest=latest, current=__version__),
+            Styles.INFO,
+        )
+    )
+
+
+def _refresh_update_cache_async() -> None:
+    threading.Thread(
+        target=lambda: check_for_update(__version__),
+        name="vexor-update-refresh",
+        daemon=True,
+    ).start()
+
+
 def run(argv: list[str] | None = None) -> None:
     """Entry point wrapper allowing optional argument override."""
     args = list(argv) if argv is not None else sys.argv[1:]
@@ -1961,10 +2026,19 @@ def run(argv: list[str] | None = None) -> None:
         console.print(_styled(Messages.INIT_RESUME_TITLE, Styles.INFO))
         console.print(resume_cmd)
         return
-    if argv is None:
-        app()
-    else:
-        app(args=args)
+    offer_notice = should_offer_update_notice(args)
+    if offer_notice:
+        # Warm the TTL cache while the command runs; the notice itself only
+        # ever reads the cache, so it costs nothing on the critical path.
+        _refresh_update_cache_async()
+    try:
+        if argv is None:
+            app()
+        else:
+            app(args=args)
+    finally:
+        if offer_notice:
+            print_update_notice_if_cached()
 
 
 def _format_command(parts: Sequence[str]) -> str:

--- a/vexor/cli.py
+++ b/vexor/cli.py
@@ -1635,7 +1635,11 @@ def update(
     console.print(_styled(Messages.INFO_UPDATE_CURRENT.format(current=__version__), Styles.INFO))
     try:
         latest = fetch_latest_pypi_version("vexor", include_prerelease=pre)
-        write_update_cache(latest)
+        if not pre:
+            # Keep the notice cache on stable-release semantics; pre-release
+            # checks are explicit one-offs and must not steer the passive
+            # notice toward release candidates.
+            write_update_cache(latest)
     except RuntimeError as exc:
         console.print(
             _styled(Messages.ERROR_UPDATE_FETCH.format(reason=str(exc)), Styles.ERROR)

--- a/vexor/cli.py
+++ b/vexor/cli.py
@@ -64,11 +64,10 @@ from .services.system_service import (
     find_command_on_path,
     git_worktree_is_dirty,
     InstallMethod,
-    parse_version,
+    is_version_newer,
     resolve_editor_command,
     run_upgrade_commands,
     run_all_doctor_checks,
-    version_tuple,
 )
 from .services.skill_service import (
     DEFAULT_SKILL_NAME,
@@ -1618,13 +1617,7 @@ def update(
         )
         raise typer.Exit(code=1)
 
-    latest_parsed = parse_version(latest)
-    current_parsed = parse_version(__version__)
-    is_newer = False
-    if latest_parsed and current_parsed:
-        is_newer = latest_parsed > current_parsed
-    elif version_tuple(latest) > version_tuple(__version__):
-        is_newer = True
+    is_newer = is_version_newer(latest, __version__)
 
     if is_newer:
         console.print(

--- a/vexor/config.py
+++ b/vexor/config.py
@@ -46,6 +46,7 @@ DIMENSION_SUPPORTED_MODELS: dict[str, tuple[int, ...]] = {
 }
 ENV_API_KEY = "VEXOR_API_KEY"
 ENV_CONFIG_JSON = "VEXOR_CONFIG_JSON"
+ENV_NO_UPDATE_CHECK = "VEXOR_NO_UPDATE_CHECK"
 REMOTE_RERANK_ENV = "VEXOR_REMOTE_RERANK_API_KEY"
 LEGACY_GEMINI_ENV = "GOOGLE_GENAI_API_KEY"
 OPENAI_ENV = "OPENAI_API_KEY"
@@ -71,6 +72,7 @@ class Config:
     base_url: str | None = None
     auto_index: bool = True
     local_cuda: bool = False
+    update_check: bool = True
     rerank: str = DEFAULT_RERANK
     flashrank_model: str | None = None
     remote_rerank: RemoteRerankConfig | None = None
@@ -187,6 +189,7 @@ def _load_stored_config() -> Config:
         base_url=raw.get("base_url") or None,
         auto_index=bool(raw.get("auto_index", True)),
         local_cuda=bool(raw.get("local_cuda", False)),
+        update_check=bool(raw.get("update_check", True)),
         rerank=rerank,
         flashrank_model=raw.get("flashrank_model") or None,
         remote_rerank=_parse_remote_rerank(raw.get("remote_rerank")),
@@ -217,6 +220,7 @@ def save_config(config: Config) -> None:
         data["base_url"] = config.base_url
     data["auto_index"] = bool(config.auto_index)
     data["local_cuda"] = bool(config.local_cuda)
+    data["update_check"] = bool(config.update_check)
     data["rerank"] = config.rerank
     if config.flashrank_model:
         data["flashrank_model"] = config.flashrank_model
@@ -342,6 +346,12 @@ def set_base_url(value: str | None) -> None:
 def set_auto_index(value: bool) -> None:
     config = _load_stored_config()
     config.auto_index = bool(value)
+    save_config(config)
+
+
+def set_update_check(value: bool) -> None:
+    config = _load_stored_config()
+    config.update_check = bool(value)
     save_config(config)
 
 
@@ -587,6 +597,7 @@ def _clone_config(config: Config) -> Config:
         base_url=config.base_url,
         auto_index=config.auto_index,
         local_cuda=config.local_cuda,
+        update_check=config.update_check,
         rerank=config.rerank,
         flashrank_model=config.flashrank_model,
         remote_rerank=(
@@ -633,6 +644,8 @@ def _apply_config_payload(config: Config, payload: Mapping[str, object]) -> None
         config.base_url = _coerce_optional_str(payload["base_url"], "base_url")
     if "auto_index" in payload:
         config.auto_index = _coerce_bool(payload["auto_index"], "auto_index")
+    if "update_check" in payload:
+        config.update_check = _coerce_bool(payload["update_check"], "update_check")
     if "local_cuda" in payload:
         config.local_cuda = _coerce_bool(payload["local_cuda"], "local_cuda")
     if "rerank" in payload:

--- a/vexor/config.py
+++ b/vexor/config.py
@@ -131,39 +131,50 @@ def _apply_env_overrides(config: Config) -> Config:
     secrets.
     """
     payload = (os.getenv(ENV_CONFIG_JSON) or "").strip()
-    if not payload:
-        return config
-    try:
-        data = _coerce_config_payload(payload)
-        if "api_key" in data:
-            raise ValueError(
-                Messages.ERROR_ENV_CONFIG_JSON_SECRET.format(
-                    field="api_key", env=ENV_API_KEY
+    if payload:
+        try:
+            data = _coerce_config_payload(payload)
+            if "api_key" in data:
+                raise ValueError(
+                    Messages.ERROR_ENV_CONFIG_JSON_SECRET.format(
+                        field="api_key", env=ENV_API_KEY
+                    )
                 )
-            )
-        remote_rerank = data.get("remote_rerank")
-        if isinstance(remote_rerank, Mapping) and "api_key" in remote_rerank:
-            raise ValueError(
-                Messages.ERROR_ENV_CONFIG_JSON_SECRET.format(
-                    field="remote_rerank.api_key", env=REMOTE_RERANK_ENV
+            remote_rerank = data.get("remote_rerank")
+            if isinstance(remote_rerank, Mapping) and "api_key" in remote_rerank:
+                raise ValueError(
+                    Messages.ERROR_ENV_CONFIG_JSON_SECRET.format(
+                        field="remote_rerank.api_key", env=REMOTE_RERANK_ENV
+                    )
                 )
-            )
-        return config_from_json(data, base=config)
-    except ValueError as exc:
-        raise ValueError(
-            Messages.ERROR_ENV_CONFIG_JSON_INVALID.format(reason=exc)
-        ) from exc
+            config = config_from_json(data, base=config)
+        except ValueError as exc:
+            raise ValueError(
+                Messages.ERROR_ENV_CONFIG_JSON_INVALID.format(reason=exc)
+            ) from exc
+
+    # The dedicated secret variables override credentials from the persisted
+    # config. Explicit API arguments are applied after load_config(), so they
+    # can still take precedence over these process-level defaults.
+    api_key = os.getenv(ENV_API_KEY)
+    if api_key:
+        config.api_key = api_key
+    remote_rerank_api_key = os.getenv(REMOTE_RERANK_ENV)
+    if remote_rerank_api_key and config.remote_rerank is not None:
+        config.remote_rerank.api_key = remote_rerank_api_key
+    return config
 
 
-def load_config() -> Config:
+def _load_stored_config() -> Config:
+    """Load the persisted config without applying environment overrides."""
     config_file = _resolve_config_file()
     if not config_file.exists():
-        return _apply_env_overrides(Config())
+        return Config()
     raw = json.loads(config_file.read_text(encoding="utf-8"))
     rerank = (raw.get("rerank") or DEFAULT_RERANK).strip().lower()
     if rerank not in SUPPORTED_RERANKERS:
         rerank = DEFAULT_RERANK
-    return _apply_env_overrides(Config(
+    return Config(
         api_key=raw.get("api_key") or None,
         model=raw.get("model") or DEFAULT_MODEL,
         batch_size=int(raw.get("batch_size", DEFAULT_BATCH_SIZE)),
@@ -180,7 +191,12 @@ def load_config() -> Config:
         flashrank_model=raw.get("flashrank_model") or None,
         remote_rerank=_parse_remote_rerank(raw.get("remote_rerank")),
         embedding_dimensions=_coerce_optional_int(raw.get("embedding_dimensions")),
-    ))
+    )
+
+
+def load_config() -> Config:
+    """Load persisted configuration and apply process-local environment overrides."""
+    return _apply_env_overrides(_load_stored_config())
 
 
 def save_config(config: Config) -> None:
@@ -260,20 +276,20 @@ def update_config_from_json(
     payload: str | Mapping[str, object], *, replace: bool = False
 ) -> Config:
     """Update config from a JSON string or mapping and persist it."""
-    base = None if replace else load_config()
+    base = None if replace else _load_stored_config()
     config = config_from_json(payload, base=base)
     save_config(config)
     return config
 
 
 def set_api_key(value: str | None) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.api_key = value
     save_config(config)
 
 
 def set_model(value: str, *, validate_embedding_dimensions: bool = True) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.model = value
     if validate_embedding_dimensions:
         _validate_config_embedding_dimensions(config)
@@ -281,31 +297,31 @@ def set_model(value: str, *, validate_embedding_dimensions: bool = True) -> None
 
 
 def set_batch_size(value: int) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.batch_size = value
     save_config(config)
 
 
 def set_embed_concurrency(value: int) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.embed_concurrency = value
     save_config(config)
 
 
 def set_extract_concurrency(value: int) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.extract_concurrency = value
     save_config(config)
 
 
 def set_extract_backend(value: str) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.extract_backend = _normalize_extract_backend(value)
     save_config(config)
 
 
 def set_provider(value: str, *, validate_embedding_dimensions: bool = True) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.provider = value
     if validate_embedding_dimensions:
         _validate_config_embedding_dimensions(config)
@@ -313,25 +329,25 @@ def set_provider(value: str, *, validate_embedding_dimensions: bool = True) -> N
 
 
 def set_base_url(value: str | None) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.base_url = value
     save_config(config)
 
 
 def set_auto_index(value: bool) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.auto_index = bool(value)
     save_config(config)
 
 
 def set_local_cuda(value: bool) -> None:
-    config = load_config()
+    config = _load_stored_config()
     config.local_cuda = bool(value)
     save_config(config)
 
 
 def set_rerank(value: str) -> None:
-    config = load_config()
+    config = _load_stored_config()
     normalized = (value or DEFAULT_RERANK).strip().lower()
     if normalized not in SUPPORTED_RERANKERS:
         normalized = DEFAULT_RERANK
@@ -340,7 +356,7 @@ def set_rerank(value: str) -> None:
 
 
 def set_flashrank_model(value: str | None) -> None:
-    config = load_config()
+    config = _load_stored_config()
     clean_value = (value or "").strip()
     config.flashrank_model = clean_value or None
     save_config(config)
@@ -362,7 +378,7 @@ def set_embedding_dimensions(
         ValueError: If value is negative, model doesn't support dimensions,
                    or dimension is not valid for the model.
     """
-    config = load_config()
+    config = _load_stored_config()
 
     # Reject negative values explicitly
     if value is not None and value < 0:
@@ -390,7 +406,7 @@ def update_remote_rerank(
     model: str | None = None,
     clear: bool = False,
 ) -> None:
-    config = load_config()
+    config = _load_stored_config()
     if clear:
         config.remote_rerank = None
         save_config(config)

--- a/vexor/config.py
+++ b/vexor/config.py
@@ -250,6 +250,11 @@ def flashrank_cache_dir(*, create: bool = True) -> Path:
     return cache_dir
 
 
+def update_check_file() -> Path:
+    """Path of the cached update-check state."""
+    return _resolve_config_dir() / "update_check.json"
+
+
 def set_config_dir(path: Path | str | None) -> None:
     global CONFIG_DIR, CONFIG_FILE
     if path is None:

--- a/vexor/config.py
+++ b/vexor/config.py
@@ -45,6 +45,7 @@ DIMENSION_SUPPORTED_MODELS: dict[str, tuple[int, ...]] = {
     "voyage-code-3": (256, 512, 1024, 2048),
 }
 ENV_API_KEY = "VEXOR_API_KEY"
+ENV_CONFIG_JSON = "VEXOR_CONFIG_JSON"
 REMOTE_RERANK_ENV = "VEXOR_REMOTE_RERANK_API_KEY"
 LEGACY_GEMINI_ENV = "GOOGLE_GENAI_API_KEY"
 OPENAI_ENV = "OPENAI_API_KEY"
@@ -120,15 +121,49 @@ def config_dir_context(path: Path | str | None):
         _CONFIG_DIR_OVERRIDE.reset(token)
 
 
+def _apply_env_overrides(config: Config) -> Config:
+    """Merge the VEXOR_CONFIG_JSON environment override over *config*.
+
+    Lets MCP client configs (and CI) inject any non-secret config field via
+    a single environment variable without touching ~/.vexor/config.json.
+    Credentials are rejected so they stay on their dedicated variables
+    (VEXOR_API_KEY, VEXOR_REMOTE_RERANK_API_KEY), which clients treat as
+    secrets.
+    """
+    payload = (os.getenv(ENV_CONFIG_JSON) or "").strip()
+    if not payload:
+        return config
+    try:
+        data = _coerce_config_payload(payload)
+        if "api_key" in data:
+            raise ValueError(
+                Messages.ERROR_ENV_CONFIG_JSON_SECRET.format(
+                    field="api_key", env=ENV_API_KEY
+                )
+            )
+        remote_rerank = data.get("remote_rerank")
+        if isinstance(remote_rerank, Mapping) and "api_key" in remote_rerank:
+            raise ValueError(
+                Messages.ERROR_ENV_CONFIG_JSON_SECRET.format(
+                    field="remote_rerank.api_key", env=REMOTE_RERANK_ENV
+                )
+            )
+        return config_from_json(data, base=config)
+    except ValueError as exc:
+        raise ValueError(
+            Messages.ERROR_ENV_CONFIG_JSON_INVALID.format(reason=exc)
+        ) from exc
+
+
 def load_config() -> Config:
     config_file = _resolve_config_file()
     if not config_file.exists():
-        return Config()
+        return _apply_env_overrides(Config())
     raw = json.loads(config_file.read_text(encoding="utf-8"))
     rerank = (raw.get("rerank") or DEFAULT_RERANK).strip().lower()
     if rerank not in SUPPORTED_RERANKERS:
         rerank = DEFAULT_RERANK
-    return Config(
+    return _apply_env_overrides(Config(
         api_key=raw.get("api_key") or None,
         model=raw.get("model") or DEFAULT_MODEL,
         batch_size=int(raw.get("batch_size", DEFAULT_BATCH_SIZE)),
@@ -145,7 +180,7 @@ def load_config() -> Config:
         flashrank_model=raw.get("flashrank_model") or None,
         remote_rerank=_parse_remote_rerank(raw.get("remote_rerank")),
         embedding_dimensions=_coerce_optional_int(raw.get("embedding_dimensions")),
-    )
+    ))
 
 
 def save_config(config: Config) -> None:

--- a/vexor/services/config_service.py
+++ b/vexor/services/config_service.py
@@ -16,6 +16,7 @@ from ..config import (
     set_extract_backend,
     set_auto_index,
     set_flashrank_model,
+    set_update_check,
     set_local_cuda,
     set_model,
     set_provider,
@@ -37,6 +38,7 @@ class ConfigUpdateResult:
     base_url_set: bool = False
     base_url_cleared: bool = False
     auto_index_set: bool = False
+    update_check_set: bool = False
     local_cuda_set: bool = False
     rerank_set: bool = False
     flashrank_model_set: bool = False
@@ -62,6 +64,7 @@ class ConfigUpdateResult:
                 self.base_url_set,
                 self.base_url_cleared,
                 self.auto_index_set,
+                self.update_check_set,
                 self.local_cuda_set,
                 self.rerank_set,
                 self.flashrank_model_set,
@@ -88,6 +91,7 @@ def apply_config_updates(
     base_url: str | None = None,
     clear_base_url: bool = False,
     auto_index: bool | None = None,
+    update_check: bool | None = None,
     local_cuda: bool | None = None,
     rerank: str | None = None,
     flashrank_model: str | None = None,
@@ -144,6 +148,9 @@ def apply_config_updates(
     if auto_index is not None:
         set_auto_index(auto_index)
         result.auto_index_set = True
+    if update_check is not None:
+        set_update_check(update_check)
+        result.update_check_set = True
     if local_cuda is not None:
         set_local_cuda(local_cuda)
         result.local_cuda_set = True

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -10,18 +10,17 @@ that a tools-only stdio server does not need.
 from __future__ import annotations
 
 import json
-import os
+
 import sys
 import threading
 from pathlib import Path
 from typing import Any, IO, Iterable, Mapping, Sequence, TextIO
 
 from .. import __version__
+from ..config import ENV_NO_UPDATE_CHECK
 from ..modes import available_modes
 from ..text import Messages
 from ..utils import format_path, resolve_directory
-
-ENV_NO_UPDATE_CHECK = "VEXOR_NO_UPDATE_CHECK"
 
 PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
 LATEST_PROTOCOL_VERSION = PROTOCOL_VERSIONS[0]
@@ -568,11 +567,11 @@ def emit_update_notice(stream: TextIO) -> None:
     stays silent on any failure. Never writes to stdout, which is reserved
     for the protocol.
     """
-    if os.getenv(ENV_NO_UPDATE_CHECK):
-        return
     try:
-        from .system_service import check_for_update
+        from .system_service import check_for_update, update_check_enabled
 
+        if not update_check_enabled():
+            return
         latest = check_for_update(__version__)
         if latest:
             print(

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -77,48 +77,97 @@ def _mode_argument(value: Any) -> str:
 def _top_argument(value: Any) -> int:
     if value is None:
         return DEFAULT_TOP
-    if isinstance(value, bool) or not isinstance(value, int):
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= MAX_TOP
+    ):
         raise InvalidToolArguments(
-            Messages.MCP_INVALID_ARGUMENTS.format(reason="'top' must be an integer")
+            Messages.MCP_INVALID_ARGUMENTS.format(
+                reason=f"'top' must be an integer between 1 and {MAX_TOP}"
+            )
         )
-    return max(1, min(value, MAX_TOP))
+    return value
 
 
 def _common_scan_properties(default_path: Path) -> dict[str, Any]:
     return {
         "path": {
             "type": "string",
-            "description": (
-                "Directory to operate on (absolute path preferred). "
-                f"Defaults to {default_path}."
-            ),
+            "description": Messages.MCP_ARG_PATH.format(path=default_path),
         },
         "mode": {
             "type": "string",
             "enum": available_modes(),
             "default": "auto",
-            "description": (
-                "Index granularity: auto routes per file type; name embeds "
-                "filenames only; head/full/brief cover content depth; code "
-                "chunks by AST; outline chunks Markdown by headings."
-            ),
+            "description": Messages.MCP_ARG_MODE,
         },
         "include_hidden": {
             "type": "boolean",
             "default": False,
-            "description": "Include hidden files.",
+            "description": Messages.MCP_ARG_INCLUDE_HIDDEN,
+        },
+        "respect_gitignore": {
+            "type": "boolean",
+            "default": True,
+            "description": Messages.MCP_ARG_RESPECT_GITIGNORE,
+        },
+        "recursive": {
+            "type": "boolean",
+            "default": True,
+            "description": Messages.MCP_ARG_RECURSIVE,
         },
         "extensions": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "Only include these file extensions, e.g. ['.py', '.md'].",
+            "description": Messages.MCP_ARG_EXTENSIONS,
         },
         "exclude_patterns": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "Gitignore-style patterns to exclude.",
+            "description": Messages.MCP_ARG_EXCLUDE_PATTERNS,
         },
     }
+
+
+_RESULT_ITEM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rank": {"type": "integer"},
+        "score": {"type": "number"},
+        "path": {"type": "string"},
+        "absolute_path": {"type": "string"},
+        "start_line": {"type": ["integer", "null"]},
+        "end_line": {"type": ["integer", "null"]},
+        "preview": {"type": ["string", "null"]},
+    },
+    "required": ["rank", "score", "path", "absolute_path"],
+}
+
+SEARCH_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string"},
+        "path": {"type": "string"},
+        "backend": {"type": ["string", "null"]},
+        "reranker": {"type": ["string", "null"]},
+        "stale": {"type": "boolean"},
+        "index_empty": {"type": "boolean"},
+        "results": {"type": "array", "items": _RESULT_ITEM_SCHEMA},
+    },
+    "required": ["query", "path", "results"],
+}
+
+INDEX_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {"type": "string"},
+        "mode": {"type": "string"},
+        "status": {"type": "string", "enum": ["stored", "up_to_date", "empty"]},
+        "files_indexed": {"type": "integer"},
+    },
+    "required": ["path", "mode", "status", "files_indexed"],
+}
 
 
 def build_tool_definitions(default_path: Path) -> list[dict[str, Any]]:
@@ -127,57 +176,56 @@ def build_tool_definitions(default_path: Path) -> list[dict[str, Any]]:
     search_properties: dict[str, Any] = {
         "query": {
             "type": "string",
-            "description": (
-                "Natural-language description of the file or code you are "
-                "looking for, e.g. 'where API retries are configured'."
-            ),
+            "minLength": 1,
+            "description": Messages.MCP_ARG_QUERY,
         },
         "top": {
             "type": "integer",
             "minimum": 1,
             "maximum": MAX_TOP,
             "default": DEFAULT_TOP,
-            "description": "Number of results to return.",
+            "description": Messages.MCP_ARG_TOP,
         },
     }
     search_properties.update(scan_properties)
     return [
         {
             "name": SEARCH_TOOL,
-            "description": (
-                "Semantic file search: find files by describing what they do "
-                "or contain, without knowing names or paths. Auto-indexes the "
-                "directory on first use and reuses the index afterwards."
-            ),
+            "description": Messages.MCP_TOOL_SEARCH_DESCRIPTION,
             "inputSchema": {
                 "type": "object",
                 "properties": search_properties,
                 "required": ["query"],
+                "additionalProperties": False,
             },
+            "outputSchema": SEARCH_OUTPUT_SCHEMA,
         },
         {
             "name": INDEX_TOOL,
-            "description": (
-                "Build or refresh the Vexor semantic index for a directory. "
-                "Optional warm-up: vexor_search indexes automatically when "
-                "needed."
-            ),
+            "description": Messages.MCP_TOOL_INDEX_DESCRIPTION,
             "inputSchema": {
                 "type": "object",
                 "properties": dict(scan_properties),
                 "required": [],
+                "additionalProperties": False,
             },
+            "outputSchema": INDEX_OUTPUT_SCHEMA,
         },
     ]
 
 
 def _text_result(payload: Mapping[str, Any], *, is_error: bool = False) -> dict[str, Any]:
-    return {
+    result: dict[str, Any] = {
         "content": [
             {"type": "text", "text": json.dumps(payload, ensure_ascii=False)}
         ],
         "isError": is_error,
     }
+    if not is_error:
+        # Mirror the text payload as structured content (MCP 2025-06-18);
+        # older clients ignore the extra field.
+        result["structuredContent"] = payload
+    return result
 
 
 def _tool_error(tool: str, reason: str) -> dict[str, Any]:
@@ -314,11 +362,22 @@ class VexorMcpServer:
             raise InvalidToolArguments(
                 Messages.MCP_INVALID_ARGUMENTS.format(reason="'path' must be a string")
             )
+        if raw_path:
+            candidate = Path(raw_path).expanduser()
+            path = candidate if candidate.is_absolute() else self.default_path / candidate
+        else:
+            path = self.default_path
         return {
-            "path": raw_path or self.default_path,
+            "path": path,
             "mode": _mode_argument(arguments.get("mode")),
             "include_hidden": _bool_argument(
                 arguments.get("include_hidden"), "include_hidden"
+            ),
+            "respect_gitignore": _bool_argument(
+                arguments.get("respect_gitignore"), "respect_gitignore", default=True
+            ),
+            "recursive": _bool_argument(
+                arguments.get("recursive"), "recursive", default=True
             ),
             "extensions": _string_list(arguments.get("extensions"), "extensions")
             or None,
@@ -346,6 +405,8 @@ class VexorMcpServer:
                 top=top,
                 mode=scan["mode"],
                 include_hidden=scan["include_hidden"],
+                respect_gitignore=scan["respect_gitignore"],
+                recursive=scan["recursive"],
                 extensions=scan["extensions"],
                 exclude_patterns=scan["exclude_patterns"],
             )
@@ -382,6 +443,8 @@ class VexorMcpServer:
                 directory,
                 mode=scan["mode"],
                 include_hidden=scan["include_hidden"],
+                respect_gitignore=scan["respect_gitignore"],
+                recursive=scan["recursive"],
                 extensions=scan["extensions"],
                 exclude_patterns=scan["exclude_patterns"],
             )

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -10,14 +10,18 @@ that a tools-only stdio server does not need.
 from __future__ import annotations
 
 import json
+import os
 import sys
+import threading
 from pathlib import Path
-from typing import Any, IO, Iterable, Mapping, Sequence
+from typing import Any, IO, Iterable, Mapping, Sequence, TextIO
 
 from .. import __version__
 from ..modes import available_modes
 from ..text import Messages
 from ..utils import format_path, resolve_directory
+
+ENV_NO_UPDATE_CHECK = "VEXOR_NO_UPDATE_CHECK"
 
 PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
 LATEST_PROTOCOL_VERSION = PROTOCOL_VERSIONS[0]
@@ -557,6 +561,41 @@ def serve(server: VexorMcpServer, stdin: Iterable[Any], stdout: IO[Any]) -> None
             _write_line(stdout, json.dumps(response, ensure_ascii=False))
 
 
+def emit_update_notice(stream: TextIO) -> None:
+    """Write a one-line stderr notice when a newer release exists.
+
+    Best-effort: the check is TTL-cached, uses a short network timeout, and
+    stays silent on any failure. Never writes to stdout, which is reserved
+    for the protocol.
+    """
+    if os.getenv(ENV_NO_UPDATE_CHECK):
+        return
+    try:
+        from .system_service import check_for_update
+
+        latest = check_for_update(__version__)
+        if latest:
+            print(
+                Messages.MCP_UPDATE_AVAILABLE.format(
+                    latest=latest, current=__version__
+                ),
+                file=stream,
+                flush=True,
+            )
+    except Exception:
+        pass
+
+
+def _start_update_notice_thread() -> None:
+    thread = threading.Thread(
+        target=emit_update_notice,
+        args=(sys.stderr,),
+        name="vexor-mcp-update-check",
+        daemon=True,
+    )
+    thread.start()
+
+
 def serve_stdio(default_path: Path | str | None = None) -> None:
     """Serve MCP over the process's real stdin/stdout."""
     server = VexorMcpServer(default_path=default_path)
@@ -567,4 +606,5 @@ def serve_stdio(default_path: Path | str | None = None) -> None:
         file=sys.stderr,
         flush=True,
     )
+    _start_update_notice_thread()
     serve(server, stdin, stdout)

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -34,6 +34,22 @@ DEFAULT_TOP = 5
 SEARCH_TOOL = "vexor_search"
 INDEX_TOOL = "vexor_index"
 
+_COMMON_TOOL_ARGUMENTS = frozenset(
+    {
+        "path",
+        "mode",
+        "include_hidden",
+        "respect_gitignore",
+        "recursive",
+        "extensions",
+        "exclude_patterns",
+    }
+)
+_TOOL_ARGUMENTS = {
+    SEARCH_TOOL: _COMMON_TOOL_ARGUMENTS | {"query", "top"},
+    INDEX_TOOL: _COMMON_TOOL_ARGUMENTS,
+}
+
 
 class InvalidToolArguments(ValueError):
     """Raised when tool arguments fail structural validation."""
@@ -42,9 +58,11 @@ class InvalidToolArguments(ValueError):
 def _string_list(value: Any, field: str) -> tuple[str, ...]:
     if value is None:
         return ()
-    if isinstance(value, str):
-        return (value,)
-    if isinstance(value, Sequence) and all(isinstance(item, str) for item in value):
+    if (
+        not isinstance(value, str)
+        and isinstance(value, Sequence)
+        and all(isinstance(item, str) for item in value)
+    ):
         return tuple(value)
     raise InvalidToolArguments(
         Messages.MCP_INVALID_ARGUMENTS.format(
@@ -88,6 +106,19 @@ def _top_argument(value: Any) -> int:
             )
         )
     return value
+
+
+def _validate_tool_arguments(name: str, arguments: Mapping[str, Any]) -> None:
+    unknown = [field for field in arguments if field not in _TOOL_ARGUMENTS[name]]
+    unknown.sort(key=repr)
+    if unknown:
+        raise InvalidToolArguments(
+            Messages.MCP_INVALID_ARGUMENTS.format(
+                reason=Messages.MCP_ARGUMENTS_UNKNOWN.format(
+                    names=", ".join(repr(field) for field in unknown)
+                )
+            )
+        )
 
 
 def _common_scan_properties(default_path: Path) -> dict[str, Any]:
@@ -334,7 +365,15 @@ class VexorMcpServer:
                 Messages.MCP_INVALID_ARGUMENTS.format(reason="params must be an object"),
             )
         name = params.get("name")
-        arguments = params.get("arguments") or {}
+        if not isinstance(name, str):
+            return _error_response(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                Messages.MCP_INVALID_ARGUMENTS.format(
+                    reason=Messages.MCP_TOOL_NAME_INVALID
+                ),
+            )
+        arguments = params.get("arguments", {})
         if not isinstance(arguments, dict):
             return _error_response(
                 request_id,
@@ -352,6 +391,7 @@ class VexorMcpServer:
                 Messages.MCP_UNKNOWN_TOOL.format(name=name),
             )
         try:
+            _validate_tool_arguments(name, arguments)
             return _result_response(request_id, handler(arguments))
         except InvalidToolArguments as exc:
             return _error_response(request_id, JSONRPC_INVALID_PARAMS, str(exc))

--- a/vexor/services/system_service.py
+++ b/vexor/services/system_service.py
@@ -25,6 +25,7 @@ from ..config import (
     RemoteRerankConfig,
     normalize_remote_rerank_url,
     resolve_remote_rerank_api_key,
+    update_check_file,
 )
 from ..text import Messages
 
@@ -537,6 +538,57 @@ def fetch_latest_pypi_version(
 ) -> str:
     versions = fetch_pypi_versions(package, timeout=timeout)
     return select_latest_version(versions, include_prerelease=include_prerelease)
+
+
+UPDATE_CHECK_TTL_SECONDS = 24 * 60 * 60
+
+
+def is_version_newer(candidate: str, current: str) -> bool:
+    """Return True when *candidate* is a newer release than *current*."""
+    candidate_parsed = parse_version(candidate)
+    current_parsed = parse_version(current)
+    if candidate_parsed and current_parsed:
+        return candidate_parsed > current_parsed
+    return version_tuple(candidate) > version_tuple(current)
+
+
+def check_for_update(
+    current_version: str,
+    *,
+    package: str = "vexor",
+    ttl_seconds: int = UPDATE_CHECK_TTL_SECONDS,
+    state_file: Path | None = None,
+    timeout: float = 5.0,
+) -> str | None:
+    """Return the newer available version, or None. Never raises.
+
+    The PyPI result is cached in *state_file* for *ttl_seconds* so
+    frequently spawned processes (such as the MCP server) do not hit the
+    network on every start.
+    """
+    import time
+
+    try:
+        if state_file is None:
+            state_file = update_check_file()
+        now = time.time()
+        latest = ""
+        try:
+            state = json.loads(state_file.read_text(encoding="utf-8"))
+            if now - float(state.get("checked_at", 0)) < ttl_seconds:
+                latest = str(state.get("latest") or "")
+        except (OSError, ValueError):
+            latest = ""
+        if not latest:
+            latest = fetch_latest_pypi_version(package, timeout=timeout)
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(
+                json.dumps({"checked_at": now, "latest": latest}),
+                encoding="utf-8",
+            )
+        return latest if is_version_newer(latest, current_version) else None
+    except Exception:
+        return None
 
 
 class InstallMethod(str, Enum):

--- a/vexor/services/system_service.py
+++ b/vexor/services/system_service.py
@@ -19,8 +19,10 @@ from urllib.parse import urlparse
 from urllib import error, request
 
 from ..config import (
+    Config,
     DEFAULT_FLASHRANK_MODEL,
     DEFAULT_RERANK,
+    ENV_NO_UPDATE_CHECK,
     SUPPORTED_RERANKERS,
     RemoteRerankConfig,
     normalize_remote_rerank_url,
@@ -543,6 +545,24 @@ def fetch_latest_pypi_version(
 UPDATE_CHECK_TTL_SECONDS = 24 * 60 * 60
 
 
+def update_check_enabled(config: Config | None = None) -> bool:
+    """Return True when automatic update checks are allowed.
+
+    The VEXOR_NO_UPDATE_CHECK environment variable is a hard off switch;
+    otherwise the persisted ``update_check`` config field decides.
+    """
+    if os.getenv(ENV_NO_UPDATE_CHECK):
+        return False
+    if config is not None:
+        return bool(getattr(config, "update_check", True))
+    try:
+        from ..config import load_config
+
+        return bool(load_config().update_check)
+    except Exception:
+        return True
+
+
 def is_version_newer(candidate: str, current: str) -> bool:
     """Return True when *candidate* is a newer release than *current*."""
     candidate_parsed = parse_version(candidate)
@@ -552,6 +572,22 @@ def is_version_newer(candidate: str, current: str) -> bool:
     return version_tuple(candidate) > version_tuple(current)
 
 
+def write_update_cache(latest: str, *, state_file: Path | None = None) -> None:
+    """Persist the latest known version for later cache-only reads."""
+    import time
+
+    try:
+        if state_file is None:
+            state_file = update_check_file()
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(
+            json.dumps({"checked_at": time.time(), "latest": latest}),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
+
 def check_for_update(
     current_version: str,
     *,
@@ -559,12 +595,15 @@ def check_for_update(
     ttl_seconds: int = UPDATE_CHECK_TTL_SECONDS,
     state_file: Path | None = None,
     timeout: float = 5.0,
+    allow_network: bool = True,
 ) -> str | None:
     """Return the newer available version, or None. Never raises.
 
     The PyPI result is cached in *state_file* for *ttl_seconds* so
     frequently spawned processes (such as the MCP server) do not hit the
-    network on every start.
+    network on every start. With ``allow_network=False`` only the cache is
+    consulted, which makes the call instant (used by the CLI notice; a
+    background refresh keeps the cache warm for the next invocation).
     """
     import time
 
@@ -580,12 +619,10 @@ def check_for_update(
         except (OSError, ValueError):
             latest = ""
         if not latest:
+            if not allow_network:
+                return None
             latest = fetch_latest_pypi_version(package, timeout=timeout)
-            state_file.parent.mkdir(parents=True, exist_ok=True)
-            state_file.write_text(
-                json.dumps({"checked_at": now, "latest": latest}),
-                encoding="utf-8",
-            )
+            write_update_cache(latest, state_file=state_file)
         return latest if is_version_newer(latest, current_version) else None
     except Exception:
         return None

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -141,6 +141,9 @@ class Messages:
     HELP_SET_BASE_URL = "Override the provider's base URL (leave unset for official endpoints)."
     HELP_CLEAR_BASE_URL = "Remove the custom base URL override."
     HELP_SET_AUTO_INDEX = "Enable/disable automatic indexing before search (default: enabled)."
+    HELP_SET_UPDATE_CHECK = (
+        "Enable/disable the daily background update check (default: enabled)."
+    )
     HELP_SET_RERANK = "Set the rerank strategy (off, bm25, flashrank, remote)."
     HELP_SET_FLASHRANK_MODEL = (
         "Set the FlashRank model name (omit or empty resets to default)."
@@ -367,6 +370,11 @@ class Messages:
     INFO_BASE_URL_SET = "Base URL override set to {value}."
     INFO_BASE_URL_CLEARED = "Base URL override cleared."
     INFO_AUTO_INDEX_SET = "Auto index {value}."
+    INFO_UPDATE_CHECK_SET = "Update check {value}."
+    CLI_UPDATE_NOTICE = (
+        "Vexor {latest} is available (current: {current}). "
+        "Run `vexor update --upgrade` to upgrade."
+    )
     INFO_RERANK_SET = "Rerank strategy set to {value}."
     INFO_FLASHRANK_MODEL_SET = "FlashRank model set to {value}."
     INFO_FLASHRANK_MODEL_RESET = "FlashRank model reset to default ({value})."
@@ -416,6 +424,7 @@ class Messages:
         "Extract concurrency: {extract_concurrency}\n"
         "Extract backend: {extract_backend}\n"
         "Auto index: {auto_index}\n"
+        "Update check: {update_check}\n"
         "Rerank: {rerank}\n"
         "{flashrank_line}"
         "{remote_rerank_line}"

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -73,6 +73,8 @@ class Messages:
     MCP_METHOD_NOT_FOUND = "Method not found: {method}"
     MCP_UNKNOWN_TOOL = "Unknown tool: {name}"
     MCP_INVALID_ARGUMENTS = "Invalid tool arguments: {reason}"
+    MCP_ARGUMENTS_UNKNOWN = "unknown argument(s): {names}"
+    MCP_TOOL_NAME_INVALID = "tool name must be a string"
     MCP_TOOL_FAILED = "{tool} failed: {reason}"
     MCP_TOOL_SEARCH_DESCRIPTION = (
         "Semantic file search: find files by describing what they do or "

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -60,9 +60,10 @@ class Messages:
         "Vexor provides semantic (natural-language) search over files. "
         "Use vexor_search when you know what a file or piece of code does "
         "but not where it lives; describe the content in plain words instead "
-        "of guessing keywords. The first search in a directory builds an "
-        "index automatically; later searches reuse it. Use vexor_index to "
-        "warm or refresh the index explicitly. Requires a configured "
+        "of guessing keywords. When auto_index is enabled in the Vexor "
+        "config (the default), the first search in a directory builds the "
+        "index automatically and later searches reuse it; otherwise call "
+        "vexor_index first. Requires a configured "
         "embedding provider: if tool calls report a missing API key, ask the "
         "user to run `vexor init` (guided setup), set an API key environment "
         "variable such as VEXOR_API_KEY, or install an offline local model "
@@ -73,6 +74,49 @@ class Messages:
     MCP_UNKNOWN_TOOL = "Unknown tool: {name}"
     MCP_INVALID_ARGUMENTS = "Invalid tool arguments: {reason}"
     MCP_TOOL_FAILED = "{tool} failed: {reason}"
+    MCP_TOOL_SEARCH_DESCRIPTION = (
+        "Semantic file search: find files by describing what they do or "
+        "contain, without knowing names or paths. Scans recursively and "
+        "respects .gitignore by default. When auto_index is enabled in the "
+        "Vexor config (the default), a missing or stale index is built "
+        "automatically; otherwise call vexor_index first. Returns ranked "
+        "matches with relative and absolute paths, relevance scores, line "
+        "ranges, and text previews."
+    )
+    MCP_TOOL_INDEX_DESCRIPTION = (
+        "Build or refresh the Vexor semantic index for a directory. Scans "
+        "recursively and respects .gitignore by default. Optional warm-up: "
+        "vexor_search indexes automatically when auto_index is enabled in "
+        "the Vexor config."
+    )
+    MCP_ARG_QUERY = (
+        "Natural-language description of the file or code you are looking "
+        "for, e.g. 'where API retries are configured'."
+    )
+    MCP_ARG_TOP = "Number of results to return."
+    MCP_ARG_PATH = (
+        "Directory to operate on. Absolute, or relative to the server's "
+        "default path ({path})."
+    )
+    MCP_ARG_MODE = (
+        "Index granularity: auto routes per file type; name embeds "
+        "filenames only; head/full/brief cover content depth; code chunks "
+        "by AST; outline chunks Markdown by headings."
+    )
+    MCP_ARG_INCLUDE_HIDDEN = (
+        "Include dot-prefixed files and directories such as .github or "
+        ".env (excluded by default)."
+    )
+    MCP_ARG_RESPECT_GITIGNORE = (
+        "Honor .gitignore rules (default). Set false to also scan ignored "
+        "files such as build output."
+    )
+    MCP_ARG_RECURSIVE = (
+        "Recurse into subdirectories (default). Set false to scan only the "
+        "top level of the directory."
+    )
+    MCP_ARG_EXTENSIONS = "Only include these file extensions, e.g. ['.py', '.md']."
+    MCP_ARG_EXCLUDE_PATTERNS = "Gitignore-style patterns to exclude."
     HELP_STAR = "Star the Vexor repository on GitHub (or use `gh` if available)."
     HELP_ALIAS = "Print a shell alias that maps `vx` to `vexor` and optionally apply it."
     HELP_INIT = "Run the interactive first-run setup wizard."
@@ -350,6 +394,10 @@ class Messages:
     ERROR_CONFIG_EDITOR_FAILED = "Editor exited with status {code}."
     ERROR_CONFIG_EDITOR_LAUNCH = "Failed to launch editor: {reason}."
     ERROR_CONFIG_JSON_INVALID = "Config JSON must be an object."
+    ERROR_ENV_CONFIG_JSON_INVALID = "Invalid VEXOR_CONFIG_JSON: {reason}"
+    ERROR_ENV_CONFIG_JSON_SECRET = (
+        "must not contain '{field}'; use the {env} environment variable instead"
+    )
     ERROR_CONFIG_VALUE_INVALID = "Config JSON has invalid value for {field}."
     INFO_CONFIG_SUMMARY = (
         "API key set: {api}\n"

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -12,7 +12,7 @@ class Styles:
 
 
 class Messages:
-    APP_HELP = "Vexor - A vector-powered CLI for semantic search over files."
+    APP_HELP = "Vexor - A semantic search engine for files and code."
     HELP_QUERY = "Text used to semantically match files."
     HELP_SEARCH_PATH = "Root directory whose search will be performed."
     HELP_SEARCH_TOP = "Number of results to display."
@@ -62,7 +62,11 @@ class Messages:
         "but not where it lives; describe the content in plain words instead "
         "of guessing keywords. The first search in a directory builds an "
         "index automatically; later searches reuse it. Use vexor_index to "
-        "warm or refresh the index explicitly."
+        "warm or refresh the index explicitly. Requires a configured "
+        "embedding provider: if tool calls report a missing API key, ask the "
+        "user to run `vexor init` (guided setup), set an API key environment "
+        "variable such as VEXOR_API_KEY, or install an offline local model "
+        "with `vexor local --setup`."
     )
     MCP_PARSE_ERROR = "Invalid JSON was received."
     MCP_METHOD_NOT_FOUND = "Method not found: {method}"
@@ -119,7 +123,12 @@ class Messages:
 
     ERROR_API_KEY_MISSING = (
         "API key is missing or still set to the placeholder. "
-        "Configure it via `vexor config --set-api-key <token>` or an environment variable."
+        "Run `vexor init` for guided setup, use "
+        "`vexor config --set-api-key <token>`, or set VEXOR_API_KEY "
+        "(works for any provider) or the variable matching the configured "
+        "provider (OPENAI_API_KEY for openai, the default; "
+        "GOOGLE_GENAI_API_KEY for gemini; VOYAGE_API_KEY for voyageai). "
+        "For fully offline use, run `vexor local --setup`."
     )
     ERROR_API_KEY_INVALID = "API key appears invalid. Verify the stored token and try again."
     ERROR_GENAI_PREFIX = "Gemini API request failed: "

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -56,6 +56,11 @@ class Messages:
     )
     HELP_MCP_PATH = "Default directory used when MCP tool calls omit a path."
     MCP_SERVER_READY = "Vexor MCP server ready (stdio). Default path: {path}"
+    MCP_UPDATE_AVAILABLE = (
+        "A newer Vexor version is available: {latest} (current: {current}). "
+        "Run `vexor update --upgrade` to upgrade, or use `uvx vexor@latest` "
+        "if you run Vexor via uvx."
+    )
     MCP_SERVER_INSTRUCTIONS = (
         "Vexor provides semantic (natural-language) search over files. "
         "Use vexor_search when you know what a file or piece of code does "


### PR DESCRIPTION
> **Merging this PR releases 0.24.1** (PyPI + GitHub release + automatic MCP registry publish).

Umbrella PR for making the MCP server distributable and self-sufficient. Nine commits across five themes:

## 1. Official MCP registry publishing (`ci`)

- `server.json` registry entry (`io.github.scarletkc/vexor`, PyPI package, `uvx vexor mcp`), validated against the official 2025-12-11 schema; versions synced by `bump_version.py` and re-synced by CI at publish time
- Hidden `mcp-name` ownership marker in the README (the registry validates it via the PyPI package description — hence the 0.24.1 release)
- New `publish_mcp_registry` job after the PyPI publish: waits until PyPI serves the release, then publishes via `mcp-publisher` with GitHub OIDC (no secrets); the publisher binary is **version-pinned and sha256-verified**; pre-releases skipped

## 2. Env-based configuration for MCP clients (`feat(config)`)

Configure Vexor entirely from the client config, no `vexor init` needed:

```toml
[mcp_servers.vexor]
command = "vexor"
args = ["mcp"]
env = { "VEXOR_API_KEY" = "sk-...", "VEXOR_CONFIG_JSON" = '{"provider": "gemini", "rerank": "bm25"}' }
```

- `VEXOR_CONFIG_JSON` (non-secret): any config field as one JSON object, merged over `~/.vexor/config.json` with full field validation; **credential fields are rejected** with a pointer to the dedicated secret variables (`VEXOR_API_KEY`, `VEXOR_REMOTE_RERANK_API_KEY`)
- Dedicated secret variables now take precedence over stored keys, and **environment overrides never persist to disk** (`vexor config --set-*` writes the stored config only)

## 3. MCP tool contract hardening (`feat(mcp)`)

- Server-side strict validation: unknown arguments, wrong types, out-of-range `top`, and non-string tool names are rejected with JSON-RPC `-32602`
- `outputSchema` declared for both tools; `structuredContent` returned on success
- New `respect_gitignore` / `recursive` arguments (default true); relative `path` resolves against the server default path
- Descriptions match actual behavior (auto-index conditional on config, dot-prefix hidden semantics, documented return fields); all MCP copy centralized in `text.py`
- Zero-config first use fails fast with actionable guidance (`vexor init` / env vars / offline local models), and server instructions tell agents how to guide recovery

## 4. Update notices (`feat(mcp)`, `feat(cli)`)

- MCP server: background thread prints a one-line stderr notice when a newer release exists (stdout stays protocol-only)
- Interactive CLI: same notice after commands, update-notifier style — display reads only the shared **24h TTL cache** (zero latency), a background thread warms the cache for the next invocation; stderr-TTY only, skipped for `mcp`/`update`/`init` and script usage
- Configurable: `vexor config --set-update-check false` (persisted, in `--show`), `VEXOR_NO_UPDATE_CHECK=1` as the hard off switch for both paths; `vexor update` refreshes the same cache
- The notice names both upgrade paths (`vexor update --upgrade` for PATH installs, `uvx vexor@latest` for uvx)

## 5. Docs & copy (`chore`, `docs`)

- One canonical project description everywhere: **"A semantic search engine for files and code."** (PyPI, CLI `--help`, plugin/marketplace manifests, registry entry)
- README: skill vs MCP are alternatives — pick one per agent
- `docs/mcp.md`: client setup (Claude Code / Codex / generic), env variable reference, "Running via uvx" section (cache refresh semantics, `vexor[local]` extra for offline models), tool schemas, behavior notes

## Testing

- `python -m pytest tests` — **487 passed** (+34 over main)
- `server.json` validated against the official registry schema; pinned `mcp-publisher` sha256 verified against the release asset
- Live stdio runs: zero-config guidance, `VEXOR_CONFIG_JSON` injection & credential rejection, strict-validation errors, relative paths, update notice (simulated cache), upgrade/downgrade cache semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
