### PR TITLE
chore(release): bump version to 0.26.0

### DIFF
--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/scarletkc/vexor",
     "source": "github"
   },
-  "version": "0.25.0",
+  "version": "0.26.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vexor",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"
 
 _API_EXPORTS = frozenset(
     {


### PR DESCRIPTION
## Summary

- release Vexor 0.26.0 with project-level configuration v1 and origin-aware config diagnostics
- ship the desktop app retirement and focus supported distribution on the CLI, Python API, and MCP server
- synchronize the Python package, bundled Claude plugin, and MCP registry metadata at 0.26.0

## Compatibility notes

- Breaking: desktop GUI artifacts are no longer built or published.
- Config schema / Python API: project .vexor/config.json files now support a strict non-secret allowlist and participate in effective config resolution.
- Bundled skill documentation is already synchronized with the new behavior.
- Cache schema remains unchanged at version 7; this release does not add provider or reranker adapters.

Merging this PR changes the package version on main, which triggers the existing Test & Publish workflow for PyPI, GitHub Release assets, and the MCP registry.

## Verification

- .venv\Scripts\python.exe -m pytest --cov=vexor --cov-report=term-missing — 595 passed, 91% coverage
- .venv\Scripts\python.exe -m build --no-isolation — built wheel and sdist
- .venv\Scripts\python.exe -m twine check dist\vexor-0.26.0* — both artifacts passed
- .venv\Scripts\python.exe -m vexor index --path . --mode code — real configured provider index succeeded
- .venv\Scripts\python.exe -m vexor search "project config origin" --path . --mode auto --no-cache — real configured provider search succeeded; vexor/config.py was the top result
- git diff --check

## CLI smoke output

    Vexor v0.26.0
    Index saved to C:\Users\kc\.vexor\index.db.
    #1  ./vexor/config.py  L400-423  similarity 0.659