### PR TITLE
feat(index): support .vexorignore for per-project ignore rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ When you remember what a file *does* but forget its name or location, Vexor find
 
 Designed for both humans and AI coding assistants, enabling semantic file discovery in autonomous agent workflows.
 
+Per-project `.vexorignore` files give you full gitignore-style control over what gets indexed.
+
 ## Install
 
 Download standalone binary from [releases](https://github.com/scarletkc/vexor/releases) (no Python required), or:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,13 +33,30 @@
 | `--exclude-pattern PATTERN` | Exclude paths by gitignore-style pattern (repeatable; `.js` treated as `**/*.js`) |
 | `--include-hidden` / `-i` | Include hidden files |
 | `--no-recursive` / `-n` | Don't recurse into subdirectories |
-| `--no-respect-gitignore` | Include gitignored files |
+| `--no-respect-gitignore` | Include files ignored by Git (does not disable `.vexorignore`) |
 | `--format porcelain` | Script-friendly TSV output |
 | `--format porcelain-z` | NUL-delimited output |
 | `--no-cache` | In-memory only; do not read/write index cache |
 
 Porcelain output fields: `rank`, `similarity`, `path`, `chunk_index`,
 `start_line`, `end_line`, `preview` (line fields are `-` when unavailable).
+
+## Ignore Files
+
+Use `.vexorignore` for project-specific indexing exclusions. It supports full
+gitignore syntax, including negation (`!pattern`), directory-only patterns, and
+anchored patterns. Files can appear in any directory; rules apply to that
+directory and its descendants, and Vexor follows the ancestor chain from the
+repository root when scanning a subdirectory. Outside a Git repository, rules
+are anchored at the scanned directory.
+
+`.vexorignore` is always honored, including with `--no-respect-gitignore`. When
+both ignore files exist in a directory, `.gitignore` is read first and
+`.vexorignore` second, so `.vexorignore` can add exclusions or re-include a path
+with a negated pattern. Explicit `--exclude-pattern` rules still apply
+separately. Changes to `.vexorignore` are detected automatically by the index
+staleness check, so the next search or index refresh updates the indexed file
+set.
 
 ## Index Modes
 

--- a/plugins/vexor/skills/vexor-cli/SKILL.md
+++ b/plugins/vexor/skills/vexor-cli/SKILL.md
@@ -29,6 +29,7 @@ vexor "<QUERY>" [--path <ROOT>] [--mode <MODE>] [--ext .py,.md] [--exclude-patte
 - `--top/-k`: number of results
 - `--include-hidden`: include dotfiles
 - `--no-respect-gitignore`: include ignored files
+- `.vexorignore` project rules always apply, even with `--no-respect-gitignore`.
 - `--no-recursive`: only the top directory
 - `--format`: `rich` (default) or `porcelain`/`porcelain-z` for scripts
 - `--no-cache`: in-memory only, do not read/write index cache

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,7 +1,10 @@
 import numpy as np
 import string
 
+import vexor.cache as cache
+import vexor.search as search_module
 from vexor.search import VexorSearcher
+from vexor.services.index_service import IndexStatus, build_index
 from vexor.utils import collect_files
 
 
@@ -10,6 +13,8 @@ ALPHABET_INDEX = {ch: idx for idx, ch in enumerate(ALPHABET)}
 
 
 class DummyBackend:
+    device = "dummy"
+
     def embed(self, texts):
         vectors = []
         for text in texts:
@@ -20,6 +25,9 @@ class DummyBackend:
                     vec[idx] += 1.0
             vectors.append(vec)
         return np.stack(vectors)
+
+    def embed_texts(self, texts):
+        return self.embed(texts)
 
 
 def test_full_search_pipeline(tmp_path):
@@ -38,3 +46,37 @@ def test_full_search_pipeline(tmp_path):
 
     assert len(results) == 2
     assert results[0].path.name in {"config_loader.py", "utils_config.py"}
+
+
+def test_vexorignore_change_removes_file_from_cached_index(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(cache, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(search_module, "VexorSearcher", lambda **_kwargs: DummyBackend())
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "kept.txt").write_text("kept", encoding="utf-8")
+    (project / "ignored.txt").write_text("ignored", encoding="utf-8")
+    index_kwargs = {
+        "include_hidden": False,
+        "respect_gitignore": True,
+        "mode": "name",
+        "recursive": True,
+        "model_name": "model",
+        "batch_size": 0,
+        "provider": "gemini",
+        "base_url": None,
+        "api_key": None,
+    }
+
+    first = build_index(project, **index_kwargs)
+    assert first.status == IndexStatus.STORED
+    paths, _, _ = cache.load_index_vectors(project, "model", False, "name", True)
+    assert sorted(path.name for path in paths) == ["ignored.txt", "kept.txt"]
+
+    (project / ".vexorignore").write_text("ignored.txt\n", encoding="utf-8")
+    second = build_index(project, **index_kwargs)
+
+    assert second.status == IndexStatus.STORED
+    paths, _, _ = cache.load_index_vectors(project, "model", False, "name", True)
+    assert [path.name for path in paths] == ["kept.txt"]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -227,3 +227,115 @@ def test_collect_files_exclude_patterns(tmp_path):
     assert "keep.py" in names
     assert "skip.js" not in names
     assert "test_keep.py" not in names
+
+
+@pytest.mark.parametrize("respect_gitignore", [True, False])
+def test_collect_files_always_respects_vexorignore(tmp_path, respect_gitignore):
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / ".vexorignore").write_text("ignored.txt\n", encoding="utf-8")
+    (root / "kept.txt").write_text("yes", encoding="utf-8")
+    (root / "ignored.txt").write_text("no", encoding="utf-8")
+
+    files = utils.collect_files(root, respect_gitignore=respect_gitignore)
+
+    assert [path.name for path in files] == ["kept.txt"]
+
+
+def test_collect_files_combines_gitignore_then_vexorignore(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()
+    (root / ".gitignore").write_text("git-only.txt\nreincluded.txt\n", encoding="utf-8")
+    (root / ".vexorignore").write_text(
+        "vexor-only.txt\n!reincluded.txt\n",
+        encoding="utf-8",
+    )
+    for filename in ("kept.txt", "git-only.txt", "reincluded.txt", "vexor-only.txt"):
+        (root / filename).write_text(filename, encoding="utf-8")
+
+    files = utils.collect_files(root, respect_gitignore=True)
+
+    assert [path.name for path in files] == ["kept.txt", "reincluded.txt"]
+
+
+def test_collect_files_nested_vexorignore_is_scoped_to_its_directory(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "nested.txt").write_text("kept", encoding="utf-8")
+    sub = root / "sub"
+    sub.mkdir()
+    (sub / ".vexorignore").write_text("nested.txt\n", encoding="utf-8")
+    (sub / "nested.txt").write_text("ignored", encoding="utf-8")
+    (sub / "kept.txt").write_text("kept", encoding="utf-8")
+
+    files = utils.collect_files(root)
+
+    assert [path.relative_to(root).as_posix() for path in files] == [
+        "nested.txt",
+        "sub/kept.txt",
+    ]
+
+
+def test_collect_files_vexorignore_ancestor_can_ignore_scan_root(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()
+    (root / ".vexorignore").write_text("ignored/\n", encoding="utf-8")
+    scan_root = root / "ignored" / "inner"
+    scan_root.mkdir(parents=True)
+    (scan_root / "file.txt").write_text("ignored", encoding="utf-8")
+
+    assert utils.collect_files(scan_root) == []
+
+
+def test_collect_files_non_recursive_respects_vexorignore(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / ".vexorignore").write_text("ignored.txt\n", encoding="utf-8")
+    (root / "kept.txt").write_text("yes", encoding="utf-8")
+    (root / "ignored.txt").write_text("no", encoding="utf-8")
+
+    files = utils.collect_files(root, recursive=False, respect_gitignore=False)
+
+    assert [path.name for path in files] == ["kept.txt"]
+
+
+def test_build_ignore_base_spec_uses_filename_order_and_git_exclude_flag(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git" / "info").mkdir(parents=True)
+    (root / ".git" / "info" / "exclude").write_text(
+        "git-excluded.txt\n",
+        encoding="utf-8",
+    )
+    (root / ".gitignore").write_text("shared.txt\n", encoding="utf-8")
+    (root / ".vexorignore").write_text(
+        "!shared.txt\nvexor-excluded.txt\n",
+        encoding="utf-8",
+    )
+    scan_root = root / "sub"
+    scan_root.mkdir()
+
+    combined, ignored = utils._build_ignore_base_spec(
+        root,
+        scan_root,
+        filenames=(utils.GITIGNORE_FILENAME, utils.VEXORIGNORE_FILENAME),
+        include_git_exclude=True,
+    )
+
+    assert ignored is False
+    assert utils._is_ignored(combined, "shared.txt", is_dir=False) is False
+    assert utils._is_ignored(combined, "vexor-excluded.txt", is_dir=False) is True
+    assert utils._is_ignored(combined, "git-excluded.txt", is_dir=False) is True
+
+    vexor_only, ignored = utils._build_ignore_base_spec(
+        root,
+        scan_root,
+        filenames=(utils.VEXORIGNORE_FILENAME,),
+        include_git_exclude=False,
+    )
+
+    assert ignored is False
+    assert utils._is_ignored(vexor_only, "vexor-excluded.txt", is_dir=False) is True
+    assert utils._is_ignored(vexor_only, "git-excluded.txt", is_dir=False) is False

--- a/vexor/utils.py
+++ b/vexor/utils.py
@@ -7,6 +7,10 @@ from typing import Iterable, List, Sequence, Tuple
 import os
 
 
+GITIGNORE_FILENAME = ".gitignore"
+VEXORIGNORE_FILENAME = ".vexorignore"
+
+
 def resolve_directory(path: Path | str) -> Path:
     """Resolve and validate a user supplied directory path."""
     dir_path = Path(path).expanduser().resolve()
@@ -185,16 +189,23 @@ def _is_ignored(spec, rel_path: str, *, is_dir: bool) -> bool:
     return spec.check_file(candidate).include is True
 
 
-def _build_gitignore_base_spec(ignore_root: Path, scan_root: Path):
+def _build_ignore_base_spec(
+    ignore_root: Path,
+    scan_root: Path,
+    *,
+    filenames: tuple[str, ...],
+    include_git_exclude: bool,
+) -> tuple[object, bool]:
     from pathspec.gitignore import GitIgnoreSpec
 
     spec = GitIgnoreSpec.from_lines([])
 
-    git_dir = _resolve_git_dir(ignore_root)
-    if git_dir is not None:
-        exclude_file = git_dir / "info" / "exclude"
-        if exclude_file.is_file():
-            spec += _gitignore_spec_from_lines(_read_gitignore_lines(exclude_file), "")
+    if include_git_exclude:
+        git_dir = _resolve_git_dir(ignore_root)
+        if git_dir is not None:
+            exclude_file = git_dir / "info" / "exclude"
+            if exclude_file.is_file():
+                spec += _gitignore_spec_from_lines(_read_gitignore_lines(exclude_file), "")
 
     try:
         parts = scan_root.relative_to(ignore_root).parts
@@ -209,14 +220,29 @@ def _build_gitignore_base_spec(ignore_root: Path, scan_root: Path):
         rel_ancestor = _relative_posix(ancestor, ignore_root)
         if depth and _is_ignored(spec, rel_ancestor, is_dir=True):
             return spec, True
-        gitignore_file = ancestor / ".gitignore"
-        if gitignore_file.is_file():
-            spec += _gitignore_spec_from_lines(_read_gitignore_lines(gitignore_file), rel_ancestor)
+        for filename in filenames:
+            ignore_file = ancestor / filename
+            if ignore_file.is_file():
+                spec += _gitignore_spec_from_lines(
+                    _read_gitignore_lines(ignore_file),
+                    rel_ancestor,
+                )
 
     rel_scan = _relative_posix(scan_root, ignore_root)
     if _is_ignored(spec, rel_scan, is_dir=True):
         return spec, True
     return spec, False
+
+
+def _build_gitignore_base_spec(ignore_root: Path, scan_root: Path) -> tuple[object, bool]:
+    """Build the legacy git-only base spec."""
+
+    return _build_ignore_base_spec(
+        ignore_root,
+        scan_root,
+        filenames=(GITIGNORE_FILENAME,),
+        include_git_exclude=True,
+    )
 
 
 def collect_files(
@@ -238,18 +264,23 @@ def collect_files(
     if normalized_excludes:
         exclude_spec = _gitignore_spec_from_lines(normalized_excludes, "")
 
-    ignore_root: Path | None = None
-    ignore_spec = None
+    ignore_root = _find_git_root(directory) or directory
     if respect_gitignore:
-        ignore_root = _find_git_root(directory) or directory
-        ignore_spec, ignored = _build_gitignore_base_spec(ignore_root, directory)
-        if ignored:
-            return []
+        ignore_filenames = (GITIGNORE_FILENAME, VEXORIGNORE_FILENAME)
+    else:
+        ignore_filenames = (VEXORIGNORE_FILENAME,)
+    ignore_spec, ignored = _build_ignore_base_spec(
+        ignore_root,
+        directory,
+        filenames=ignore_filenames,
+        include_git_exclude=respect_gitignore,
+    )
+    if ignored:
+        return []
 
     if recursive:
         spec_by_dir: dict[Path, object] = {}
-        if respect_gitignore and ignore_root is not None and ignore_spec is not None:
-            spec_by_dir[directory] = ignore_spec
+        spec_by_dir[directory] = ignore_spec
 
         for dirpath, dirnames, filenames in os.walk(directory, topdown=True):
             if not include_hidden:
@@ -264,27 +295,26 @@ def collect_files(
                 if _is_ignored(exclude_spec, rel_dir, is_dir=True):
                     dirnames[:] = []
                     continue
-            spec = ignore_spec
-            if respect_gitignore and ignore_root is not None and ignore_spec is not None:
-                spec = spec_by_dir.get(current_dir, ignore_spec)
-                gitignore_file = current_dir / ".gitignore"
-                if gitignore_file.is_file():
+            spec = spec_by_dir.get(current_dir, ignore_spec)
+            for ignore_filename in ignore_filenames:
+                ignore_file = current_dir / ignore_filename
+                if ignore_file.is_file():
                     rel_dir = _relative_posix(current_dir, ignore_root)
                     spec = spec + _gitignore_spec_from_lines(
-                        _read_gitignore_lines(gitignore_file),
+                        _read_gitignore_lines(ignore_file),
                         rel_dir,
                     )
-                    spec_by_dir[current_dir] = spec
+            spec_by_dir[current_dir] = spec
 
-                kept: list[str] = []
-                for dirname in dirnames:
-                    child = current_dir / dirname
-                    rel_child = _relative_posix(child, ignore_root)
-                    if _is_ignored(spec, rel_child, is_dir=True):
-                        continue
-                    kept.append(dirname)
-                    spec_by_dir[child] = spec
-                dirnames[:] = kept
+            kept: list[str] = []
+            for dirname in dirnames:
+                child = current_dir / dirname
+                rel_child = _relative_posix(child, ignore_root)
+                if _is_ignored(spec, rel_child, is_dir=True):
+                    continue
+                kept.append(dirname)
+                spec_by_dir[child] = spec
+            dirnames[:] = kept
 
             for filename in filenames:
                 candidate = current_dir / filename
@@ -294,19 +324,18 @@ def collect_files(
                         continue
                 if normalized_exts and not _matches_extension(candidate, normalized_exts):
                     continue
-                if respect_gitignore and ignore_root is not None and spec is not None:
-                    rel_file = _relative_posix(candidate, ignore_root)
-                    if _is_ignored(spec, rel_file, is_dir=False):
-                        continue
+                rel_file = _relative_posix(candidate, ignore_root)
+                if _is_ignored(spec, rel_file, is_dir=False):
+                    continue
                 files.append(candidate)
     else:
         spec = ignore_spec
-        if respect_gitignore and ignore_root is not None and ignore_spec is not None:
-            gitignore_file = directory / ".gitignore"
-            if gitignore_file.is_file():
+        for ignore_filename in ignore_filenames:
+            ignore_file = directory / ignore_filename
+            if ignore_file.is_file():
                 rel_dir = _relative_posix(directory, ignore_root)
-                spec = ignore_spec + _gitignore_spec_from_lines(
-                    _read_gitignore_lines(gitignore_file),
+                spec = spec + _gitignore_spec_from_lines(
+                    _read_gitignore_lines(ignore_file),
                     rel_dir,
                 )
         for entry in directory.iterdir():
@@ -322,10 +351,9 @@ def collect_files(
                     continue
             if normalized_exts and not _matches_extension(entry, normalized_exts):
                 continue
-            if respect_gitignore and ignore_root is not None and spec is not None:
-                rel_file = _relative_posix(entry, ignore_root)
-                if _is_ignored(spec, rel_file, is_dir=False):
-                    continue
+            rel_file = _relative_posix(entry, ignore_root)
+            if _is_ignored(spec, rel_file, is_dir=False):
+                continue
             files.append(entry)
 
     files.sort()


### PR DESCRIPTION
## Motivation

Roadmap P2: per-project ignore rules. Users need a way to exclude paths from indexing without touching .gitignore (which affects git itself) or passing --exclude-pattern on every invocation.

## Changes

- `.vexorignore` files with **full gitignore semantics**: per-directory files, ancestor chain anchored at the git root (or the scanned directory outside a repo), negation, directory-only patterns. Implemented by parametrizing the existing gitignore machinery in `vexor/utils.py` by filename — no second matching implementation.
- **Always honored**, including with `--no-respect-gitignore` (that flag means "ignore git''s rules"; `.vexorignore` is vexor''s own config). No new CLI/MCP flags.
- In-directory precedence: `.gitignore` is read first, `.vexorignore` second — so `.vexorignore` can add exclusions or re-include (`!pattern`) gitignored paths. `--exclude-pattern` stays a separate spec.
- No cache-schema change: `.vexorignore` edits change the collected file set, which the existing snapshot staleness check picks up (same mechanism as `.gitignore` today). An integration test pins this.
- Docs: docs/cli.md "Ignore Files" section, README, bundled skill note.

## Compatibility

No config-schema, cache-schema, or Python API change. Behavior change only for trees that already contain a `.vexorignore` file (previously inert, now honored).

## Tests

- `python -m pytest tests -q` (.venv, offline): **504 passed** (8 new: 6 unit scenarios incl. negation override, nested scoping, ancestor chain, non-recursive; 1 parametrized always-honored; 1 integration staleness test)
- Real smoke: `collect_files` on a temp project with `.vexorignore` — ignored file absent with `respect_gitignore` True and False

Implementation by Codex CLI (gpt-5.6-sol, high reasoning) under Claude supervision; reviewed diff-by-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)