### PR TITLE
refactor(config): move provider capability metadata to providers/capabilities.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
   - `cli.py`, `__main__.py` — Typer CLI entrypoints; `api.py` — public Python API; `search.py` — search/result models.
   - Shared helpers: `cache.py`, `config.py`, `modes.py`, `output.py`, `text.py`, `utils.py`.
   - `vexor/services/` — orchestration layer: indexing, search, config, cache inspection, content/keyword extraction, JS parsing, init/setup flows, system diagnostics, skill installation, and the MCP stdio server (`mcp_service.py`, exposed via `vexor mcp`).
-  - `vexor/providers/` — embedding provider adapters (`gemini.py`, `openai.py`, `local.py`); the `voyageai` and `custom` providers flow through the OpenAI-compatible path.
+  - `vexor/providers/` — embedding provider adapters (`gemini.py`, `openai.py`, `local.py`) and `capabilities.py` (provider capability metadata: default models, env vars, base URLs, dimension rules); the `voyageai` and `custom` providers flow through the OpenAI-compatible path.
 - `docs/` — `configuration.md`, `cli.md`, `mcp.md`, `api/python.md`, `development.md`, `roadmap.md`. The README stays lean and links into these. `docs/roadmap.md` is the source of truth for priorities.
 - `gui/` — desktop app (Vue + Electron). Maintenance mode: security/dependency bumps only, no new features (see "GUI policy" in the roadmap).
 - `plugins/vexor/` — bundled agent assets, including `skills/vexor-cli/`.

--- a/tests/unit/test_provider_capabilities.py
+++ b/tests/unit/test_provider_capabilities.py
@@ -1,0 +1,73 @@
+import pytest
+
+import vexor.config as config_module
+import vexor.providers.capabilities as caps
+from vexor.providers.capabilities import (
+    DEFAULT_GEMINI_MODEL,
+    DEFAULT_MODEL,
+    VOYAGE_BASE_URL,
+    get_supported_dimensions,
+    resolve_api_key,
+    resolve_base_url,
+    resolve_default_model,
+    supports_dimensions,
+    validate_embedding_dimensions_for_model,
+)
+
+
+def test_resolve_default_model_direct_import():
+    assert resolve_default_model("gemini", None) == DEFAULT_GEMINI_MODEL
+    assert (
+        resolve_default_model("gemini", "text-embedding-3-small")
+        == DEFAULT_GEMINI_MODEL
+    )
+    assert resolve_default_model("openai", "custom-model") == "custom-model"
+
+
+def test_resolve_base_url_direct_import():
+    assert resolve_base_url("voyageai", None) == VOYAGE_BASE_URL
+    assert resolve_base_url("openai", "http://x") == "http://x"
+
+
+def test_resolve_api_key_direct_import(monkeypatch):
+    for env_name in (
+        caps.ENV_API_KEY,
+        caps.LEGACY_GEMINI_ENV,
+        caps.OPENAI_ENV,
+        caps.VOYAGE_ENV,
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+    assert resolve_api_key(None, "local") is None
+    assert resolve_api_key(None, "openai") is None
+
+    monkeypatch.setenv(caps.OPENAI_ENV, "openai-env")
+    assert resolve_api_key(None, "openai") == "openai-env"
+
+    monkeypatch.setenv(caps.ENV_API_KEY, "vexor-env")
+    assert resolve_api_key(None, "openai") == "vexor-env"
+    assert resolve_api_key("configured", "openai") == "configured"
+
+
+def test_dimension_capabilities_direct_import():
+    assert supports_dimensions("text-embedding-3-small") is True
+    assert supports_dimensions("custom-model") is False
+    assert get_supported_dimensions("voyage-3-lite") == (256, 512, 1024, 2048)
+    assert get_supported_dimensions("custom-model") is None
+
+
+def test_validate_embedding_dimensions_direct_import():
+    validate_embedding_dimensions_for_model(None, "custom-model")
+    validate_embedding_dimensions_for_model(512, "text-embedding-3-small")
+
+    with pytest.raises(ValueError, match="does not support custom dimensions"):
+        validate_embedding_dimensions_for_model(512, "custom-model")
+    with pytest.raises(ValueError, match="Dimension 3072 is not supported"):
+        validate_embedding_dimensions_for_model(3072, "text-embedding-3-small")
+
+
+def test_config_re_exports_provider_capabilities_by_identity():
+    assert config_module.DEFAULT_MODEL is caps.DEFAULT_MODEL
+    assert config_module.SUPPORTED_PROVIDERS is caps.SUPPORTED_PROVIDERS
+    assert config_module.resolve_api_key is caps.resolve_api_key
+    assert config_module.resolve_default_model is caps.resolve_default_model

--- a/vexor/api.py
+++ b/vexor/api.py
@@ -14,20 +14,22 @@ from .config import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_EXTRACT_BACKEND,
     DEFAULT_EXTRACT_CONCURRENCY,
-    DEFAULT_PROVIDER,
     DEFAULT_RERANK,
     Config,
     RemoteRerankConfig,
     SUPPORTED_RERANKERS,
     config_from_json,
     config_dir_context,
-    validate_embedding_dimensions_for_model,
     load_config,
-    resolve_default_model,
     set_config_dir,
 )
 from .cache import cache_dir_context, set_cache_dir
 from .modes import available_modes, get_strategy
+from .providers.capabilities import (
+    DEFAULT_PROVIDER,
+    resolve_default_model,
+    validate_embedding_dimensions_for_model,
+)
 from .services.index_service import (
     IndexResult,
     build_index,

--- a/vexor/cli.py
+++ b/vexor/cli.py
@@ -32,25 +32,27 @@ from .config import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_FLASHRANK_MODEL,
     DEFAULT_FLASHRANK_MAX_LENGTH,
+    DEFAULT_RERANK,
+    SUPPORTED_EXTRACT_BACKENDS,
+    SUPPORTED_RERANKERS,
+    flashrank_cache_dir,
+    load_config,
+    normalize_remote_rerank_url,
+    resolve_remote_rerank_api_key,
+)
+from .modes import available_modes, get_strategy
+from .providers.capabilities import (
     DEFAULT_GEMINI_MODEL,
     DEFAULT_LOCAL_MODEL,
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
-    DEFAULT_RERANK,
     DEFAULT_VOYAGE_MODEL,
     DIMENSION_SUPPORTED_MODELS,
-    SUPPORTED_EXTRACT_BACKENDS,
     SUPPORTED_PROVIDERS,
-    SUPPORTED_RERANKERS,
-    flashrank_cache_dir,
     get_supported_dimensions,
-    load_config,
-    normalize_remote_rerank_url,
-    resolve_remote_rerank_api_key,
     resolve_default_model,
     supports_dimensions,
 )
-from .modes import available_modes, get_strategy
 from .services.cache_service import is_cache_current, load_index_metadata_safe
 from .services.config_service import apply_config_updates, get_config_snapshot
 from .services.init_service import run_init_wizard, should_auto_run_init

--- a/vexor/config.py
+++ b/vexor/config.py
@@ -12,6 +12,27 @@ from pathlib import Path
 from typing import Any, Dict
 from urllib.parse import urlparse, urlunparse
 
+# Permanent public re-exports preserve existing imports from vexor.config.
+from .providers.capabilities import (
+    DEFAULT_GEMINI_MODEL,
+    DEFAULT_LOCAL_MODEL,
+    DEFAULT_MODEL,
+    DEFAULT_PROVIDER,
+    DEFAULT_VOYAGE_MODEL,
+    DIMENSION_SUPPORTED_MODELS,
+    ENV_API_KEY,
+    LEGACY_GEMINI_ENV,
+    OPENAI_ENV,
+    SUPPORTED_PROVIDERS,
+    VOYAGE_BASE_URL,
+    VOYAGE_ENV,
+    get_supported_dimensions,
+    resolve_api_key,
+    resolve_base_url,
+    resolve_default_model,
+    supports_dimensions,
+    validate_embedding_dimensions_for_model,
+)
 from .text import Messages
 
 DEFAULT_CONFIG_DIR = Path(os.path.expanduser("~")) / ".vexor"
@@ -21,36 +42,18 @@ _CONFIG_DIR_OVERRIDE: ContextVar[Path | None] = ContextVar(
     "vexor_config_dir_override",
     default=None,
 )
-DEFAULT_MODEL = "text-embedding-3-small"
-DEFAULT_GEMINI_MODEL = "gemini-embedding-001"
-DEFAULT_VOYAGE_MODEL = "voyage-3-large"
-DEFAULT_LOCAL_MODEL = "intfloat/multilingual-e5-small"
 DEFAULT_BATCH_SIZE = 64
 DEFAULT_EMBED_CONCURRENCY = 4
 DEFAULT_EXTRACT_CONCURRENCY = max(1, min(4, os.cpu_count() or 1))
 DEFAULT_EXTRACT_BACKEND = "auto"
-DEFAULT_PROVIDER = "openai"
 DEFAULT_RERANK = "off"
 DEFAULT_FLASHRANK_MODEL = "ms-marco-TinyBERT-L-2-v2"
 DEFAULT_FLASHRANK_MAX_LENGTH = 256
-VOYAGE_BASE_URL = "https://api.voyageai.com/v1"
-SUPPORTED_PROVIDERS: tuple[str, ...] = (DEFAULT_PROVIDER, "gemini", "voyageai", "custom", "local")
 SUPPORTED_RERANKERS: tuple[str, ...] = ("off", "bm25", "flashrank", "remote")
 SUPPORTED_EXTRACT_BACKENDS: tuple[str, ...] = ("auto", "thread", "process")
-# Models that support the dimensions parameter (model prefix/name -> supported dimensions)
-DIMENSION_SUPPORTED_MODELS: dict[str, tuple[int, ...]] = {
-    "text-embedding-3-small": (256, 512, 1024, 1536),
-    "text-embedding-3-large": (256, 512, 1024, 1536, 3072),
-    "voyage-3": (256, 512, 1024, 2048),
-    "voyage-code-3": (256, 512, 1024, 2048),
-}
-ENV_API_KEY = "VEXOR_API_KEY"
 ENV_CONFIG_JSON = "VEXOR_CONFIG_JSON"
 ENV_NO_UPDATE_CHECK = "VEXOR_NO_UPDATE_CHECK"
 REMOTE_RERANK_ENV = "VEXOR_REMOTE_RERANK_API_KEY"
-LEGACY_GEMINI_ENV = "GOOGLE_GENAI_API_KEY"
-OPENAI_ENV = "OPENAI_API_KEY"
-VOYAGE_ENV = "VOYAGE_API_KEY"
 
 
 @dataclass
@@ -460,60 +463,6 @@ def normalize_remote_rerank_url(value: str | None) -> str | None:
     return urlunparse(normalized)
 
 
-def resolve_default_model(provider: str | None, model: str | None) -> str:
-    """Return the effective model name for the selected provider."""
-    clean_model = (model or "").strip()
-    normalized = (provider or DEFAULT_PROVIDER).lower()
-    if normalized == "gemini" and (not clean_model or clean_model == DEFAULT_MODEL):
-        return DEFAULT_GEMINI_MODEL
-    if normalized == "voyageai" and (not clean_model or clean_model == DEFAULT_MODEL):
-        return DEFAULT_VOYAGE_MODEL
-    if clean_model:
-        return clean_model
-    return DEFAULT_MODEL
-
-
-def resolve_base_url(provider: str | None, configured_url: str | None) -> str | None:
-    """Return the effective base URL for the selected provider."""
-    if configured_url:
-        return configured_url
-    normalized = (provider or DEFAULT_PROVIDER).lower()
-    if normalized == "voyageai":
-        return VOYAGE_BASE_URL
-    return None
-
-
-def supports_dimensions(model: str) -> bool:
-    """Check if a model supports the dimensions parameter."""
-    return get_supported_dimensions(model) is not None
-
-
-def get_supported_dimensions(model: str) -> tuple[int, ...] | None:
-    """Return the supported dimensions for a model, or None if not supported."""
-    model_lower = model.lower()
-    for prefix, dims in DIMENSION_SUPPORTED_MODELS.items():
-        if model_lower.startswith(prefix):
-            return dims
-    return None
-
-
-def validate_embedding_dimensions_for_model(value: int | None, model: str) -> None:
-    """Validate that `value` is supported by `model` when value is set."""
-    if value is None:
-        return
-    supported = get_supported_dimensions(model)
-    if not supported:
-        raise ValueError(
-            f"Model '{model}' does not support custom dimensions. "
-            f"Supported model names/prefixes: {', '.join(DIMENSION_SUPPORTED_MODELS.keys())}"
-        )
-    if value not in supported:
-        raise ValueError(
-            f"Dimension {value} is not supported for model '{model}'. "
-            f"Supported dimensions: {supported}"
-        )
-
-
 def _validate_config_embedding_dimensions(config: Config) -> None:
     """Ensure stored embedding dimensions remain compatible with provider/model."""
     if config.embedding_dimensions is None:
@@ -530,32 +479,6 @@ def _validate_config_embedding_dimensions(config: Config) -> None:
             f"model '{effective_model}'. Clear it with "
             "`vexor config --clear-embedding-dimensions` or set a supported value."
         ) from exc
-
-
-def resolve_api_key(configured: str | None, provider: str) -> str | None:
-    """Return the first available API key from config or environment."""
-
-    normalized = (provider or DEFAULT_PROVIDER).lower()
-    if normalized == "local":
-        return None
-    if configured:
-        return configured
-    general = os.getenv(ENV_API_KEY)
-    if general:
-        return general
-    if normalized == "gemini":
-        legacy = os.getenv(LEGACY_GEMINI_ENV)
-        if legacy:
-            return legacy
-    if normalized == "voyageai":
-        voyage_key = os.getenv(VOYAGE_ENV)
-        if voyage_key:
-            return voyage_key
-    if normalized in {"openai", "custom"}:
-        openai_key = os.getenv(OPENAI_ENV)
-        if openai_key:
-            return openai_key
-    return None
 
 
 def resolve_remote_rerank_api_key(configured: str | None) -> str | None:

--- a/vexor/providers/capabilities.py
+++ b/vexor/providers/capabilities.py
@@ -1,0 +1,110 @@
+"""Provider capability metadata.
+
+This module is the home for default models, provider environment variables,
+base URLs, and dimension rules. New provider-specific rules belong here, not
+in config.py. Convert this module to a per-provider registry when the next
+provider (for example, Azure) lands.
+"""
+
+import os
+
+DEFAULT_MODEL = "text-embedding-3-small"
+DEFAULT_GEMINI_MODEL = "gemini-embedding-001"
+DEFAULT_VOYAGE_MODEL = "voyage-3-large"
+DEFAULT_LOCAL_MODEL = "intfloat/multilingual-e5-small"
+DEFAULT_PROVIDER = "openai"
+VOYAGE_BASE_URL = "https://api.voyageai.com/v1"
+SUPPORTED_PROVIDERS: tuple[str, ...] = (DEFAULT_PROVIDER, "gemini", "voyageai", "custom", "local")
+
+# Models that support the dimensions parameter (model prefix/name -> supported dimensions)
+DIMENSION_SUPPORTED_MODELS: dict[str, tuple[int, ...]] = {
+    "text-embedding-3-small": (256, 512, 1024, 1536),
+    "text-embedding-3-large": (256, 512, 1024, 1536, 3072),
+    "voyage-3": (256, 512, 1024, 2048),
+    "voyage-code-3": (256, 512, 1024, 2048),
+}
+
+ENV_API_KEY = "VEXOR_API_KEY"
+LEGACY_GEMINI_ENV = "GOOGLE_GENAI_API_KEY"
+OPENAI_ENV = "OPENAI_API_KEY"
+VOYAGE_ENV = "VOYAGE_API_KEY"
+
+
+def resolve_default_model(provider: str | None, model: str | None) -> str:
+    """Return the effective model name for the selected provider."""
+    clean_model = (model or "").strip()
+    normalized = (provider or DEFAULT_PROVIDER).lower()
+    if normalized == "gemini" and (not clean_model or clean_model == DEFAULT_MODEL):
+        return DEFAULT_GEMINI_MODEL
+    if normalized == "voyageai" and (not clean_model or clean_model == DEFAULT_MODEL):
+        return DEFAULT_VOYAGE_MODEL
+    if clean_model:
+        return clean_model
+    return DEFAULT_MODEL
+
+
+def resolve_base_url(provider: str | None, configured_url: str | None) -> str | None:
+    """Return the effective base URL for the selected provider."""
+    if configured_url:
+        return configured_url
+    normalized = (provider or DEFAULT_PROVIDER).lower()
+    if normalized == "voyageai":
+        return VOYAGE_BASE_URL
+    return None
+
+
+def supports_dimensions(model: str) -> bool:
+    """Check if a model supports the dimensions parameter."""
+    return get_supported_dimensions(model) is not None
+
+
+def get_supported_dimensions(model: str) -> tuple[int, ...] | None:
+    """Return the supported dimensions for a model, or None if not supported."""
+    model_lower = model.lower()
+    for prefix, dims in DIMENSION_SUPPORTED_MODELS.items():
+        if model_lower.startswith(prefix):
+            return dims
+    return None
+
+
+def validate_embedding_dimensions_for_model(value: int | None, model: str) -> None:
+    """Validate that `value` is supported by `model` when value is set."""
+    if value is None:
+        return
+    supported = get_supported_dimensions(model)
+    if not supported:
+        raise ValueError(
+            f"Model '{model}' does not support custom dimensions. "
+            f"Supported model names/prefixes: {', '.join(DIMENSION_SUPPORTED_MODELS.keys())}"
+        )
+    if value not in supported:
+        raise ValueError(
+            f"Dimension {value} is not supported for model '{model}'. "
+            f"Supported dimensions: {supported}"
+        )
+
+
+def resolve_api_key(configured: str | None, provider: str) -> str | None:
+    """Return the first available API key from config or environment."""
+
+    normalized = (provider or DEFAULT_PROVIDER).lower()
+    if normalized == "local":
+        return None
+    if configured:
+        return configured
+    general = os.getenv(ENV_API_KEY)
+    if general:
+        return general
+    if normalized == "gemini":
+        legacy = os.getenv(LEGACY_GEMINI_ENV)
+        if legacy:
+            return legacy
+    if normalized == "voyageai":
+        voyage_key = os.getenv(VOYAGE_ENV)
+        if voyage_key:
+            return voyage_key
+    if normalized in {"openai", "custom"}:
+        openai_key = os.getenv(OPENAI_ENV)
+        if openai_key:
+            return openai_key
+    return None

--- a/vexor/providers/gemini.py
+++ b/vexor/providers/gemini.py
@@ -12,7 +12,7 @@ from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
-from ..config import DEFAULT_GEMINI_MODEL
+from .capabilities import DEFAULT_GEMINI_MODEL
 from ..text import Messages
 
 

--- a/vexor/search.py
+++ b/vexor/search.py
@@ -8,8 +8,8 @@ from typing import List, Protocol, Sequence
 
 import numpy as np
 
-from .config import (
-    DEFAULT_EMBED_CONCURRENCY,
+from .config import DEFAULT_EMBED_CONCURRENCY
+from .providers.capabilities import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
     SUPPORTED_PROVIDERS,

--- a/vexor/services/init_service.py
+++ b/vexor/services/init_service.py
@@ -20,14 +20,16 @@ from .. import __version__, config as config_module
 from ..config import (
     DEFAULT_FLASHRANK_MAX_LENGTH,
     DEFAULT_FLASHRANK_MODEL,
-    DEFAULT_LOCAL_MODEL,
-    DEFAULT_PROVIDER,
     flashrank_cache_dir,
     load_config,
     normalize_remote_rerank_url,
+    resolve_remote_rerank_api_key,
+)
+from ..providers.capabilities import (
+    DEFAULT_LOCAL_MODEL,
+    DEFAULT_PROVIDER,
     resolve_api_key,
     resolve_default_model,
-    resolve_remote_rerank_api_key,
 )
 from ..providers.local import LocalEmbeddingBackend
 from ..services.config_service import apply_config_updates

--- a/vexor/services/system_service.py
+++ b/vexor/services/system_service.py
@@ -81,7 +81,7 @@ def check_config_exists() -> DoctorCheckResult:
 
 def check_api_key_configured(provider: str, api_key: str | None) -> DoctorCheckResult:
     """Check if API key is configured."""
-    from ..config import resolve_api_key
+    from ..providers.capabilities import resolve_api_key
 
     if (provider or "").lower() == "local":
         return DoctorCheckResult(
@@ -113,7 +113,7 @@ def check_api_connectivity(
     local_cuda: bool = False,
 ) -> DoctorCheckResult:
     """Test API connectivity with a minimal embedding request."""
-    from ..config import resolve_api_key
+    from ..providers.capabilities import resolve_api_key
 
     normalized = (provider or "").lower()
     if normalized == "local":


### PR DESCRIPTION
## Motivation

Executes the roadmap Engineering TODO: config.py owned both generic config persistence and provider capability metadata (default models, provider env var chains, base URLs, embedding-dimension rules). Provider metadata now lives in a dedicated module so future provider-specific rules (e.g. Azure) land there instead of growing config.py.

## Changes

- New `vexor/providers/capabilities.py`: verbatim move of `DEFAULT_MODEL` / `DEFAULT_GEMINI_MODEL` / `DEFAULT_VOYAGE_MODEL` / `DEFAULT_LOCAL_MODEL` / `DEFAULT_PROVIDER` / `SUPPORTED_PROVIDERS` / `VOYAGE_BASE_URL` / `DIMENSION_SUPPORTED_MODELS` / provider env var names, and `resolve_default_model` / `resolve_base_url` / `resolve_api_key` / `supports_dimensions` / `get_supported_dimensions` / `validate_embedding_dimensions_for_model`. Stdlib-only imports, no cycles.
- `config.py` permanently re-exports every moved name — **no public Python API change** (`from vexor.config import X` keeps working). `_validate_config_embedding_dimensions` stays in config.py (persistence glue).
- Runtime-internal imports updated to the new module: `search.py`, `api.py`, `cli.py`, `services/init_service.py`, `services/system_service.py`, `providers/gemini.py`. `providers/local.py` intentionally keeps importing `local_model_dir` from config (storage-location helper, not capability metadata).
- Existing tests untouched (they now double as re-export regression coverage); new `tests/unit/test_provider_capabilities.py` adds direct-import smoke tests plus a re-export identity guard.
- AGENTS.md providers bullet updated.

## Compatibility

No config-schema, cache-schema, or Python API change. Pure refactor.

## Tests

- `python -m pytest tests -q` (.venv, offline): **502 passed** (496 existing + 6 new)
- `python -c "from vexor.config import DEFAULT_MODEL, resolve_api_key, SUPPORTED_PROVIDERS"` — re-export OK
- `python -m vexor --help` — CLI smoke OK

Implementation by Codex CLI (gpt-5.6-sol, high reasoning) under Claude supervision; reviewed diff-by-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)