### PR TITLE
fix(index): correct full-mode chunk line numbers

### DIFF
--- a/tests/unit/test_content_extract_service.py
+++ b/tests/unit/test_content_extract_service.py
@@ -310,6 +310,9 @@ def test_extract_full_chunks_with_lines_ranges_map_back_to_source(tmp_path):
     assert len(chunks) >= 2
     for chunk in chunks:
         sliced = "\n".join(source_lines[chunk.start_line - 1 : chunk.end_line])
+        # Containment, not equality: windows are cut on character offsets, so the first
+        # and last line of a chunk can be partial. Tightening this to `==` would fail on
+        # correct output.
         for line in chunk.text.splitlines():
             assert line in sliced
 

--- a/tests/unit/test_content_extract_service.py
+++ b/tests/unit/test_content_extract_service.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from docx import Document
 from pptx import Presentation
 
@@ -279,6 +280,53 @@ def test_extract_full_chunks_with_lines_multiple_windows(tmp_path):
     assert chunks[0].start_line == 1
     assert chunks[0].end_line >= 1
     assert chunks[-1].end_line == 6
+
+
+@pytest.mark.parametrize("leading_blank_lines", [0, 1, 5])
+def test_extract_full_chunks_with_lines_compensates_leading_blanks(tmp_path, leading_blank_lines):
+    text_path = tmp_path / "leading.txt"
+    text_path.write_text(
+        "\n" * leading_blank_lines + "ALPHA\n" + "filler\n" * 5,
+        encoding="utf-8",
+    )
+    source_lines = text_path.read_text(encoding="utf-8").splitlines()
+    expected_start = source_lines.index("ALPHA") + 1
+
+    chunks = extract_full_chunks_with_lines(text_path, chunk_size=100, overlap=0)
+
+    assert chunks
+    assert chunks[0].start_line == expected_start
+    assert chunks[0].end_line == len(source_lines)
+
+
+def test_extract_full_chunks_with_lines_ranges_map_back_to_source(tmp_path):
+    """Line ranges must be usable to read the chunk back out of the file."""
+    text_path = tmp_path / "mappable.txt"
+    text_path.write_text("\n\n\nfirst\nsecond\nthird\nfourth\nfifth\nsixth\n", encoding="utf-8")
+    source_lines = text_path.read_text(encoding="utf-8").splitlines()
+
+    chunks = extract_full_chunks_with_lines(text_path, chunk_size=20, overlap=0)
+
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        sliced = "\n".join(source_lines[chunk.start_line - 1 : chunk.end_line])
+        for line in chunk.text.splitlines():
+            assert line in sliced
+
+
+def test_extract_full_chunks_with_lines_text_excludes_leading_blanks(tmp_path):
+    """The offset fix must not alter chunk text, or every label hash would change."""
+    plain = tmp_path / "plain.txt"
+    plain.write_text("alpha\nbeta\n", encoding="utf-8")
+    padded = tmp_path / "padded.txt"
+    padded.write_text("\n\n\nalpha\nbeta\n", encoding="utf-8")
+
+    plain_chunks = extract_full_chunks_with_lines(plain, chunk_size=100, overlap=0)
+    padded_chunks = extract_full_chunks_with_lines(padded, chunk_size=100, overlap=0)
+
+    assert [chunk.text for chunk in plain_chunks] == [chunk.text for chunk in padded_chunks]
+    assert plain_chunks[0].start_line == 1
+    assert padded_chunks[0].start_line == 4
 
 
 def test_extract_full_chunks_with_lines_non_text_has_no_lines(tmp_path):

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -177,7 +177,8 @@ def extract_full_chunks_with_lines(
     """Return sliding-window chunks and approximate line ranges for text-like files.
 
     Line ranges are computed only for plain text inputs (TEXT_EXTENSIONS). Other extractors
-    return chunks with line metadata set to None.
+    return chunks with line metadata set to None. Ranges are 1-based and refer to the
+    original file, so leading blank lines dropped by normalization are compensated for.
     """
 
     suffix = path.suffix.lower()
@@ -197,7 +198,8 @@ def extract_full_chunks_with_lines(
     if text is None:
         return []
 
-    normalized = text.replace("\r\n", "\n").strip()
+    converted = text.replace("\r\n", "\n")
+    normalized = converted.strip()
     if not normalized:
         return []
 
@@ -205,8 +207,13 @@ def extract_full_chunks_with_lines(
     stride = max(size - max(int(overlap), 0), 1)
     chunks: list[FullChunk] = []
     newline_positions: list[int] = []
+    # Line numbers are computed over the stripped text, so every line dropped from the
+    # front has to be added back or the whole file reports a constant negative offset.
+    line_offset = 0
     if include_lines:
         newline_positions = [idx for idx, ch in enumerate(normalized) if ch == "\n"]
+        stripped_head = converted[: len(converted) - len(converted.lstrip())]
+        line_offset = stripped_head.count("\n")
     start = 0
     length = len(normalized)
     while start < length:
@@ -221,9 +228,9 @@ def extract_full_chunks_with_lines(
                 trailing = len(window) - len(window.rstrip())
                 span_start = min(start + leading, length)
                 span_end = max(span_start, end - trailing)
-                start_line = bisect_left(newline_positions, span_start) + 1
+                start_line = bisect_left(newline_positions, span_start) + 1 + line_offset
                 last_index = max(span_start, span_end - 1)
-                end_line = bisect_left(newline_positions, last_index) + 1
+                end_line = bisect_left(newline_positions, last_index) + 1 + line_offset
             chunks.append(FullChunk(text=cleaned, start_line=start_line, end_line=end_line))
         if end >= length:
             break


### PR DESCRIPTION
## Motivation

`extract_full_chunks_with_lines` computes line numbers over `text.replace("\r\n","\n").strip()`, but reports them as if they referred to the original file. `.strip()` removes leading blank lines, so every chunk in such a file carries a line range shifted up by exactly the number of lines dropped — a constant negative offset across the whole file.

Only `full` is affected. `code` (AST node line numbers) and `outline` (raw line scan) were already correct. Because `auto` routes every non-py/js/md small file through `full`, the blast radius is wider than the mode name suggests.

This surfaced while scoping the "return chunk content" work, where search results would be read back out of the file by line range. That plan is blocked on line numbers being trustworthy, so this lands first and on its own.

## Approach

Count the newlines in the prefix that `.strip()` removes, and add that offset back to both `start_line` and `end_line`.

**Chunk text is deliberately left untouched.** Text unchanged → `label` unchanged → `label_hash` unchanged. The fix therefore re-embeds nothing, does not invalidate existing indexes, and needs no `CACHE_VERSION` bump. Indexes built before this change keep their shifted line numbers until they are rebuilt for unrelated reasons; nothing else about them is wrong.

## Verification

**Unit** — `python -m pytest`: 600 passed. Coverage `--cov=vexor`: 91% total.

New cases in `tests/unit/test_content_extract_service.py`:
- leading blank lines parametrized over 0 / 1 / 5, asserting against the real line number in the source
- line ranges must map back to the source — every line of `chunk.text` must be findable in the slice its own range points at (this is the property the follow-up work depends on)
- chunk text must be identical with and without leading blanks, which is what keeps label hashes stable

Confirmed these tests fail without the fix: reverting the source change alone fails 4 of them, while the `leading_blank_lines=0` case still passes — exactly the expected signature of an offset bug.

**End-to-end** — real embedding provider (`custom` / SiliconFlow `BAAI/bge-m3`), against a file whose content genuinely starts on line 5:

```
$ cat -n pool_notes.txt
     1
     2
     3
     4
     5  The connection pool manages reusable database sessions.
     6  It limits concurrent connections and recycles idle handles.
     7  Tuning the pool size avoids exhausting the database server.
```

```
# before  (rank  sim    path              chunk  start  end  preview)
1	0.696	./pool_notes.txt	0	1	3	The connection pool manages…

# after
1	0.696	./pool_notes.txt	0	5	7	The connection pool manages…
```

Line range goes from `1 3` to the correct `5 7`. Similarity is byte-identical at `0.696` across both runs — independent confirmation that the chunk text and its embedding are untouched.

## Compatibility

- No config, cache, or porcelain format changes. Porcelain column count and order are unchanged.
- `CACHE_VERSION` unchanged; existing indexes remain valid and are not forced to rebuild.
- Python API and MCP surfaces unchanged.
