### PR TITLE
fix(mcp): align search schema with CLI

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -128,6 +128,7 @@ first.
 | `query` | string | required | Natural-language description of the file/code you want |
 | `path` | string | server default path | Directory to search; absolute, or relative to the server's default path |
 | `top` | integer | 5 | Number of results (1–50; out-of-range values are rejected) |
+| `no_cache` | boolean | false | Use a temporary in-memory index and disable disk caches; slower and may regenerate embeddings |
 | `mode` | string | `auto` | Index mode (`auto`/`name`/`head`/`brief`/`full`/`code`/`outline`) |
 | `include_hidden` | boolean | false | Include dot-prefixed files and directories such as `.github` |
 | `respect_gitignore` | boolean | true | Honor `.gitignore` rules; set false to scan ignored files |
@@ -162,8 +163,8 @@ Returns JSON text:
 ### `vexor_index`
 
 Build or refresh the index for a directory. Use it to warm the cache or when
-`auto_index` is disabled. It accepts the same arguments as `vexor_search`
-except `query` and `top`, and returns
+`auto_index` is disabled. It accepts the same scan arguments as
+`vexor_search`, but not `query`, `top`, or `no_cache`, and returns
 `{path, mode, status, files_indexed}` where `status` is `stored`,
 `up_to_date`, or `empty`.
 
@@ -178,17 +179,19 @@ except `query` and `top`, and returns
   (`--path`, or the server's working directory).
 - Index cache keys follow the same rules as the CLI (see
   [Cache Behavior](cli.md#cache-behavior)): tool calls with the same
-  path/mode/filters share indexes with CLI usage.
+  path/mode/filters share indexes with CLI usage. With `no_cache=true`,
+  `vexor_search` instead builds a temporary in-memory index and writes no
+  index, embedding, or query caches.
 - Execution failures (missing directory, provider errors, missing API key)
   are returned as tool results with `isError: true` so the agent can
   self-correct; malformed arguments (wrong types, out-of-range `top`,
   unknown mode) are rejected as JSON-RPC `-32602` errors.
 - The server writes exactly one startup line to stderr and never writes
   non-protocol output to stdout.
-- On startup a background thread checks PyPI for a newer release (cached
-  for 24 hours in `~/.vexor/update_check.json`, 5-second timeout, silent on
-  failure) and prints a one-line notice to stderr when an update exists.
+- On startup a background thread checks PyPI for a newer release. Network
+  checks happen at most once per 24 hours using `~/.vexor/update_check.json`
+  (5-second timeout, silent on failure); while that cache contains a newer
+  version, each MCP start may print a one-line notice to stderr.
   Disable it with `vexor config --set-update-check false`, or set
-  `VEXOR_NO_UPDATE_CHECK=1` as a hard off switch. The same daily notice
-  (and the same 24h cache) also applies to interactive CLI usage, where it
-  only appears when stderr is a terminal.
+  `VEXOR_NO_UPDATE_CHECK=1` as a hard off switch. Interactive CLI usage shares
+  the same cache and only shows the notice when stderr is a terminal.

--- a/tests/unit/test_mcp_service.py
+++ b/tests/unit/test_mcp_service.py
@@ -21,6 +21,7 @@ from vexor.services.mcp_service import (
     serve,
 )
 from vexor.services.search_service import SearchResponse
+from vexor.text import Messages
 
 
 class FakeClient:
@@ -180,6 +181,7 @@ def test_search_tool_returns_ranked_results(tmp_path):
     assert hit["path"] == "./src/config.py"
     assert hit["start_line"] == 1
     assert client.search_calls[0]["top"] == 3
+    assert client.search_calls[0]["no_cache"] is False
     assert client.search_calls[0]["path"] == tmp_path.resolve()
 
 
@@ -199,17 +201,24 @@ def test_search_tool_passes_scan_flags(tmp_path):
     server.handle_message(
         tool_call(
             SEARCH_TOOL,
-            {"query": "q", "respect_gitignore": False, "recursive": False},
+            {
+                "query": "q",
+                "respect_gitignore": False,
+                "recursive": False,
+                "no_cache": True,
+            },
         )
     )
     call = client.search_calls[0]
     assert call["respect_gitignore"] is False
     assert call["recursive"] is False
+    assert call["no_cache"] is True
     # Defaults when omitted.
     server.handle_message(tool_call(SEARCH_TOOL, {"query": "q"}))
     call = client.search_calls[1]
     assert call["respect_gitignore"] is True
     assert call["recursive"] is True
+    assert call["no_cache"] is False
 
 
 def test_relative_path_resolves_against_default_path(tmp_path):
@@ -244,9 +253,24 @@ def test_tools_advertise_output_schemas_and_strict_input(tmp_path):
         assert "outputSchema" in tool
     search_tool, index_tool = definitions
     assert search_tool["inputSchema"]["properties"]["query"]["minLength"] == 1
+    assert search_tool["inputSchema"]["properties"]["no_cache"] == {
+        "type": "boolean",
+        "default": False,
+        "description": Messages.MCP_ARG_NO_CACHE,
+    }
     assert "respect_gitignore" in search_tool["inputSchema"]["properties"]
+    assert "no_cache" not in index_tool["inputSchema"]["properties"]
     assert "recursive" in index_tool["inputSchema"]["properties"]
     assert search_tool["outputSchema"]["properties"]["results"]["type"] == "array"
+    assert set(search_tool["outputSchema"]["required"]) == {
+        "query",
+        "path",
+        "backend",
+        "reranker",
+        "stale",
+        "index_empty",
+        "results",
+    }
     assert index_tool["outputSchema"]["properties"]["status"]["enum"] == [
         "stored",
         "up_to_date",
@@ -292,6 +316,7 @@ def test_search_tool_rejects_bad_argument_types(tmp_path):
         {"query": "q", "top": "five"},
         {"query": "q", "mode": "invalid-mode"},
         {"query": "q", "include_hidden": "yes"},
+        {"query": "q", "no_cache": "yes"},
         {"query": "q", "extensions": [1, 2]},
         {"query": "q", "extensions": ".py"},
         {"query": "q", "exclude_patterns": "build/**"},

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -49,7 +49,7 @@ _COMMON_TOOL_ARGUMENTS = frozenset(
     }
 )
 _TOOL_ARGUMENTS = {
-    SEARCH_TOOL: _COMMON_TOOL_ARGUMENTS | {"query", "top"},
+    SEARCH_TOOL: _COMMON_TOOL_ARGUMENTS | {"query", "top", "no_cache"},
     INDEX_TOOL: _COMMON_TOOL_ARGUMENTS,
 }
 
@@ -189,7 +189,15 @@ SEARCH_OUTPUT_SCHEMA: dict[str, Any] = {
         "index_empty": {"type": "boolean"},
         "results": {"type": "array", "items": _RESULT_ITEM_SCHEMA},
     },
-    "required": ["query", "path", "results"],
+    "required": [
+        "query",
+        "path",
+        "backend",
+        "reranker",
+        "stale",
+        "index_empty",
+        "results",
+    ],
 }
 
 INDEX_OUTPUT_SCHEMA: dict[str, Any] = {
@@ -219,6 +227,11 @@ def build_tool_definitions(default_path: Path) -> list[dict[str, Any]]:
             "maximum": MAX_TOP,
             "default": DEFAULT_TOP,
             "description": Messages.MCP_ARG_TOP,
+        },
+        "no_cache": {
+            "type": "boolean",
+            "default": False,
+            "description": Messages.MCP_ARG_NO_CACHE,
         },
     }
     search_properties.update(scan_properties)
@@ -444,6 +457,7 @@ class VexorMcpServer:
                 )
             )
         top = _top_argument(arguments.get("top"))
+        no_cache = _bool_argument(arguments.get("no_cache"), "no_cache")
         scan = self._resolve_scan_arguments(arguments)
         try:
             directory = resolve_directory(scan["path"])
@@ -457,6 +471,7 @@ class VexorMcpServer:
                 recursive=scan["recursive"],
                 extensions=scan["extensions"],
                 exclude_patterns=scan["exclude_patterns"],
+                no_cache=no_cache,
             )
         except Exception as exc:
             return _tool_error(SEARCH_TOOL, str(exc))

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -91,6 +91,10 @@ class Messages:
         "for, e.g. 'where API retries are configured'."
     )
     MCP_ARG_TOP = "Number of results to return."
+    MCP_ARG_NO_CACHE = (
+        "Build a temporary in-memory index and disable all disk caches for "
+        "this search. Slower and may regenerate embeddings."
+    )
     MCP_ARG_PATH = (
         "Directory to operate on. Absolute, or relative to the server's "
         "default path ({path})."


### PR DESCRIPTION
## Summary

- expose an opt-in `no_cache` argument on `vexor_search`
- mark the always-present backend, reranker, stale, and index-empty status fields as required
- keep `no_cache` search-only and document its temporary in-memory indexing cost
- clarify the difference between the 24-hour update-check cache and per-start notices

## Why

The MCP search surface omitted the CLI/API `no_cache` capability. Its output schema also treated status fields as optional even though successful responses always include them. This left MCP clients with less control and a weaker result contract than the CLI and Python API.

## Impact

Agents can explicitly avoid disk index, embedding, and query caches when required, and clients can rely on the documented status fields. Existing calls are unchanged because `no_cache` defaults to `false`; `vexor_index` remains unchanged and the MCP `top` limit remains 50.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q` — 496 passed
- `git diff --check`
