### PR TITLE
refactor(mcp): simplify tool descriptions

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -115,9 +115,9 @@ being silently ignored.
 
 ### `vexor_search`
 
-Semantic file search. Scans recursively and respects `.gitignore` by
-default. When `auto_index` is enabled in the Vexor config (the default), a
-missing or stale index is built automatically; otherwise call `vexor_index`
+Find files or code from a natural-language description and return ranked
+paths, scores, line ranges, and previews. Missing or stale indexes are built
+automatically when `auto_index` is enabled; otherwise call `vexor_index`
 first.
 
 | Argument | Type | Default | Description |
@@ -158,9 +158,9 @@ Returns JSON text:
 
 ### `vexor_index`
 
-Build or refresh the index for a directory (optional warm-up; searching
-auto-indexes when `auto_index` is enabled). Accepts the same arguments as
-`vexor_search` except `query` and `top`. Returns
+Build or refresh the index for a directory. Use it to warm the cache or when
+`auto_index` is disabled. It accepts the same arguments as `vexor_search`
+except `query` and `top`, and returns
 `{path, mode, status, files_indexed}` where `status` is `stored`,
 `up_to_date`, or `empty`.
 

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -62,17 +62,14 @@ class Messages:
         "if you run Vexor via uvx."
     )
     MCP_SERVER_INSTRUCTIONS = (
-        "Vexor provides semantic (natural-language) search over files. "
-        "Use vexor_search when you know what a file or piece of code does "
-        "but not where it lives; describe the content in plain words instead "
-        "of guessing keywords. When auto_index is enabled in the Vexor "
-        "config (the default), the first search in a directory builds the "
-        "index automatically and later searches reuse it; otherwise call "
-        "vexor_index first. Requires a configured "
-        "embedding provider: if tool calls report a missing API key, ask the "
-        "user to run `vexor init` (guided setup), set an API key environment "
-        "variable such as VEXOR_API_KEY, or install an offline local model "
-        "with `vexor local --setup`."
+        "Vexor searches files and code by meaning. Use vexor_search when you "
+        "know the desired behavior or content but not its name or location; "
+        "describe it in natural language. Use vexor_index to build or refresh "
+        "an index explicitly. Searches recurse and respect .gitignore by "
+        "default; with auto_index enabled (the default), missing or stale "
+        "indexes are built automatically. A configured embedding provider is "
+        "required. If setup is missing, ask the user to run `vexor init`, set "
+        "VEXOR_API_KEY, or run `vexor local --setup` for offline use."
     )
     MCP_PARSE_ERROR = "Invalid JSON was received."
     MCP_METHOD_NOT_FOUND = "Method not found: {method}"
@@ -82,19 +79,12 @@ class Messages:
     MCP_TOOL_NAME_INVALID = "tool name must be a string"
     MCP_TOOL_FAILED = "{tool} failed: {reason}"
     MCP_TOOL_SEARCH_DESCRIPTION = (
-        "Semantic file search: find files by describing what they do or "
-        "contain, without knowing names or paths. Scans recursively and "
-        "respects .gitignore by default. When auto_index is enabled in the "
-        "Vexor config (the default), a missing or stale index is built "
-        "automatically; otherwise call vexor_index first. Returns ranked "
-        "matches with relative and absolute paths, relevance scores, line "
-        "ranges, and text previews."
+        "Find files or code from a natural-language description. Returns "
+        "ranked matches with paths, relevance scores, line ranges, and previews."
     )
     MCP_TOOL_INDEX_DESCRIPTION = (
-        "Build or refresh the Vexor semantic index for a directory. Scans "
-        "recursively and respects .gitignore by default. Optional warm-up: "
-        "vexor_search indexes automatically when auto_index is enabled in "
-        "the Vexor config."
+        "Build or refresh the semantic index for a directory. Use it to warm "
+        "the cache or when auto_index is disabled."
     )
     MCP_ARG_QUERY = (
         "Natural-language description of the file or code you are looking "


### PR DESCRIPTION
## Summary

- simplify the MCP server instructions while preserving setup and indexing guidance
- keep `vexor_search` and `vexor_index` descriptions focused on their distinct responsibilities
- update the MCP documentation to match the advertised tool descriptions

## Why

Shared details about recursion, `.gitignore`, and automatic indexing were repeated across the server instructions and both tool descriptions. This made the tool metadata longer and obscured the distinction between searching and explicit indexing.

## Impact

There are no protocol, schema, or runtime behavior changes. MCP clients receive shorter descriptions with the shared behavior stated once at the server level.

## Validation

- `.venv-1\Scripts\python.exe -m pytest tests/unit/test_mcp_service.py tests/unit/test_text.py -q` — 33 passed
- `.venv-1\Scripts\python.exe -m pytest -q` — 489 passed
- `git diff --check`
