### PR TITLE
docs(readme): add Awesome CLI Apps feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Vexor has been recognized and featured by the community:
 - **[Ruan Yifeng's Weekly (Issue #379)](https://github.com/ruanyf/weekly/blob/master/docs/issue-379.md#ai-%E7%9B%B8%E5%85%B3)** - A leading tech newsletter in the Chinese developer community.
 - **[Awesome Claude Skills](https://github.com/VoltAgent/awesome-claude-skills?tab=readme-ov-file#development-and-testing)** - Curated list of best-in-class skills for AI agents.
 - **[Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers#-developer-tools)** - Curated list of Model Context Protocol servers.
+- **[Awesome CLI Apps](https://github.com/agarrharr/awesome-cli-apps#search)** - Curated list of command-line apps.
 
 ## Why Vexor?
 


### PR DESCRIPTION
## Summary

- add Awesome CLI Apps to the README `Featured In` section
- link directly to the upstream `Search` category containing Vexor

## Why

Vexor was added to Awesome CLI Apps through upstream PR #1266. The README should reflect that community listing while preserving the existing one-link, one-description format.

## Impact

Documentation only; no runtime behavior changes.

## Validation

- `git diff --cached --check`
- verified upstream PR #1266 is merged
- verified Vexor is listed under Awesome CLI Apps → Search
