### PR TITLE
perf(mcp): reduce startup and idle overhead

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -84,6 +84,9 @@ configuration kept on separate channels:
   `embedding_dimensions`, `auto_index`, and so on. Credential fields
   (`api_key`, `remote_rerank.api_key`) are rejected with a clear error so
   secrets stay on the dedicated variables above.
+- `VEXOR_MCP_NUM_THREADS` — numeric-library worker limit for the MCP process;
+  defaults to `2` to avoid large per-process thread-stack reservations. A
+  backend-specific setting such as `OPENBLAS_NUM_THREADS` takes precedence.
 
 ```json
 {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,12 +36,11 @@ never leaving the machine.
   which is O(N) filesystem work on every query today.
 - Replace SQLite vector blobs with `vectors.npy` + `metadata.json`
   (memmap) to reuse across searches.
-- Lazy imports to cut CLI cold start (~0.7s measured) toward ~0.3s;
-  agents may invoke the CLI dozens of times per session so startup
-  latency multiplies.
+- Extend the MCP lazy-start path to other CLI commands; agents may invoke
+  the CLI dozens of times per session so startup latency multiplies.
 - Dependency slimming: move document extractors (`pypdf`, `python-docx`,
-  `python-pptx`) behind a `vexor[docs]` extra; replace the `scikit-learn`
-  dependency with direct NumPy ops if cosine similarity is the only use.
+  `python-pptx`) behind a `vexor[docs]` extra. They are already imported
+  lazily, and cosine similarity now uses direct NumPy operations.
 - Apple Silicon support for local embeddings (issue #7): CoreML/MPS
   execution provider for onnxruntime, or documented guidance.
 - API performance improvements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pathspec>=0.12.1",
     "rank-bm25>=0.2.2",
-    "scikit-learn>=1.3.0",
     "numpy>=1.23.0",
     "tokenizers>=0.15.0",
     "typer>=0.20.0",
@@ -71,7 +70,7 @@ flashrank = [
 Repository = "https://github.com/scarletkc/vexor"
 
 [project.scripts]
-vexor = "vexor.cli:run"
+vexor = "vexor.__main__:main"
 
 [tool.hatch.version]
 path = "vexor/__init__.py"

--- a/tests/unit/test_content_extract_service.py
+++ b/tests/unit/test_content_extract_service.py
@@ -58,7 +58,7 @@ def test_extract_head_from_pdf(monkeypatch, tmp_path):
         def __init__(self, *_):
             self.pages = [DummyPage("PDF snippet one"), DummyPage("Second page text")]
 
-    monkeypatch.setattr(ces, "PdfReader", lambda path: DummyReader(path))
+    monkeypatch.setattr("pypdf.PdfReader", lambda path: DummyReader(path))
 
     snippet = extract_head(pdf_path)
 
@@ -107,7 +107,7 @@ def test_extract_full_chunks_from_pdf(monkeypatch, tmp_path):
         def __init__(self, *_):
             self.pages = [DummyPage("One two three four five six seven eight nine ten" * 5)]
 
-    monkeypatch.setattr(ces, "PdfReader", lambda path: DummyReader(path))
+    monkeypatch.setattr("pypdf.PdfReader", lambda path: DummyReader(path))
 
     chunks = extract_full_chunks(pdf_path, chunk_size=40, overlap=0)
 
@@ -139,7 +139,10 @@ def test_extract_full_chunks_returns_empty_for_unknown_or_empty(tmp_path, monkey
     assert extract_full_chunks(empty) == []
 
     # from_path failure should return no chunks for non-UTF8 payloads
-    monkeypatch.setattr(ces, "from_path", lambda *_args, **_kwargs: (_ for _ in ()).throw(Exception("boom")))
+    monkeypatch.setattr(
+        "charset_normalizer.from_path",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(Exception("boom")),
+    )
     text_path = tmp_path / "boom.txt"
     text_path.write_bytes(b"\xff\xfe\xfd")
     assert extract_full_chunks(text_path) == []
@@ -411,7 +414,7 @@ def test_text_readers_fallback_to_charset_detection(monkeypatch, tmp_path):
         def __len__(self):
             return 0
 
-    monkeypatch.setattr(ces, "from_path", lambda _path: EmptyResult())
+    monkeypatch.setattr("charset_normalizer.from_path", lambda _path: EmptyResult())
     assert ces._read_text_head(data_path) is None
     assert ces._read_text_full(data_path) is None
 
@@ -422,7 +425,7 @@ def test_text_readers_fallback_to_charset_detection(monkeypatch, tmp_path):
         def best(self):
             return None
 
-    monkeypatch.setattr(ces, "from_path", lambda _path: NoBest())
+    monkeypatch.setattr("charset_normalizer.from_path", lambda _path: NoBest())
     assert ces._read_text_head(data_path) is None
     assert ces._read_text_full(data_path) is None
 
@@ -433,7 +436,7 @@ def test_text_readers_fallback_to_charset_detection(monkeypatch, tmp_path):
         def best(self):
             return ""
 
-    monkeypatch.setattr(ces, "from_path", lambda _path: EmptyBest())
+    monkeypatch.setattr("charset_normalizer.from_path", lambda _path: EmptyBest())
     assert ces._read_text_head(data_path) is None
     assert ces._read_text_full(data_path) is None
 
@@ -444,7 +447,7 @@ def test_text_readers_fallback_to_charset_detection(monkeypatch, tmp_path):
         def best(self):
             return " Alpha \n Beta "
 
-    monkeypatch.setattr(ces, "from_path", lambda _path: GoodBest())
+    monkeypatch.setattr("charset_normalizer.from_path", lambda _path: GoodBest())
     assert ces._read_text_head(data_path, char_limit=20) == "Alpha Beta"
     assert ces._read_text_full(data_path, char_limit=6) == " Alpha"
     assert ces._read_text_full(data_path, char_limit=0) == " Alpha \n Beta "
@@ -464,7 +467,10 @@ def test_pdf_extractor_error_and_empty_paths(monkeypatch, tmp_path):
     pdf_path = tmp_path / "sample.pdf"
     pdf_path.write_bytes(b"%PDF")
 
-    monkeypatch.setattr(ces, "PdfReader", lambda _path: (_ for _ in ()).throw(RuntimeError("bad pdf")))
+    monkeypatch.setattr(
+        "pypdf.PdfReader",
+        lambda _path: (_ for _ in ()).throw(RuntimeError("bad pdf")),
+    )
     assert ces._pdf_extractor(pdf_path) is None
 
     class ErrorPage:
@@ -478,7 +484,7 @@ def test_pdf_extractor_error_and_empty_paths(monkeypatch, tmp_path):
     class Reader:
         pages = [ErrorPage(), BlankPage()]
 
-    monkeypatch.setattr(ces, "PdfReader", lambda _path: Reader())
+    monkeypatch.setattr("pypdf.PdfReader", lambda _path: Reader())
     assert ces._pdf_extractor(pdf_path) is None
 
 
@@ -486,15 +492,17 @@ def test_docx_extractor_error_and_empty(monkeypatch, tmp_path):
     doc_path = tmp_path / "sample.docx"
     doc_path.write_bytes(b"bad")
 
-    monkeypatch.setattr(ces, "Document", lambda _path: (_ for _ in ()).throw(RuntimeError("bad docx")))
+    monkeypatch.setattr(
+        "docx.Document",
+        lambda _path: (_ for _ in ()).throw(RuntimeError("bad docx")),
+    )
     assert ces._docx_extractor(doc_path) is None
 
-    monkeypatch.setattr(ces, "Document", lambda _path: SimpleNamespace(paragraphs=[]))
+    monkeypatch.setattr("docx.Document", lambda _path: SimpleNamespace(paragraphs=[]))
     assert ces._docx_extractor(doc_path) is None
 
     monkeypatch.setattr(
-        ces,
-        "Document",
+        "docx.Document",
         lambda _path: SimpleNamespace(
             paragraphs=[
                 SimpleNamespace(text="  "),
@@ -510,10 +518,13 @@ def test_pptx_extractor_error_empty_and_shape_text(monkeypatch, tmp_path):
     ppt_path = tmp_path / "sample.pptx"
     ppt_path.write_bytes(b"bad")
 
-    monkeypatch.setattr(ces, "Presentation", lambda _path: (_ for _ in ()).throw(RuntimeError("bad pptx")))
+    monkeypatch.setattr(
+        "pptx.Presentation",
+        lambda _path: (_ for _ in ()).throw(RuntimeError("bad pptx")),
+    )
     assert ces._pptx_extractor(ppt_path) is None
 
-    monkeypatch.setattr(ces, "Presentation", lambda _path: SimpleNamespace(slides=[]))
+    monkeypatch.setattr("pptx.Presentation", lambda _path: SimpleNamespace(slides=[]))
     assert ces._pptx_extractor(ppt_path) is None
 
     shape_with_text = SimpleNamespace(text_frame=None, text=" Fallback text ")
@@ -536,8 +547,7 @@ def test_pptx_extractor_error_empty_and_shape_text(monkeypatch, tmp_path):
     )
     slide = SimpleNamespace(shapes=[empty_shape, shape_with_text, shape_with_frame])
     monkeypatch.setattr(
-        ces,
-        "Presentation",
+        "pptx.Presentation",
         lambda _path: SimpleNamespace(slides=[slide]),
     )
 

--- a/tests/unit/test_entrypoints.py
+++ b/tests/unit/test_entrypoints.py
@@ -28,3 +28,7 @@ def test_cli_version_flag_prints_version():
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
     assert "Vexor v" in result.stdout
+
+
+def test_public_api_is_loaded_lazily():
+    assert vexor.VexorClient.__module__ == "vexor.api"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import os
 import runpy
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -38,3 +40,105 @@ def test_module_runs_as_script(monkeypatch):
 
     assert called["ok"] is True
     assert exc.value.code is None
+
+
+def test_main_routes_mcp_without_loading_full_cli(monkeypatch):
+    import vexor.__main__ as vexor_main
+
+    called = {}
+    monkeypatch.setattr(sys, "argv", ["vexor", "mcp", "--path", "."])
+    monkeypatch.setattr(
+        vexor_main,
+        "_run_mcp",
+        lambda args: called.setdefault("args", list(args)),
+    )
+    monkeypatch.setattr(
+        vexor_main,
+        "run",
+        lambda: (_ for _ in ()).throw(AssertionError("full CLI should stay unloaded")),
+    )
+
+    vexor_main.main()
+
+    assert called["args"] == ["--path", "."]
+
+
+def test_mcp_help_uses_centralized_messages(monkeypatch, capsys):
+    import vexor.__main__ as vexor_main
+    from vexor.text import Messages
+
+    monkeypatch.setattr(Messages, "HELP_MCP", "Centralized MCP help.")
+    monkeypatch.setattr(Messages, "HELP_MCP_PATH", "Centralized path help.")
+
+    with pytest.raises(SystemExit) as exc:
+        vexor_main._run_mcp(["--help"])
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "Centralized MCP help." in output
+    assert "Centralized path help." in output
+
+
+def test_mcp_accepts_short_path_alias(monkeypatch, tmp_path):
+    import vexor.__main__ as vexor_main
+    import vexor.services.mcp_service as mcp_service
+
+    captured = {}
+    for name in vexor_main._NUMERIC_THREAD_ENV:
+        monkeypatch.setenv(name, "1")
+    monkeypatch.setattr(
+        mcp_service,
+        "serve_stdio",
+        lambda path: captured.setdefault("path", path),
+    )
+
+    vexor_main._run_mcp(["-p", str(tmp_path)])
+
+    assert captured["path"] == tmp_path
+
+
+def test_mcp_runs_when_main_file_is_executed_as_script(monkeypatch, tmp_path):
+    import vexor.__main__ as vexor_main
+    import vexor.services.mcp_service as mcp_service
+
+    captured = {}
+    script_path = Path(vexor_main.__file__)
+    for name in vexor_main._NUMERIC_THREAD_ENV:
+        monkeypatch.setenv(name, "1")
+    monkeypatch.setattr(
+        mcp_service,
+        "serve_stdio",
+        lambda path: captured.setdefault("path", path),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(script_path), "mcp", "--path", str(tmp_path)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(str(script_path), run_name="__main__")
+
+    assert exc.value.code is None
+    assert captured["path"] == tmp_path
+
+
+def test_mcp_numeric_threads_respect_explicit_backend_values(monkeypatch, tmp_path):
+    import vexor.__main__ as vexor_main
+    import vexor.services.mcp_service as mcp_service
+
+    captured = {}
+    for name in vexor_main._NUMERIC_THREAD_ENV:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("VEXOR_MCP_NUM_THREADS", "3")
+    monkeypatch.setenv("OPENBLAS_NUM_THREADS", "7")
+    monkeypatch.setattr(
+        mcp_service,
+        "serve_stdio",
+        lambda path: captured.update(path=path, mkl=os.environ["MKL_NUM_THREADS"]),
+    )
+
+    vexor_main._run_mcp(["--path", str(tmp_path)])
+
+    assert captured == {"path": tmp_path, "mkl": "3"}
+    assert os.environ["OPENBLAS_NUM_THREADS"] == "7"

--- a/tests/unit/test_mcp_service.py
+++ b/tests/unit/test_mcp_service.py
@@ -112,6 +112,16 @@ def test_ping_returns_empty_result(tmp_path):
     assert response == {"jsonrpc": "2.0", "id": 7, "result": {}}
 
 
+def test_protocol_requests_do_not_construct_default_client(tmp_path):
+    server = VexorMcpServer(default_path=tmp_path)
+
+    server.handle_message(request("initialize"))
+    server.handle_message(request("ping"))
+    server.handle_message(request("tools/list"))
+
+    assert server._client is None
+
+
 def test_notifications_produce_no_response(tmp_path):
     server, _ = make_server(tmp_path)
     message = {"jsonrpc": "2.0", "method": "notifications/initialized"}

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -74,7 +74,9 @@ def test_vexor_searcher_creates_gemini_backend(monkeypatch):
         def embed(self, texts):
             return np.zeros((len(texts), 2), dtype=np.float32)
 
-    monkeypatch.setattr("vexor.search.GeminiEmbeddingBackend", DummyGeminiBackend)
+    monkeypatch.setattr(
+        "vexor.providers.gemini.GeminiEmbeddingBackend", DummyGeminiBackend
+    )
     searcher = VexorSearcher(model_name="m", provider="gemini", api_key="k", batch_size=2)
     assert "Gemini" in searcher.device
     assert created["model_name"] == "m"
@@ -92,7 +94,9 @@ def test_vexor_searcher_creates_openai_backend(monkeypatch):
         def embed(self, texts):
             return np.zeros((len(texts), 2), dtype=np.float32)
 
-    monkeypatch.setattr("vexor.search.OpenAIEmbeddingBackend", DummyOpenAIBackend)
+    monkeypatch.setattr(
+        "vexor.providers.openai.OpenAIEmbeddingBackend", DummyOpenAIBackend
+    )
     searcher = VexorSearcher(model_name="m", provider="openai", api_key="k")
     assert "OpenAI" in searcher.device
     assert created["model_name"] == "m"
@@ -109,7 +113,9 @@ def test_vexor_searcher_creates_custom_backend(monkeypatch):
         def embed(self, texts):
             return np.zeros((len(texts), 2), dtype=np.float32)
 
-    monkeypatch.setattr("vexor.search.OpenAIEmbeddingBackend", DummyOpenAIBackend)
+    monkeypatch.setattr(
+        "vexor.providers.openai.OpenAIEmbeddingBackend", DummyOpenAIBackend
+    )
     searcher = VexorSearcher(
         model_name="m",
         provider="custom",
@@ -131,7 +137,9 @@ def test_vexor_searcher_creates_local_backend(monkeypatch):
         def embed(self, texts):
             return np.zeros((len(texts), 2), dtype=np.float32)
 
-    monkeypatch.setattr("vexor.search.LocalEmbeddingBackend", DummyLocalBackend)
+    monkeypatch.setattr(
+        "vexor.providers.local.LocalEmbeddingBackend", DummyLocalBackend
+    )
     searcher = VexorSearcher(model_name="m", provider="local")
     assert "local" in searcher.device.lower()
     assert created["model_name"] == "m"

--- a/tests/unit/test_search_backend.py
+++ b/tests/unit/test_search_backend.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from vexor import search
+from vexor.search import VexorSearcher
 from vexor.providers import gemini as gemini_backend
 from vexor.providers import local as local_backend
 from vexor.providers import openai as openai_backend
@@ -442,7 +442,7 @@ def test_vexor_searcher_embed_texts(monkeypatch):
             self.calls.append(list(texts))
             return np.asarray([[3.0, 4.0]], dtype=np.float32)
 
-    searcher = search.VexorSearcher(backend=DummyBackend())
+    searcher = VexorSearcher(backend=DummyBackend())
     vector = searcher.embed_texts(["name"])
 
     assert np.allclose(vector[0], [0.6, 0.8])  # normalized

--- a/vexor.spec
+++ b/vexor.spec
@@ -112,7 +112,6 @@ else:
 
 hiddenimports = []
 hiddenimports += collect_submodules("google.genai")
-hiddenimports += collect_submodules("sklearn")
 hiddenimports += collect_submodules("tokenizers")
 hiddenimports += collect_submodules("tree_sitter")
 hiddenimports += ["tree_sitter_javascript", "tree_sitter_typescript"]

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -2,18 +2,10 @@
 
 from __future__ import annotations
 
-from .api import (
-    InMemoryIndex,
-    VexorClient,
-    VexorError,
-    clear_index,
-    config_context,
-    index,
-    index_in_memory,
-    search,
-    set_config_json,
-    set_data_dir,
-)
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .api import InMemoryIndex, VexorClient, VexorError
 
 __all__ = [
     "__version__",
@@ -31,6 +23,33 @@ __all__ = [
 ]
 
 __version__ = "0.24.2"
+
+_API_EXPORTS = frozenset(
+    {
+        "InMemoryIndex",
+        "VexorClient",
+        "VexorError",
+        "clear_index",
+        "config_context",
+        "index",
+        "index_in_memory",
+        "search",
+        "set_config_json",
+        "set_data_dir",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Load the public Python API only when an exported object is requested."""
+
+    if name not in _API_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from . import api
+
+    value = getattr(api, name)
+    globals()[name] = value
+    return value
 
 
 def get_version() -> str:

--- a/vexor/__main__.py
+++ b/vexor/__main__.py
@@ -2,15 +2,74 @@
 
 from __future__ import annotations
 
-try:
-    # Normal package execution path
-    from .cli import run
-except ImportError:  # pragma: no cover - happens in frozen single-file builds
-    from vexor.cli import run  # type: ignore[import]
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+_NUMERIC_THREAD_ENV = (
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+
+def run() -> None:
+    """Load and execute the full Typer CLI."""
+
+    try:
+        from .cli import run as run_cli
+    except ImportError:  # pragma: no cover - frozen single-file builds
+        from vexor.cli import run as run_cli  # type: ignore[import]
+    run_cli()
+
+
+def _run_mcp(args: Sequence[str]) -> None:
+    """Parse the small MCP command without importing the full CLI stack."""
+
+    try:
+        from .text import Messages
+    except ImportError:  # pragma: no cover - frozen single-file builds
+        from vexor.text import Messages
+
+    parser = argparse.ArgumentParser(
+        prog="vexor mcp",
+        description=Messages.HELP_MCP,
+    )
+    parser.add_argument(
+        "--path",
+        "-p",
+        type=Path,
+        default=Path.cwd(),
+        help=Messages.HELP_MCP_PATH,
+    )
+    options = parser.parse_args(list(args))
+
+    # Matrix-vector search rarely benefits from a machine-wide BLAS thread
+    # pool, while every reserved worker stack is charged to each MCP process.
+    # Respect explicit backend settings and allow one shared Vexor override.
+    numeric_threads = os.environ.get("VEXOR_MCP_NUM_THREADS", "2").strip()
+    if numeric_threads.isdigit() and int(numeric_threads) > 0:
+        for name in _NUMERIC_THREAD_ENV:
+            os.environ.setdefault(name, numeric_threads)
+
+    try:
+        from .services.mcp_service import serve_stdio
+    except ImportError:  # pragma: no cover - frozen single-file builds
+        from vexor.services.mcp_service import serve_stdio
+
+    serve_stdio(options.path)
 
 
 def main() -> None:
     """Execute the Typer application."""
+
+    args = sys.argv[1:]
+    if args and args[0] == "mcp":
+        _run_mcp(args[1:])
+        return
     run()
 
 

--- a/vexor/search.py
+++ b/vexor/search.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import List, Protocol, Sequence
 
 import numpy as np
-from sklearn.metrics.pairwise import cosine_similarity
 
 from .config import (
     DEFAULT_EMBED_CONCURRENCY,
@@ -17,9 +16,6 @@ from .config import (
     resolve_api_key,
     resolve_base_url,
 )
-from .providers.gemini import GeminiEmbeddingBackend
-from .providers.local import LocalEmbeddingBackend
-from .providers.openai import OpenAIEmbeddingBackend
 from .text import Messages
 
 
@@ -112,9 +108,9 @@ class VexorSearcher:
         file_labels = [self._prepare_text(path) for path in files]
         file_vectors = self._encode(file_labels)
         query_vector = self._encode([clean_query])[0]
-        similarities = cosine_similarity(
-            query_vector.reshape(1, -1), file_vectors
-        )[0]
+        # ``_encode`` L2-normalizes both sides, so the dot product is cosine
+        # similarity without importing the much larger scikit-learn runtime.
+        similarities = file_vectors @ query_vector
         scored = [
             SearchResult(path=path, score=float(score))
             for path, score in zip(files, similarities)
@@ -129,6 +125,8 @@ class VexorSearcher:
 
     def _create_backend(self) -> EmbeddingBackend:
         if self.provider == "gemini":
+            from .providers.gemini import GeminiEmbeddingBackend
+
             self._device = f"{self.model_name} via Gemini API"
             return GeminiEmbeddingBackend(
                 model_name=self.model_name,
@@ -138,6 +136,8 @@ class VexorSearcher:
                 api_key=self.api_key,
             )
         if self.provider == "local":
+            from .providers.local import LocalEmbeddingBackend
+
             self._device = f"{self.model_name} via local model"
             return LocalEmbeddingBackend(
                 model_name=self.model_name,
@@ -146,6 +146,8 @@ class VexorSearcher:
                 cuda=self.local_cuda,
             )
         if self.provider == "voyageai":
+            from .providers.openai import OpenAIEmbeddingBackend
+
             self._device = f"{self.model_name} via Voyage AI API"
             return OpenAIEmbeddingBackend(
                 model_name=self.model_name,
@@ -156,6 +158,8 @@ class VexorSearcher:
                 dimensions=self.embedding_dimensions,
             )
         if self.provider == "custom":
+            from .providers.openai import OpenAIEmbeddingBackend
+
             base_url = (self.base_url or "").strip()
             if not base_url:
                 raise RuntimeError(Messages.ERROR_CUSTOM_BASE_URL_REQUIRED)
@@ -171,6 +175,8 @@ class VexorSearcher:
                 dimensions=self.embedding_dimensions,
             )
         if self.provider == "openai":
+            from .providers.openai import OpenAIEmbeddingBackend
+
             self._device = f"{self.model_name} via OpenAI API"
             return OpenAIEmbeddingBackend(
                 model_name=self.model_name,

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -10,11 +10,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Protocol
 
-from charset_normalizer import from_path
-from docx import Document
-from pptx import Presentation
-from pypdf import PdfReader
-
 HEAD_CHAR_LIMIT = 1000
 FULL_CHAR_LIMIT = 200_000
 DEFAULT_CHUNK_SIZE = 1000
@@ -711,6 +706,8 @@ def _read_text_head(path: Path, char_limit: int = HEAD_CHAR_LIMIT) -> str | None
         return _cleanup_snippet(text)
 
     try:
+        from charset_normalizer import from_path
+
         result = from_path(path)
     except Exception:
         return None
@@ -734,6 +731,8 @@ def _read_text_full(path: Path, char_limit: int = FULL_CHAR_LIMIT) -> str | None
         return text
 
     try:
+        from charset_normalizer import from_path
+
         result = from_path(path)
     except Exception:
         return None
@@ -771,6 +770,8 @@ def _read_text_utf8(path: Path, *, char_limit: int) -> str | None:
 
 def _pdf_extractor(path: Path, char_limit: int = HEAD_CHAR_LIMIT) -> str | None:
     try:
+        from pypdf import PdfReader
+
         reader = PdfReader(str(path))
     except Exception:
         return None
@@ -799,6 +800,8 @@ def _pdf_extractor(path: Path, char_limit: int = HEAD_CHAR_LIMIT) -> str | None:
 
 def _docx_extractor(path: Path, char_limit: int = HEAD_CHAR_LIMIT) -> str | None:
     try:
+        from docx import Document
+
         document = Document(str(path))
     except Exception:
         return None
@@ -823,6 +826,8 @@ def _docx_extractor(path: Path, char_limit: int = HEAD_CHAR_LIMIT) -> str | None
 
 def _pptx_extractor(path: Path, char_limit: int = HEAD_CHAR_LIMIT) -> str | None:
     try:
+        from pptx import Presentation
+
         presentation = Presentation(str(path))
     except Exception:
         return None

--- a/vexor/services/index_service.py
+++ b/vexor/services/index_service.py
@@ -146,7 +146,6 @@ def build_index(
 ) -> IndexResult:
     """Create or refresh the cached index for *directory*."""
 
-    from ..search import VexorSearcher  # local import
     from ..utils import collect_files  # local import
     from ..cache import apply_index_updates, store_index  # local import
 
@@ -160,6 +159,8 @@ def build_index(
     )
     if not files:
         return IndexResult(status=IndexStatus.EMPTY)
+    from ..search import VexorSearcher  # local import
+
     stat_cache: dict[Path, os.stat_result] = {}
     extract_concurrency = _resolve_extract_concurrency(extract_concurrency)
 

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -278,14 +278,19 @@ class VexorMcpServer:
         default_path: Path | str | None = None,
         client: Any | None = None,
     ) -> None:
-        if client is None:
-            from ..api import VexorClient
-
-            client = VexorClient()
         self._client = client
         self.default_path = Path(default_path or Path.cwd()).resolve()
         self.protocol_version = LATEST_PROTOCOL_VERSION
         self.initialized = False
+
+    def _get_client(self) -> Any:
+        """Create the API client only when a tool is first invoked."""
+
+        if self._client is None:
+            from ..api import VexorClient
+
+            self._client = VexorClient()
+        return self._client
 
     # -- JSON-RPC plumbing -------------------------------------------------
 
@@ -442,7 +447,7 @@ class VexorMcpServer:
         scan = self._resolve_scan_arguments(arguments)
         try:
             directory = resolve_directory(scan["path"])
-            response = self._client.search(
+            response = self._get_client().search(
                 query.strip(),
                 path=directory,
                 top=top,
@@ -482,7 +487,7 @@ class VexorMcpServer:
         scan = self._resolve_scan_arguments(arguments)
         try:
             directory = resolve_directory(scan["path"])
-            result = self._client.index(
+            result = self._get_client().index(
                 directory,
                 mode=scan["mode"],
                 include_hidden=scan["include_hidden"],


### PR DESCRIPTION
## Summary

- add a lightweight `vexor mcp` entry path that avoids loading the full Typer CLI
- default MCP numerical-library worker pools to 2 while respecting explicit backend settings
- lazy-load the public API, embedding providers, document extractors, and MCP API client
- replace scikit-learn cosine similarity with normalized NumPy dot products and remove the dependency
- preserve the existing `--path/-p` interface and frozen executable compatibility
- document the runtime setting and add regression coverage

## Why

The MCP stdio process eagerly imported the full CLI, provider, document-processing, and scikit-learn stacks before handling a tool call. Numerical backends could also reserve a machine-wide worker pool for every long-lived MCP process. Together these increased cold-start time, memory reservation, and idle resource use.

## Impact

MCP startup and idle overhead are reduced without changing ordinary CLI routing. `VEXOR_MCP_NUM_THREADS` defaults to `2` only on the MCP path, and backend-specific variables such as `OPENBLAS_NUM_THREADS` continue to take precedence.

In a local before/after measurement, MCP initialization dropped from about 431 ms to 149 ms, while idle working set dropped from about 94 MB to 53 MB.

## Validation

- `.\.venv-1\Scripts\python.exe -m pytest -q` — 496 passed
- `.\.venv-1\Scripts\python.exe vexor\__main__.py mcp --help`
- `git diff --check`
