### PR TITLE
chore(release): bump version to 0.24.2

### DIFF
--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/scarletkc/vexor",
     "source": "github"
   },
-  "version": "0.24.1",
+  "version": "0.24.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vexor",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -30,7 +30,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.24.1"
+__version__ = "0.24.2"
 
 
 def get_version() -> str:


### PR DESCRIPTION
> **Merge order**: merge this **last**, after #20, #21, and #22 — merging it triggers the 0.24.2 release (PyPI + GitHub release + MCP registry auto-publish), and the release should include those changes.

## 0.24.2 highlights (once #20–#22 land)

- **fix**: after a stale-triggered auto-reindex, chunk previews and line ranges could misalign because `chunk_ids` was not refreshed from the reloaded metadata (#21)
- **refactor**: `perform_search` / `search_from_vectors` deduplicated into single-source helpers (#21)
- **docs**: README slimmed with reference content moved to `docs/configuration.md` and `docs/cli.md`; roadmap pruned and the hybrid-retrieval design constraints recorded (#22); Glama score badge (#20); official MCP registry link (#18, already merged)

server.json version is synced automatically by `bump_version.py` and re-synced by CI at publish time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)