### PR TITLE
docs(readme): link the official MCP registry listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ and any config overrides via `env` (no `vexor init` needed):
 }
 ```
 
-The server exposes two tools: `vexor_search` (semantic file search) and `vexor_index` (explicit index warm-up). No extra dependencies are required. See [`docs/mcp.md`](https://github.com/scarletkc/vexor/tree/main/docs/mcp.md) for tool schemas, environment variables, and client setup details.
+The server exposes two tools: `vexor_search` (semantic file search) and `vexor_index` (explicit index warm-up). No extra dependencies are required. Vexor is listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.scarletkc/vexor`. See [`docs/mcp.md`](https://github.com/scarletkc/vexor/tree/main/docs/mcp.md) for tool schemas, environment variables, and client setup details.
 
 ## Configuration
 


### PR DESCRIPTION
Adds one line to the MCP Server section noting that Vexor is listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.scarletkc/vexor` — discoverability signal for readers, and the exact name for clients that install from the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)