### PR TITLE
feat(search): return chunk content in search results

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -91,11 +91,30 @@ Cache control:
 - `temporary_index`: build index in memory (no index cache read/write)
 - `no_cache`: disable all disk caches (index + embedding + query)
 
+Chunk content:
+
+- `include_content`: also return each match's source text (default `False`)
+- `content_chars_per_result`: per-result character cap (default `2000`)
+- `content_chars_total`: per-response character cap (default `8000`)
+
 Returns a `SearchResponse` with:
 
 - `results`: list of `SearchResult` items (`path`, `score`, `preview`, `chunk_index`, `start_line`, `end_line`)
 - `backend`: backend description string
 - `is_stale`, `index_empty`, `reranker`
+- `content_budget`: `ContentBudget(limit, used)` when `include_content=True`, else `None`
+
+With `include_content=True`, each `SearchResult` also carries `content`,
+`content_start_line`, `content_end_line`, `content_truncated`, and
+`content_unavailable`. The text is read from the file at search time using
+the indexed line range, preserving the original indentation.
+
+`content` is `None` whenever `content_unavailable` is set — `no_line_range`
+(modes without line ranges, and PDF/docx/pptx), `stale_line_range` (the file
+changed since indexing), `budget_exhausted`, or `unreadable`. The `preview`
+is still populated in all of these cases and the search still succeeds.
+Check `content_truncated` before assuming a chunk is complete;
+`content_end_line` reports the last line actually returned.
 
 ### index(...)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,6 +36,8 @@
 | `--no-respect-gitignore` | Include files ignored by Git (does not disable `.vexorignore`) |
 | `--format porcelain` | Script-friendly TSV output |
 | `--format porcelain-z` | NUL-delimited output |
+| `--format json` | Full response as JSON, including chunk content |
+| `--content` | Print each match's source text below the results table |
 | `--no-cache` | In-memory only; do not read/write index cache |
 | `--local` | With `index`, create and use `<path>/.vexor/index.db` |
 
@@ -45,6 +47,29 @@ strategies (`off`, `bm25`, `flashrank`, `remote`, `hybrid`).
 
 Porcelain output fields: `rank`, `similarity`, `path`, `chunk_index`,
 `start_line`, `end_line`, `preview` (line fields are `-` when unavailable).
+This column set is a compatibility contract and does not carry chunk content —
+use `--format json` when you need the source text.
+
+## Chunk Content
+
+`--content` and `--format json` return each match's source text, not just its
+path and a truncated preview. The text is read from the file at search time
+using the indexed line range, so it always reflects what is on disk now.
+
+A result carries `content_unavailable` instead of `content` when:
+
+| Reason | Meaning |
+|--------|---------|
+| `no_line_range` | The mode records no line range (`name`, `head`, `brief`) or the format has no stable lines (PDF, docx, pptx) |
+| `stale_line_range` | The file changed since indexing, so the stored range no longer matches; re-run `vexor index` |
+| `budget_exhausted` | The response's character budget was spent on higher-ranked results |
+| `unreadable` | The file was deleted, is not readable, or failed to decode |
+
+Content is capped at 2000 characters per result and 8000 characters per
+response, spent on the highest-ranked matches first. When a result is cut
+short, `content_truncated` is `true` and `content_end_line` reports the last
+line actually returned. The `content_budget` object reports the limit and how
+much was used.
 
 ## Project Configuration
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -120,9 +120,9 @@ being silently ignored.
 ### `vexor_search`
 
 Find files or code from a natural-language description and return ranked
-paths, scores, line ranges, and previews. Missing or stale indexes are built
-automatically when `auto_index` is enabled; otherwise call `vexor_index`
-first.
+paths, scores, line ranges, and the matching source text. Missing or stale
+indexes are built automatically when `auto_index` is enabled; otherwise call
+`vexor_index` first.
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -130,6 +130,8 @@ first.
 | `path` | string | server default path | Directory to search; absolute, or relative to the server's default path |
 | `top` | integer | 5 | Number of results (1–50; out-of-range values are rejected) |
 | `no_cache` | boolean | false | Use a temporary in-memory index and disable disk caches; slower and may regenerate embeddings |
+| `include_content` | boolean | **true** | Return each match's source text so most results need no follow-up file read |
+| `content_budget` | integer | 8000 | Total characters of source text one response may return (500–40000), spent on the highest-ranked matches first |
 | `mode` | string | `auto` | Index mode (`auto`/`name`/`head`/`brief`/`full`/`code`/`outline`) |
 | `include_hidden` | boolean | false | Include dot-prefixed files and directories such as `.github` |
 | `respect_gitignore` | boolean | true | Honor `.gitignore` rules; set false to scan ignored files |
@@ -155,9 +157,15 @@ Returns JSON text:
       "absolute_path": "C:/projects/demo/src/config.py",
       "start_line": 1,
       "end_line": 20,
-      "preview": "config loader entrypoint"
+      "preview": "config loader entrypoint",
+      "content": "def load_config(path):\n    ...",
+      "content_start_line": 1,
+      "content_end_line": 20,
+      "content_truncated": false,
+      "content_unavailable": null
     }
-  ]
+  ],
+  "content_budget": { "limit": 8000, "used": 174 }
 }
 ```
 
@@ -165,11 +173,33 @@ When the configured rerank strategy is `hybrid`, the `reranker` field is
 `"hybrid"` and each result's `score` is a normalized reciprocal-rank-fusion
 score in `[0, 1]` rather than a cosine similarity.
 
+#### Chunk content
+
+`content` holds the source text for the result's line range, read from the
+file at search time rather than stored in the index, so it always reflects
+what is on disk now. It preserves the original indentation and line breaks.
+
+When content cannot be returned, `content` is `null` and
+`content_unavailable` explains why:
+
+| Reason | Meaning |
+|--------|---------|
+| `no_line_range` | The mode records no line range (`name`, `head`, `brief`) or the format has no stable lines (PDF, docx, pptx) |
+| `stale_line_range` | The file changed since indexing, so the stored range no longer matches; call `vexor_index` to refresh |
+| `budget_exhausted` | `content_budget` was spent on higher-ranked results |
+| `unreadable` | The file was deleted, is not readable, or failed to decode |
+
+The result's `preview` is still present in every one of these cases, and the
+search itself still succeeds. When a result is cut short,
+`content_truncated` is `true` and `content_end_line` reports the last line
+actually returned — always check it before assuming you have the whole chunk.
+
 ### `vexor_index`
 
 Build or refresh the index for a directory. Use it to warm the cache or when
 `auto_index` is disabled. It accepts the same scan arguments as
-`vexor_search`, but not `query`, `top`, or `no_cache`. Its optional `local`
+`vexor_search`, but not `query`, `top`, `no_cache`, `include_content`, or
+`content_budget`. Its optional `local`
 boolean argument creates `<path>/.vexor` and stores the project's index there.
 The tool returns `{path, mode, status, files_indexed}` where `status` is `stored`,
 `up_to_date`, or `empty`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,6 +10,21 @@ never leaving the machine.
 
 ## P0 — Agent-first distribution
 
+- Chunk content in search results (shipped): `vexor_search`, the Python API,
+  and `vexor search --content` / `--format json` return the matching source
+  text, read back from the file by line range at search time. Previously a
+  caller got a path plus a 160-character preview and had to re-read the file,
+  which spent back most of what retrieval saved. Porcelain output is
+  unchanged. Follow-ups this unblocks:
+  - Feed chunk content to the rerankers. `_build_rerank_document` still scores
+    against filename, path, and the truncated preview, so rerank quality is
+    capped by preview length. Changing it shifts existing result ordering, so
+    it needs its own benchmark — and the collection API work below already
+    requires extracting that seam.
+  - The token-cost evaluation below is only worth running after this: with
+    path-only results, agent+Vexor could not show much saving over grep
+    because the follow-up reads dominated.
+
 - Add a filesystem-independent, general-purpose text collection API for
   callers to submit records from databases directly, with operations such
   as `upsert(id, text, metadata)`, `delete(id)`, and

--- a/plugins/vexor/skills/vexor-cli/SKILL.md
+++ b/plugins/vexor/skills/vexor-cli/SKILL.md
@@ -17,7 +17,7 @@ Find files by intent (what they do), not exact text.
 ## Command
 
 ```bash
-vexor "<QUERY>" [--path <ROOT>] [--mode <MODE>] [--ext .py,.md] [--exclude-pattern <PATTERN>] [--top 5] [--format rich|porcelain|porcelain-z]
+vexor "<QUERY>" [--path <ROOT>] [--mode <MODE>] [--ext .py,.md] [--exclude-pattern <PATTERN>] [--top 5] [--content] [--format rich|porcelain|porcelain-z|json]
 ```
 
 ## Common Flags
@@ -31,7 +31,8 @@ vexor "<QUERY>" [--path <ROOT>] [--mode <MODE>] [--ext .py,.md] [--exclude-patte
 - `--no-respect-gitignore`: include ignored files
 - `.vexorignore` project rules always apply, even with `--no-respect-gitignore`.
 - `--no-recursive`: only the top directory
-- `--format`: `rich` (default) or `porcelain`/`porcelain-z` for scripts
+- `--format`: `rich` (default), `porcelain`/`porcelain-z` for scripts, `json` for full output with chunk content
+- `--content`: print each match's source text below the table — usually removes the need to read the files afterwards
 - `--no-cache`: in-memory only, do not read/write index cache
 - `vexor index --local`: create and use project-local `.vexor/index.db` storage
 
@@ -90,8 +91,14 @@ vexor search "config loader" --path . --mode code --ext .py
 vexor search "config loader" --path . --exclude-pattern tests/** --exclude-pattern .js
 ```
 
+```bash
+# Read the matching code directly, without a follow-up file read
+vexor search "where JWT claims are validated" --path . --mode code --content
+```
+
 ## Tips
 
 - First time search will index files (may take a minute). Subsequent searches are fast. Use longer timeouts if needed.
 - Results return similarity ranking, exact file location, line numbers, and matching snippet preview.
+- Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
 - Combine `--ext` with `--exclude-pattern` to focus on a subset (exclude rules apply on top).

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -11,7 +11,7 @@ from vexor.config import DEFAULT_MODEL
 import vexor.cache as cache
 from vexor.search import SearchResult
 from vexor.services.index_service import IndexResult, IndexStatus
-from vexor.services.search_service import SearchResponse
+from vexor.services.search_service import ContentBudget, SearchResponse
 from vexor.text import Messages
 
 
@@ -429,6 +429,204 @@ def test_search_outputs_porcelain(tmp_path, monkeypatch):
     assert "1\t0.990\t./alpha.txt\t0\t5\t6\talpha\\tbeta\\ncharlie\n" in result.stdout
     assert "Similarity" not in result.stdout
     assert captured["recursive"] is True
+
+
+def test_porcelain_column_contract_is_unchanged(tmp_path, monkeypatch):
+    """Porcelain output is parsed by scripts and agents; its shape is a contract.
+
+    Locks the field count and order so adding result fields (such as chunk content)
+    cannot silently shift the columns that existing parsers depend on.
+    """
+    runner = CliRunner()
+    sample_file = tmp_path / "alpha.txt"
+    sample_file.write_text("data")
+
+    def fake_perform_search(request):
+        return SearchResponse(
+            base_path=tmp_path,
+            backend="fake-backend",
+            results=[
+                SearchResult(
+                    path=sample_file,
+                    score=0.5,
+                    preview="preview text",
+                    start_line=5,
+                    end_line=6,
+                    content="def verify():\n    return True",
+                    content_start_line=5,
+                    content_end_line=6,
+                )
+            ],
+            is_stale=False,
+            index_empty=False,
+        )
+
+    monkeypatch.setattr("vexor.cli.perform_search", fake_perform_search)
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "alpha",
+            "--path",
+            str(tmp_path),
+            "--mode",
+            "name",
+            "--format",
+            "porcelain",
+        ],
+    )
+
+    assert result.exit_code == 0
+    row = result.stdout.strip().splitlines()[-1]
+    fields = row.split("\t")
+    assert fields == ["1", "0.500", "./alpha.txt", "0", "5", "6", "preview text"]
+    # Content must never leak into the tab-separated stream.
+    assert "def verify" not in result.stdout
+
+
+def test_search_json_format_includes_content(tmp_path, monkeypatch):
+    runner = CliRunner()
+    sample_file = tmp_path / "alpha.py"
+    sample_file.write_text("data")
+    captured = {}
+
+    def fake_perform_search(request):
+        captured["include_content"] = request.include_content
+        return SearchResponse(
+            base_path=tmp_path,
+            backend="fake-backend",
+            results=[
+                SearchResult(
+                    path=sample_file,
+                    score=0.75,
+                    preview="verify token",
+                    start_line=5,
+                    end_line=6,
+                    content="def verify():\n    return True",
+                    content_start_line=5,
+                    content_end_line=6,
+                    content_truncated=True,
+                )
+            ],
+            is_stale=False,
+            index_empty=False,
+            content_budget=ContentBudget(limit=8000, used=29),
+        )
+
+    monkeypatch.setattr("vexor.cli.perform_search", fake_perform_search)
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "verify",
+            "--path",
+            str(tmp_path),
+            "--mode",
+            "name",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["include_content"] is True
+    payload = json.loads(result.stdout)
+    hit = payload["results"][0]
+    assert hit["content"] == "def verify():\n    return True"
+    assert hit["content_truncated"] is True
+    assert hit["content_start_line"] == 5
+    assert payload["content_budget"] == {"limit": 8000, "used": 29}
+
+
+def test_search_content_flag_prints_source_text(tmp_path, monkeypatch):
+    runner = CliRunner()
+    sample_file = tmp_path / "alpha.py"
+    sample_file.write_text("data")
+    captured = {}
+
+    def fake_perform_search(request):
+        captured["include_content"] = request.include_content
+        return SearchResponse(
+            base_path=tmp_path,
+            backend="fake-backend",
+            results=[
+                SearchResult(
+                    path=sample_file,
+                    score=0.75,
+                    preview="verify token",
+                    start_line=5,
+                    end_line=6,
+                    content="def verify():\n    return True",
+                    content_start_line=5,
+                    content_end_line=6,
+                )
+            ],
+            is_stale=False,
+            index_empty=False,
+            content_budget=ContentBudget(limit=8000, used=29),
+        )
+
+    monkeypatch.setattr("vexor.cli.perform_search", fake_perform_search)
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "verify",
+            "--path",
+            str(tmp_path),
+            "--mode",
+            "name",
+            "--content",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["include_content"] is True
+    assert "def verify():" in result.stdout
+
+
+def test_search_reports_missing_content_reason(tmp_path, monkeypatch):
+    runner = CliRunner()
+    sample_file = tmp_path / "alpha.pdf"
+    sample_file.write_text("data")
+
+    def fake_perform_search(request):
+        return SearchResponse(
+            base_path=tmp_path,
+            backend="fake-backend",
+            results=[
+                SearchResult(
+                    path=sample_file,
+                    score=0.75,
+                    preview="some preview",
+                    content_unavailable="no_line_range",
+                )
+            ],
+            is_stale=False,
+            index_empty=False,
+            content_budget=ContentBudget(limit=8000, used=0),
+        )
+
+    monkeypatch.setattr("vexor.cli.perform_search", fake_perform_search)
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "verify",
+            "--path",
+            str(tmp_path),
+            "--mode",
+            "name",
+            "--content",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "no_line_range" in result.stdout
 
 
 def test_default_search_invokes_search(tmp_path, monkeypatch):

--- a/tests/unit/test_content_extract_service.py
+++ b/tests/unit/test_content_extract_service.py
@@ -56,6 +56,67 @@ def test_read_chunk_content_handles_single_oversized_line(tmp_path):
     assert chunk.truncated is True
 
 
+def test_read_chunk_content_stops_reading_at_the_requested_lines(tmp_path):
+    """Reading a small chunk must not pull the whole file into memory."""
+    source = tmp_path / "big.txt"
+    # ~2 MB, with the wanted lines right at the top.
+    source.write_text("".join(f"line-{idx} {'x' * 200}\n" for idx in range(10_000)), encoding="utf-8")
+
+    read_sizes = []
+    real_open = Path.open
+
+    def counting_open(self, *args, **kwargs):
+        handle = real_open(self, *args, **kwargs)
+        if "b" not in (args[0] if args else kwargs.get("mode", "r")):
+            return handle
+        real_read = handle.read
+
+        def tracked_read(size=-1):
+            data = real_read(size)
+            read_sizes.append(len(data))
+            return data
+
+        handle.read = tracked_read
+        return handle
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(Path, "open", counting_open)
+        chunk = read_chunk_content(source, 1, 3, max_chars=2000)
+
+    assert chunk is not None
+    assert chunk.text.startswith("line-0 ")
+    total_read = sum(read_sizes)
+    assert total_read < 200_000, f"read {total_read} bytes from a ~2MB file for 3 lines"
+
+
+def test_read_chunk_content_falls_back_for_non_utf8(tmp_path):
+    source = tmp_path / "latin.txt"
+    source.write_bytes("alpha\ncaf\xe9 beta\ngamma\n".encode("latin-1"))
+
+    chunk = read_chunk_content(source, 1, 3, max_chars=1000)
+
+    # charset detection may or may not recover this; it must never raise.
+    assert chunk is None or "alpha" in chunk.text
+
+
+def test_chunk_reader_and_indexers_share_the_same_bound():
+    """The reader must reach every line the indexers could have chunked.
+
+    If indexing is allowed to run past what reading covers, chunks near the end of a
+    large file start reporting as unreadable instead of returning their text.
+    """
+    import inspect
+
+    source = inspect.getsource(ces._read_text_through_line)
+    assert "FULL_CHAR_LIMIT" in source
+    assert inspect.signature(ces.extract_full_chunks_with_lines).parameters[
+        "char_limit"
+    ].default == ces.FULL_CHAR_LIMIT
+    assert inspect.signature(ces.extract_code_chunks).parameters[
+        "char_limit"
+    ].default == ces.FULL_CHAR_LIMIT
+
+
 def test_read_chunk_content_returns_none_for_bad_input(tmp_path):
     source = tmp_path / "a.txt"
     source.write_text("alpha\nbeta\n", encoding="utf-8")

--- a/tests/unit/test_content_extract_service.py
+++ b/tests/unit/test_content_extract_service.py
@@ -12,8 +12,60 @@ from vexor.services.content_extract_service import (
     extract_full_chunks,
     extract_full_chunks_with_lines,
     extract_head,
+    read_chunk_content,
     HEAD_CHAR_LIMIT,
 )
+
+
+def test_read_chunk_content_preserves_indentation(tmp_path):
+    source = tmp_path / "mod.py"
+    source.write_text(
+        "import os\n\n\ndef verify(token):\n    if not token:\n        raise ValueError\n",
+        encoding="utf-8",
+    )
+
+    chunk = read_chunk_content(source, 4, 6, max_chars=1000)
+
+    assert chunk.text == (
+        "def verify(token):\n    if not token:\n        raise ValueError"
+    )
+    assert (chunk.start_line, chunk.end_line) == (4, 6)
+    assert chunk.truncated is False
+
+
+def test_read_chunk_content_truncates_on_line_boundary(tmp_path):
+    source = tmp_path / "long.txt"
+    source.write_text("".join(f"line-{idx}\n" for idx in range(30)), encoding="utf-8")
+
+    chunk = read_chunk_content(source, 1, 30, max_chars=25)
+
+    assert chunk.truncated is True
+    assert chunk.end_line < 30
+    # Cutting on a line boundary means no partial trailing line.
+    assert not chunk.text.endswith("line-")
+    assert len(chunk.text) <= 25
+
+
+def test_read_chunk_content_handles_single_oversized_line(tmp_path):
+    source = tmp_path / "one.txt"
+    source.write_text("x" * 500 + "\n", encoding="utf-8")
+
+    chunk = read_chunk_content(source, 1, 1, max_chars=50)
+
+    assert len(chunk.text) == 50
+    assert chunk.truncated is True
+
+
+def test_read_chunk_content_returns_none_for_bad_input(tmp_path):
+    source = tmp_path / "a.txt"
+    source.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    assert read_chunk_content(tmp_path / "missing.txt", 1, 2, max_chars=100) is None
+    assert read_chunk_content(source, 0, 2, max_chars=100) is None
+    assert read_chunk_content(source, 3, 1, max_chars=100) is None
+    assert read_chunk_content(source, 1, 2, max_chars=0) is None
+    # A range past the end of the file resolves to nothing.
+    assert read_chunk_content(source, 50, 60, max_chars=100) is None
 
 
 def test_extract_head_from_text(tmp_path):

--- a/tests/unit/test_mcp_service.py
+++ b/tests/unit/test_mcp_service.py
@@ -563,3 +563,75 @@ def test_index_tool_rejects_non_boolean_local(tmp_path):
     assert response["error"]["code"] == JSONRPC_INVALID_PARAMS
     assert "'local' must be a boolean" in response["error"]["message"]
     assert client.index_calls == []
+
+
+def test_default_content_budget_matches_the_service(tmp_path):
+    """The schema default is duplicated to keep numpy off the MCP startup path."""
+    from vexor.services import mcp_service
+    from vexor.services.search_service import DEFAULT_CONTENT_CHARS_TOTAL
+
+    assert mcp_service.DEFAULT_CONTENT_BUDGET == DEFAULT_CONTENT_CHARS_TOTAL
+
+
+def test_advertised_search_arguments_match_the_validator(tmp_path):
+    """Every argument in inputSchema must survive validation, and vice versa."""
+    from vexor.services.mcp_service import _TOOL_ARGUMENTS
+
+    definitions = {tool["name"]: tool for tool in build_tool_definitions(tmp_path)}
+    advertised = set(definitions[SEARCH_TOOL]["inputSchema"]["properties"])
+
+    assert advertised == _TOOL_ARGUMENTS[SEARCH_TOOL]
+
+
+def test_search_tool_requests_content_by_default(tmp_path):
+    server, client = make_server(tmp_path)
+
+    server.handle_message(tool_call(SEARCH_TOOL, {"query": "config loader"}))
+
+    assert client.search_calls[0]["include_content"] is True
+    assert client.search_calls[0]["content_chars_total"] == 8000
+
+
+def test_search_tool_honors_explicit_content_arguments(tmp_path):
+    server, client = make_server(tmp_path)
+
+    server.handle_message(
+        tool_call(
+            SEARCH_TOOL,
+            {"query": "q", "include_content": False, "content_budget": 1500},
+        )
+    )
+
+    assert client.search_calls[0]["include_content"] is False
+    assert client.search_calls[0]["content_chars_total"] == 1500
+
+
+@pytest.mark.parametrize("budget", [0, 100, 999_999, "8000", True])
+def test_search_tool_rejects_out_of_range_content_budget(tmp_path, budget):
+    server, client = make_server(tmp_path)
+
+    response = server.handle_message(
+        tool_call(SEARCH_TOOL, {"query": "q", "content_budget": budget})
+    )
+
+    assert response["error"]["code"] == JSONRPC_INVALID_PARAMS
+    assert "'content_budget' must be an integer" in response["error"]["message"]
+    assert client.search_calls == []
+
+
+def test_search_result_carries_content_fields(tmp_path):
+    server, _ = make_server(tmp_path)
+
+    response = server.handle_message(tool_call(SEARCH_TOOL, {"query": "q"}))
+    payload = response["result"]["structuredContent"]
+
+    assert "content_budget" in payload
+    result = payload["results"][0]
+    for field in (
+        "content",
+        "content_start_line",
+        "content_end_line",
+        "content_truncated",
+        "content_unavailable",
+    ):
+        assert field in result

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -80,14 +80,14 @@ def test_hybrid_retrieves_lexical_match_outside_dense_candidate_clamp(
     metadata = {"chunks": chunks}
     meta_getter = service._chunk_meta_from_entries(chunks)
 
-    legacy, legacy_label = service._rank_results(
+    legacy, legacy_label, _ = service._rank_results(
         _hybrid_request(tmp_path, "needle", "bm25"),
         paths=paths,
         file_vectors=vectors,
         query_vector=np.array([1.0, 0.0], dtype=np.float32),
         chunk_meta_getter=meta_getter,
     )
-    hybrid, hybrid_label = service._rank_results(
+    hybrid, hybrid_label, _ = service._rank_results(
         _hybrid_request(tmp_path, "needle", "hybrid"),
         paths=paths,
         file_vectors=vectors,
@@ -126,7 +126,7 @@ def test_hybrid_ranks_exact_identifier_above_sub_token_matches(tmp_path: Path) -
             }
         )
 
-    results, reranker = service._rank_results(
+    results, reranker, _ = service._rank_results(
         _hybrid_request(tmp_path, "alpha_beta_gamma", "hybrid"),
         paths=paths,
         file_vectors=vectors,
@@ -149,7 +149,7 @@ def test_hybrid_empty_tokens_fall_back_to_dense(tmp_path: Path) -> None:
             "bm25_doc_len": 1,
         }
     ]
-    results, reranker = service._rank_results(
+    results, reranker, _ = service._rank_results(
         _hybrid_request(tmp_path, "!!!", "hybrid"),
         paths=[tmp_path / "a.txt"],
         file_vectors=np.array([[1.0, 0.0]], dtype=np.float32),
@@ -1199,3 +1199,232 @@ def test_perform_search_raises_on_dimension_mismatch(monkeypatch, tmp_path: Path
 
     with pytest.raises(ValueError, match="Embedding dimension mismatch"):
         perform_search(request)
+
+
+# --- chunk content ----------------------------------------------------------
+
+
+def _content_request(tmp_path: Path, **overrides) -> SearchRequest:
+    params = dict(
+        query="needle",
+        directory=tmp_path,
+        include_hidden=False,
+        respect_gitignore=True,
+        mode="full",
+        recursive=True,
+        top_k=5,
+        model_name="model",
+        batch_size=0,
+        provider="local",
+        base_url=None,
+        api_key=None,
+        local_cuda=False,
+        exclude_patterns=(),
+        extensions=(),
+        auto_index=False,
+        rerank="off",
+        include_content=True,
+    )
+    params.update(overrides)
+    return SearchRequest(**params)
+
+
+def _rank_with_content(request: SearchRequest, paths, chunks):
+    from vexor.services import search_service as service
+
+    vectors = np.array([[1.0, 0.0] for _ in paths], dtype=np.float32)
+    return service._rank_results(
+        request,
+        paths=paths,
+        file_vectors=vectors,
+        query_vector=np.array([1.0, 0.0], dtype=np.float32),
+        chunk_meta_getter=service._chunk_meta_from_entries(chunks),
+    )
+
+
+def test_content_is_read_back_with_original_indentation(tmp_path: Path) -> None:
+    source = tmp_path / "mod.py"
+    source.write_text(
+        "\n\n\ndef verify(token):\n    if not token:\n        raise ValueError\n",
+        encoding="utf-8",
+    )
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": "def verify(token): if not token: raise ValueError",
+            "start_line": 4,
+            "end_line": 6,
+        }
+    ]
+
+    results, _, budget = _rank_with_content(_content_request(tmp_path), [source], chunks)
+
+    assert results[0].content == (
+        "def verify(token):\n    if not token:\n        raise ValueError"
+    )
+    assert results[0].content_start_line == 4
+    assert results[0].content_end_line == 6
+    assert results[0].content_unavailable is None
+    assert budget.used == len(results[0].content)
+
+
+def test_content_absent_when_not_requested(tmp_path: Path) -> None:
+    source = tmp_path / "a.txt"
+    source.write_text("alpha beta gamma\n", encoding="utf-8")
+    chunks = [
+        {"chunk_index": 0, "preview": "alpha beta gamma", "start_line": 1, "end_line": 1}
+    ]
+
+    results, _, budget = _rank_with_content(
+        _content_request(tmp_path, include_content=False), [source], chunks
+    )
+
+    assert results[0].content is None
+    assert results[0].content_unavailable is None
+    assert budget is None
+
+
+def test_content_unavailable_without_line_range(tmp_path: Path) -> None:
+    from vexor.services import search_service as service
+
+    source = tmp_path / "doc.pdf"
+    source.write_text("irrelevant", encoding="utf-8")
+    chunks = [{"chunk_index": 0, "preview": "some preview text here"}]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source], chunks)
+
+    assert results[0].content is None
+    assert results[0].content_unavailable == service.CONTENT_NO_LINE_RANGE
+
+
+def test_content_rejected_when_file_changed_since_indexing(tmp_path: Path) -> None:
+    """A stale line range must degrade to preview, never hand back the wrong lines."""
+    from vexor.services import search_service as service
+
+    source = tmp_path / "moved.py"
+    source.write_text(
+        "def unrelated_helper():\n    return 'completely different text'\n",
+        encoding="utf-8",
+    )
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": "def verify_token(token): return decode(token, algorithms=['HS256'])",
+            "start_line": 1,
+            "end_line": 2,
+        }
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source], chunks)
+
+    assert results[0].content is None
+    assert results[0].content_unavailable == service.CONTENT_STALE_LINE_RANGE
+    assert results[0].preview is not None
+
+
+def test_content_unavailable_when_file_is_gone(tmp_path: Path) -> None:
+    from vexor.services import search_service as service
+
+    missing = tmp_path / "deleted.txt"
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": "text that was indexed before deletion",
+            "start_line": 1,
+            "end_line": 3,
+        }
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [missing], chunks)
+
+    assert results[0].content is None
+    assert results[0].content_unavailable == service.CONTENT_UNREADABLE
+
+
+def test_content_budget_stops_at_the_limit(tmp_path: Path) -> None:
+    from vexor.services import search_service as service
+
+    paths = []
+    chunks = []
+    body = "unique padding line for budget test\n" * 20
+    for idx in range(4):
+        path = tmp_path / f"file-{idx}.txt"
+        path.write_text(body, encoding="utf-8")
+        paths.append(path)
+        chunks.append(
+            {
+                "chunk_index": 0,
+                "preview": "unique padding line for budget test",
+                "start_line": 1,
+                "end_line": 20,
+            }
+        )
+
+    results, _, budget = _rank_with_content(
+        _content_request(tmp_path, content_chars_total=900), paths, chunks
+    )
+
+    assert budget.limit == 900
+    assert budget.used <= 900
+    assert results[0].content is not None
+    exhausted = [
+        r for r in results if r.content_unavailable == service.CONTENT_BUDGET_EXHAUSTED
+    ]
+    assert exhausted, "later results should report the budget running out"
+
+
+def test_tiny_leftover_budget_is_not_reported_as_stale(tmp_path: Path) -> None:
+    """A sliver of remaining budget must not masquerade as a changed file.
+
+    Reading two characters can never match the stored preview, so without a floor the
+    result would claim the index is stale and invite a pointless rebuild.
+    """
+    from vexor.services import search_service as service
+
+    paths = []
+    chunks = []
+    for idx in range(2):
+        path = tmp_path / f"file-{idx}.txt"
+        path.write_text("alpha beta gamma delta epsilon zeta\n" * 4, encoding="utf-8")
+        paths.append(path)
+        chunks.append(
+            {
+                "chunk_index": 0,
+                "preview": "alpha beta gamma delta epsilon zeta",
+                "start_line": 1,
+                "end_line": 4,
+            }
+        )
+
+    # Each chunk is 143 characters, so the first result is served in full and the
+    # second is left with a sliver.
+    results, _, _ = _rank_with_content(
+        _content_request(tmp_path, content_chars_total=250), paths, chunks
+    )
+
+    assert results[0].content is not None
+    assert results[1].content_unavailable == service.CONTENT_BUDGET_EXHAUSTED
+
+
+def test_truncated_content_reports_the_lines_it_actually_returned(tmp_path: Path) -> None:
+    source = tmp_path / "long.txt"
+    source.write_text(
+        "".join(f"line {idx} padding text\n" for idx in range(40)), encoding="utf-8"
+    )
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": "line 0 padding text",
+            "start_line": 1,
+            "end_line": 40,
+        }
+    ]
+
+    results, _, _ = _rank_with_content(
+        _content_request(tmp_path, content_chars_per_result=100), [source], chunks
+    )
+
+    result = results[0]
+    assert result.content_truncated is True
+    assert result.content_end_line < 40
+    assert len(result.content) <= 100

--- a/vexor/api.py
+++ b/vexor/api.py
@@ -43,6 +43,8 @@ from .services.index_service import (
     clear_index_entries,
 )
 from .services.search_service import (
+    DEFAULT_CONTENT_CHARS_PER_RESULT,
+    DEFAULT_CONTENT_CHARS_TOTAL,
     SearchRequest,
     SearchResponse,
     perform_search,
@@ -106,6 +108,9 @@ class InMemoryIndex:
         flashrank_model: str | None = None,
         remote_rerank: RemoteRerankConfig | None = None,
         no_cache: bool = True,
+        include_content: bool = False,
+        content_chars_per_result: int = DEFAULT_CONTENT_CHARS_PER_RESULT,
+        content_chars_total: int = DEFAULT_CONTENT_CHARS_TOTAL,
     ) -> SearchResponse:
         """Search against the in-memory index without touching disk."""
 
@@ -160,6 +165,9 @@ class InMemoryIndex:
             remote_rerank=(
                 remote_rerank if remote_rerank is not None else self.remote_rerank
             ),
+            include_content=include_content,
+            content_chars_per_result=content_chars_per_result,
+            content_chars_total=content_chars_total,
         )
         return search_from_vectors(
             request,
@@ -332,6 +340,9 @@ class VexorClient:
         config: Config | Mapping[str, object] | str | None = None,
         temporary_index: bool = False,
         no_cache: bool = False,
+        include_content: bool = False,
+        content_chars_per_result: int = DEFAULT_CONTENT_CHARS_PER_RESULT,
+        content_chars_total: int = DEFAULT_CONTENT_CHARS_TOTAL,
         data_dir: Path | str | None = None,
         config_dir: Path | str | None = None,
         cache_dir: Path | str | None = None,
@@ -367,6 +378,9 @@ class VexorClient:
             config=config,
             temporary_index=temporary_index,
             no_cache=no_cache,
+            include_content=include_content,
+            content_chars_per_result=content_chars_per_result,
+            content_chars_total=content_chars_total,
             runtime_config=self._runtime_config,
             data_dir=resolved_data_dir,
             config_dir=resolved_config_dir,
@@ -576,6 +590,9 @@ def search(
     config: Config | Mapping[str, object] | str | None = None,
     temporary_index: bool = False,
     no_cache: bool = False,
+    include_content: bool = False,
+    content_chars_per_result: int = DEFAULT_CONTENT_CHARS_PER_RESULT,
+    content_chars_total: int = DEFAULT_CONTENT_CHARS_TOTAL,
     data_dir: Path | str | None = None,
     config_dir: Path | str | None = None,
     cache_dir: Path | str | None = None,
@@ -606,6 +623,9 @@ def search(
         config=config,
         temporary_index=temporary_index,
         no_cache=no_cache,
+        include_content=include_content,
+        content_chars_per_result=content_chars_per_result,
+        content_chars_total=content_chars_total,
         runtime_config=_RUNTIME_CONFIG,
         data_dir=data_dir,
         config_dir=config_dir,
@@ -777,6 +797,9 @@ def _search_with_settings(
     config: Config | Mapping[str, object] | str | None,
     temporary_index: bool,
     no_cache: bool,
+    include_content: bool = False,
+    content_chars_per_result: int = DEFAULT_CONTENT_CHARS_PER_RESULT,
+    content_chars_total: int = DEFAULT_CONTENT_CHARS_TOTAL,
     runtime_config: _RuntimeConfigOverride | None,
     data_dir: Path | str | None,
     config_dir: Path | str | None,
@@ -844,6 +867,9 @@ def _search_with_settings(
             embedding_dimensions=settings.embedding_dimensions,
             flashrank_model=settings.flashrank_model,
             remote_rerank=settings.remote_rerank,
+            include_content=include_content,
+            content_chars_per_result=content_chars_per_result,
+            content_chars_total=content_chars_total,
         )
         return perform_search(request)
 

--- a/vexor/cli.py
+++ b/vexor/cli.py
@@ -179,6 +179,7 @@ class SearchOutputFormat(str, Enum):
     rich = "rich"
     porcelain = "porcelain"
     porcelain_z = "porcelain-z"
+    json = "json"
 
 
 
@@ -430,6 +431,11 @@ def search(
         "--no-cache",
         help=Messages.HELP_NO_CACHE,
     ),
+    show_content: bool = typer.Option(
+        False,
+        "--content",
+        help=Messages.HELP_SEARCH_CONTENT,
+    ),
 ) -> None:
     """Run the semantic search."""
     directory = resolve_directory(path)
@@ -490,6 +496,7 @@ def search(
         flashrank_model=flashrank_model,
         remote_rerank=remote_rerank,
         embedding_dimensions=config.embedding_dimensions,
+        include_content=show_content or output_format == SearchOutputFormat.json,
     )
     if output_format == SearchOutputFormat.rich:
         if no_cache:
@@ -558,7 +565,16 @@ def search(
     if output_format == SearchOutputFormat.porcelain_z:
         _render_results_porcelain_z(response.results, response.base_path)
         return
-    _render_results(response.results, response.base_path, response.backend, response.reranker)
+    if output_format == SearchOutputFormat.json:
+        _render_results_json(response, response.base_path)
+        return
+    _render_results(
+        response.results,
+        response.base_path,
+        response.backend,
+        response.reranker,
+        show_content=show_content,
+    )
 
 
 @app.command()
@@ -1959,11 +1975,73 @@ def feedback() -> None:
         raise typer.Exit(code=1) from exc
 
 
+def _render_results_json(response, base: Path) -> None:
+    """Emit the full response, including chunk content, as one JSON object."""
+    payload = {
+        "path": str(base),
+        "backend": response.backend,
+        "reranker": response.reranker,
+        "stale": response.is_stale,
+        "index_empty": response.index_empty,
+        "results": [
+            {
+                "rank": idx,
+                "score": round(float(result.score), 4),
+                "path": format_path(result.path, base),
+                "absolute_path": str(result.path),
+                "chunk_index": result.chunk_index,
+                "start_line": result.start_line,
+                "end_line": result.end_line,
+                "preview": result.preview,
+                "content": result.content,
+                "content_start_line": result.content_start_line,
+                "content_end_line": result.content_end_line,
+                "content_truncated": result.content_truncated,
+                "content_unavailable": result.content_unavailable,
+            }
+            for idx, result in enumerate(response.results, start=1)
+        ],
+        "content_budget": (
+            {
+                "limit": response.content_budget.limit,
+                "used": response.content_budget.used,
+            }
+            if response.content_budget is not None
+            else None
+        ),
+    }
+    typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def _render_result_content(result: "SearchResult") -> None:
+    """Print one result's source text under its table row."""
+    if result.content is None:
+        if result.content_unavailable:
+            console.print(
+                _styled(
+                    Messages.CONTENT_UNAVAILABLE.format(
+                        reason=result.content_unavailable
+                    ),
+                    Styles.INFO,
+                )
+            )
+        return
+    header = Messages.CONTENT_HEADER.format(
+        start=result.content_start_line,
+        end=result.content_end_line,
+    )
+    if result.content_truncated:
+        header = f"{header} {Messages.CONTENT_TRUNCATED}"
+    console.print(_styled(header, Styles.INFO))
+    console.print(result.content, markup=False, highlight=False)
+
+
 def _render_results(
     results: Sequence["SearchResult"],
     base: Path,
     backend: str | None,
     reranker: str | None,
+    show_content: bool = False,
 ) -> None:
     console.print(_styled(Messages.TABLE_TITLE, Styles.TITLE))
     if backend:
@@ -1986,6 +2064,16 @@ def _render_results(
             _format_preview(result.preview),
         )
     console.print(table)
+    if not show_content:
+        return
+    # Content goes below the table rather than inside a cell: chunk text is multi-line
+    # and would destroy the column layout.
+    for idx, result in enumerate(results, start=1):
+        console.print()
+        console.print(
+            _styled(f"[{idx}] {format_path(result.path, base)}", Styles.TABLE_HEADER)
+        )
+        _render_result_content(result)
 
 
 def _escape_porcelain_field(value: str) -> str:

--- a/vexor/modes.py
+++ b/vexor/modes.py
@@ -104,7 +104,7 @@ class FullStrategy(IndexModeStrategy):
             return [self.fallback.payload_for_file(file)]
         payloads: list[ModePayload] = []
         for index, chunk in enumerate(chunks):
-            normalized = _normalize_preview_chunk(chunk.text)
+            normalized = normalize_preview_chunk(chunk.text)
             if not normalized:
                 continue
             preview = _trim_preview(normalized)
@@ -156,7 +156,7 @@ class CodeStrategy(IndexModeStrategy):
                 continue
             local_total = len(windows)
             for local_idx, window in enumerate(windows, start=1):
-                normalized = _normalize_preview_chunk(window)
+                normalized = normalize_preview_chunk(window)
                 if not normalized:
                     continue
                 preview_snippet = _trim_preview(normalized)
@@ -322,12 +322,22 @@ def _trim_preview(text: str, limit: int = PREVIEW_CHAR_LIMIT) -> str:
     return stripped[: limit - 1].rstrip() + "…"
 
 
-def _normalize_preview_chunk(text: str) -> str | None:
+def normalize_preview_chunk(text: str) -> str | None:
+    """Flatten chunk text the way previews are stored: one line, no blank runs.
+
+    Public because the search path re-derives it to compare a stored preview against
+    text read back from disk. The two must normalize identically or that comparison
+    reports false mismatches.
+    """
     lines = [line.strip() for line in text.splitlines() if line.strip()]
     if lines:
         return " ".join(lines)
     stripped = text.strip()
     return stripped or None
+
+
+# Retained for callers pinned to the pre-0.27 private name.
+_normalize_preview_chunk = normalize_preview_chunk
 
 
 def _chunk_text(text: str, *, chunk_size: int, overlap: int) -> list[str]:

--- a/vexor/search.py
+++ b/vexor/search.py
@@ -29,6 +29,14 @@ class SearchResult:
     chunk_index: int = 0
     start_line: int | None = None
     end_line: int | None = None
+    # Chunk source text, read back from the file at search time rather than stored in
+    # the index. ``content_unavailable`` carries the reason whenever ``content`` is
+    # ``None`` despite the caller asking for it.
+    content: str | None = None
+    content_start_line: int | None = None
+    content_end_line: int | None = None
+    content_truncated: bool = False
+    content_unavailable: str | None = None
 
 
 class EmbeddingBackend(Protocol):

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -59,6 +59,16 @@ class FullChunk:
     end_line: int | None
 
 
+@dataclass(frozen=True, slots=True)
+class ChunkContent:
+    """A chunk's source text read back out of the file it was indexed from."""
+
+    text: str
+    start_line: int
+    end_line: int
+    truncated: bool
+
+
 _registry: Dict[str, HeadExtractor] = {}
 
 TEXT_EXTENSIONS = (
@@ -236,6 +246,62 @@ def extract_full_chunks_with_lines(
             break
         start += stride
     return chunks
+
+
+def read_chunk_content(
+    path: Path,
+    start_line: int,
+    end_line: int,
+    *,
+    max_chars: int,
+) -> ChunkContent | None:
+    """Read lines ``start_line``..``end_line`` (1-based, inclusive) back out of *path*.
+
+    Unlike the indexing extractors this preserves the original indentation and line
+    breaks: the text is meant to be read by a caller, not embedded. Returns ``None``
+    when the file cannot be read or the range does not resolve to any line, so callers
+    can fall back to the stored preview instead of surfacing an error.
+    """
+
+    if start_line < 1 or end_line < start_line or max_chars <= 0:
+        return None
+    text = _read_text_full(path, FULL_CHAR_LIMIT)
+    if text is None:
+        return None
+    lines = text.replace("\r\n", "\n").split("\n")
+    selected = lines[start_line - 1 : end_line]
+    if not selected:
+        return None
+
+    kept: list[str] = []
+    used = 0
+    truncated = False
+    last_line = start_line
+    for offset, line in enumerate(selected):
+        # Every line after the first also costs the newline that joins it.
+        projected = used + len(line) + (1 if kept else 0)
+        if kept and projected > max_chars:
+            truncated = True
+            break
+        kept.append(line)
+        used = projected
+        last_line = start_line + offset
+
+    body = "\n".join(kept)
+    if len(body) > max_chars:
+        # A single line longer than the whole budget still has to be cut somewhere.
+        body = body[:max_chars]
+        truncated = True
+    if not body.strip():
+        return None
+    if last_line < end_line:
+        truncated = True
+    return ChunkContent(
+        text=body,
+        start_line=start_line,
+        end_line=last_line,
+        truncated=truncated,
+    )
 
 
 def extract_code_chunks(

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -11,7 +11,13 @@ from pathlib import Path
 from typing import Dict, Protocol
 
 HEAD_CHAR_LIMIT = 1000
+# Also bounds how far ``read_chunk_content`` will read back: no indexer chunks past
+# this point, so no chunk can carry a line range beyond it either. Raising the limit
+# for indexing without raising it for reading would make late chunks report as
+# unreadable. ``test_chunk_reader_and_indexers_share_the_same_bound`` pins the pair.
 FULL_CHAR_LIMIT = 200_000
+# Read granularity when pulling a chunk's lines back out of a file.
+LINE_READ_BLOCK_BYTES = 64 * 1024
 DEFAULT_CHUNK_SIZE = 1000
 DEFAULT_CHUNK_OVERLAP = 100
 UTF8_BYTE_MULTIPLIER = 4
@@ -248,6 +254,38 @@ def extract_full_chunks_with_lines(
     return chunks
 
 
+def _read_text_through_line(path: Path, last_line: int) -> str | None:
+    """Return UTF-8 text covering the file's first *last_line* lines, and no more.
+
+    Reading the whole file to slice a few lines out of it is pure waste: a chunk is at
+    most a couple of kilobytes, while the file behind it can be far larger. Stops as
+    soon as enough newlines have been seen. Returns ``None`` when the file is not
+    readable as UTF-8, leaving the caller to fall back to charset detection.
+    """
+
+    if last_line < 1:
+        return None
+    try:
+        decoder = codecs.getincrementaldecoder("utf-8")()
+        parts: list[str] = []
+        newlines = 0
+        total_chars = 0
+        with path.open("rb") as handle:
+            while newlines < last_line and total_chars < FULL_CHAR_LIMIT:
+                data = handle.read(LINE_READ_BLOCK_BYTES)
+                if not data:
+                    parts.append(decoder.decode(b"", final=True))
+                    break
+                chunk = decoder.decode(data)
+                newlines += chunk.count("\n")
+                total_chars += len(chunk)
+                parts.append(chunk)
+    except (OSError, UnicodeDecodeError):
+        return None
+    text = "".join(parts)
+    return text or None
+
+
 def read_chunk_content(
     path: Path,
     start_line: int,
@@ -265,7 +303,11 @@ def read_chunk_content(
 
     if start_line < 1 or end_line < start_line or max_chars <= 0:
         return None
-    text = _read_text_full(path, FULL_CHAR_LIMIT)
+    text = _read_text_through_line(path, end_line)
+    if text is None:
+        # Not valid UTF-8 (or unreadable); fall back to the full read, which also
+        # carries the charset-detection path.
+        text = _read_text_full(path, FULL_CHAR_LIMIT)
     if text is None:
         return None
     lines = text.replace("\r\n", "\n").split("\n")

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -34,6 +34,11 @@ JSONRPC_INTERNAL_ERROR = -32603
 MAX_TOP = 50
 DEFAULT_TOP = 5
 
+# Mirrors search_service.DEFAULT_CONTENT_CHARS_TOTAL. Duplicated rather than imported so
+# building the tool schema does not pull numpy into MCP server startup; the consistency
+# test in tests/unit/test_mcp_service.py keeps the two from drifting.
+DEFAULT_CONTENT_BUDGET = 8000
+
 SEARCH_TOOL = "vexor_search"
 INDEX_TOOL = "vexor_index"
 
@@ -49,9 +54,13 @@ _COMMON_TOOL_ARGUMENTS = frozenset(
     }
 )
 _TOOL_ARGUMENTS = {
-    SEARCH_TOOL: _COMMON_TOOL_ARGUMENTS | {"query", "top", "no_cache"},
+    SEARCH_TOOL: _COMMON_TOOL_ARGUMENTS
+    | {"query", "top", "no_cache", "include_content", "content_budget"},
     INDEX_TOOL: _COMMON_TOOL_ARGUMENTS | {"local"},
 }
+
+MIN_CONTENT_BUDGET = 500
+MAX_CONTENT_BUDGET = 40_000
 
 
 class InvalidToolArguments(ValueError):
@@ -106,6 +115,25 @@ def _top_argument(value: Any) -> int:
         raise InvalidToolArguments(
             Messages.MCP_INVALID_ARGUMENTS.format(
                 reason=f"'top' must be an integer between 1 and {MAX_TOP}"
+            )
+        )
+    return value
+
+
+def _content_budget_argument(value: Any) -> int:
+    if value is None:
+        return DEFAULT_CONTENT_BUDGET
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not MIN_CONTENT_BUDGET <= value <= MAX_CONTENT_BUDGET
+    ):
+        raise InvalidToolArguments(
+            Messages.MCP_INVALID_ARGUMENTS.format(
+                reason=(
+                    "'content_budget' must be an integer between "
+                    f"{MIN_CONTENT_BUDGET} and {MAX_CONTENT_BUDGET}"
+                )
             )
         )
     return value
@@ -174,6 +202,11 @@ _RESULT_ITEM_SCHEMA: dict[str, Any] = {
         "start_line": {"type": ["integer", "null"]},
         "end_line": {"type": ["integer", "null"]},
         "preview": {"type": ["string", "null"]},
+        "content": {"type": ["string", "null"]},
+        "content_start_line": {"type": ["integer", "null"]},
+        "content_end_line": {"type": ["integer", "null"]},
+        "content_truncated": {"type": "boolean"},
+        "content_unavailable": {"type": ["string", "null"]},
     },
     "required": ["rank", "score", "path", "absolute_path"],
 }
@@ -188,6 +221,14 @@ SEARCH_OUTPUT_SCHEMA: dict[str, Any] = {
         "stale": {"type": "boolean"},
         "index_empty": {"type": "boolean"},
         "results": {"type": "array", "items": _RESULT_ITEM_SCHEMA},
+        "content_budget": {
+            "type": ["object", "null"],
+            "properties": {
+                "limit": {"type": "integer"},
+                "used": {"type": "integer"},
+            },
+            "required": ["limit", "used"],
+        },
     },
     "required": [
         "query",
@@ -232,6 +273,18 @@ def build_tool_definitions(default_path: Path) -> list[dict[str, Any]]:
             "type": "boolean",
             "default": False,
             "description": Messages.MCP_ARG_NO_CACHE,
+        },
+        "include_content": {
+            "type": "boolean",
+            "default": True,
+            "description": Messages.MCP_ARG_INCLUDE_CONTENT,
+        },
+        "content_budget": {
+            "type": "integer",
+            "minimum": MIN_CONTENT_BUDGET,
+            "maximum": MAX_CONTENT_BUDGET,
+            "default": DEFAULT_CONTENT_BUDGET,
+            "description": Messages.MCP_ARG_CONTENT_BUDGET,
         },
     }
     search_properties.update(scan_properties)
@@ -464,6 +517,12 @@ class VexorMcpServer:
             )
         top = _top_argument(arguments.get("top"))
         no_cache = _bool_argument(arguments.get("no_cache"), "no_cache")
+        # Defaults to on: the consumer here is an agent, and returning only a path plus a
+        # truncated preview forces it to spend another read on every hit.
+        include_content = _bool_argument(
+            arguments.get("include_content"), "include_content", default=True
+        )
+        content_budget = _content_budget_argument(arguments.get("content_budget"))
         scan = self._resolve_scan_arguments(arguments)
         try:
             directory = resolve_directory(scan["path"])
@@ -478,6 +537,8 @@ class VexorMcpServer:
                 extensions=scan["extensions"],
                 exclude_patterns=scan["exclude_patterns"],
                 no_cache=no_cache,
+                include_content=include_content,
+                content_chars_total=content_budget,
             )
         except Exception as exc:
             return _tool_error(SEARCH_TOOL, str(exc))
@@ -498,9 +559,22 @@ class VexorMcpServer:
                         "start_line": result.start_line,
                         "end_line": result.end_line,
                         "preview": result.preview,
+                        "content": result.content,
+                        "content_start_line": result.content_start_line,
+                        "content_end_line": result.content_end_line,
+                        "content_truncated": result.content_truncated,
+                        "content_unavailable": result.content_unavailable,
                     }
                     for rank, result in enumerate(response.results, start=1)
                 ],
+                "content_budget": (
+                    {
+                        "limit": response.content_budget.limit,
+                        "used": response.content_budget.used,
+                    }
+                    if response.content_budget is not None
+                    else None
+                ),
             }
         )
 

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -40,6 +40,13 @@ DEFAULT_CONTENT_CHARS_TOTAL = 8000
 # result as stale rather than as out of budget.
 MIN_USEFUL_CONTENT_CHARS = 200
 
+# How much of a stored preview is compared against re-read text, and the shortest
+# probe worth comparing at all. Both are heuristics: the check exists to catch text
+# read from the wrong place, and it errs toward accepting, since a false negative
+# costs a preview fallback while a false positive hands back the wrong lines.
+PREVIEW_PROBE_CHARS = 40
+PREVIEW_PROBE_MIN_CHARS = 12
+
 # Reasons a result carries no content despite the caller asking for it.
 CONTENT_NO_LINE_RANGE = "no_line_range"
 CONTENT_STALE_LINE_RANGE = "stale_line_range"
@@ -206,13 +213,13 @@ def _content_matches_preview(content: str, preview: str | None) -> bool:
     """
 
     probe = _preview_probe(preview)
-    if len(probe) < 12:
+    if len(probe) < PREVIEW_PROBE_MIN_CHARS:
         # Too short to identify a location; nothing useful to verify against.
         return True
-    from ..modes import _normalize_preview_chunk
+    from ..modes import normalize_preview_chunk
 
-    normalized = _normalize_preview_chunk(content) or ""
-    return probe[:40] in normalized
+    normalized = normalize_preview_chunk(content) or ""
+    return probe[:PREVIEW_PROBE_CHARS] in normalized
 
 
 def _attach_chunk_content(

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -29,6 +29,23 @@ from .cache_service import is_cache_current
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ..search import SearchResult
 
+# Chunk text is returned to callers verbatim, so it has to be capped or a single
+# search could bury an agent's context window. Counted in characters rather than
+# tokens on purpose: a tokenizer dependency would not earn its weight here.
+DEFAULT_CONTENT_CHARS_PER_RESULT = 2000
+DEFAULT_CONTENT_CHARS_TOTAL = 8000
+
+# Below this much remaining budget a read would return a sliver too small to be worth
+# anything — and too small to survive the preview check, which would then misreport the
+# result as stale rather than as out of budget.
+MIN_USEFUL_CONTENT_CHARS = 200
+
+# Reasons a result carries no content despite the caller asking for it.
+CONTENT_NO_LINE_RANGE = "no_line_range"
+CONTENT_STALE_LINE_RANGE = "stale_line_range"
+CONTENT_BUDGET_EXHAUSTED = "budget_exhausted"
+CONTENT_UNREADABLE = "unreadable"
+
 
 @dataclass(slots=True)
 class SearchRequest:
@@ -57,6 +74,17 @@ class SearchRequest:
     flashrank_model: str | None = None
     remote_rerank: RemoteRerankConfig | None = None
     embedding_dimensions: int | None = None
+    include_content: bool = False
+    content_chars_per_result: int = DEFAULT_CONTENT_CHARS_PER_RESULT
+    content_chars_total: int = DEFAULT_CONTENT_CHARS_TOTAL
+
+
+@dataclass(slots=True)
+class ContentBudget:
+    """How much chunk text a single response was allowed to carry, and how much it used."""
+
+    limit: int
+    used: int
 
 
 @dataclass(slots=True)
@@ -67,6 +95,7 @@ class SearchResponse:
     is_stale: bool
     index_empty: bool
     reranker: str | None = None
+    content_budget: ContentBudget | None = None
 
 
 _TOKEN_RE = bm25._TOKEN_RE
@@ -152,6 +181,81 @@ def _hybrid_scorer_from_entries(
 
     score.has_data = True
     return score
+
+
+def _preview_probe(preview: str | None) -> str:
+    """Return the part of a stored preview that should also appear in the chunk text.
+
+    ``code`` and ``outline`` previews are prefixed with a symbol path or heading
+    breadcrumb (``display :: snippet``); only the trailing snippet came from the file.
+    ``_trim_preview`` may also have appended an ellipsis.
+    """
+
+    if not preview:
+        return ""
+    return preview.rsplit(" :: ", 1)[-1].rstrip("…").strip()
+
+
+def _content_matches_preview(content: str, preview: str | None) -> bool:
+    """Check that re-read text still looks like what was indexed at that line range.
+
+    Guards two cases that both produce plausible-looking but wrong text: indexes built
+    before the full-mode line offset fix, and files edited since they were indexed.
+    Deliberately lenient — a false negative only costs the caller a preview fallback,
+    while a false positive hands an agent code from the wrong part of the file.
+    """
+
+    probe = _preview_probe(preview)
+    if len(probe) < 12:
+        # Too short to identify a location; nothing useful to verify against.
+        return True
+    from ..modes import _normalize_preview_chunk
+
+    normalized = _normalize_preview_chunk(content) or ""
+    return probe[:40] in normalized
+
+
+def _attach_chunk_content(
+    request: SearchRequest, results: Sequence[SearchResult]
+) -> ContentBudget | None:
+    """Fill in ``content`` for each result, in rank order, until the budget runs out."""
+
+    if not request.include_content:
+        return None
+    from .content_extract_service import read_chunk_content  # local import
+
+    per_result = max(int(request.content_chars_per_result), 0)
+    total = max(int(request.content_chars_total), 0)
+    used = 0
+    for result in results:
+        if result.start_line is None or result.end_line is None:
+            result.content_unavailable = CONTENT_NO_LINE_RANGE
+            continue
+        remaining = total - used
+        if remaining < min(MIN_USEFUL_CONTENT_CHARS, per_result):
+            result.content_unavailable = CONTENT_BUDGET_EXHAUSTED
+            continue
+        try:
+            chunk = read_chunk_content(
+                result.path,
+                result.start_line,
+                result.end_line,
+                max_chars=min(per_result, remaining),
+            )
+        except OSError:
+            chunk = None
+        if chunk is None:
+            result.content_unavailable = CONTENT_UNREADABLE
+            continue
+        if not _content_matches_preview(chunk.text, result.preview):
+            result.content_unavailable = CONTENT_STALE_LINE_RANGE
+            continue
+        result.content = chunk.text
+        result.content_start_line = chunk.start_line
+        result.content_end_line = chunk.end_line
+        result.content_truncated = chunk.truncated
+        used += len(chunk.text)
+    return ContentBudget(limit=total, used=used)
 
 
 def _build_rerank_document(result: SearchResult) -> str:
@@ -558,8 +662,12 @@ def _rank_results(
     query_vector: np.ndarray,
     chunk_meta_getter,
     lexical_scorer: Callable[[Sequence[str]], dict[int, float]] | None = None,
-) -> tuple[list, str | None]:
-    """Score the index against the query, then rank and optionally rerank."""
+) -> tuple[list, str | None, ContentBudget | None]:
+    """Score the index against the query, then rank and optionally rerank.
+
+    Chunk content is attached last, after reranking has settled the final order, so the
+    shared budget is spent on the results the caller actually sees first.
+    """
     from ..search import SearchResult  # local import
 
     reranker = None
@@ -614,7 +722,7 @@ def _rank_results(
                             end_line=int(end_line) if end_line is not None else None,
                         )
                     )
-                return scored, "hybrid"
+                return scored, "hybrid", _attach_chunk_content(request, scored)
     top_indices = _top_indices(similarities, candidate_count)
     chunk_meta_for = chunk_meta_getter(top_indices)
     scored: list[SearchResult] = []
@@ -644,7 +752,8 @@ def _rank_results(
         else:
             scored = _apply_remote_rerank(request.query, scored, request.remote_rerank)
             reranker = "remote"
-    return scored[: request.top_k], reranker
+    final = scored[: request.top_k]
+    return final, reranker, _attach_chunk_content(request, final)
 
 
 @dataclass(slots=True)
@@ -821,7 +930,7 @@ def perform_search(request: SearchRequest) -> SearchResponse:
         state.file_vectors,
         index_id=state.metadata.get("index_id"),
     )
-    results, reranker = _rank_results(
+    results, reranker, content_budget = _rank_results(
         request,
         paths=state.paths,
         file_vectors=state.file_vectors,
@@ -842,6 +951,7 @@ def perform_search(request: SearchRequest) -> SearchResponse:
         is_stale=state.stale,
         index_empty=False,
         reranker=reranker,
+        content_budget=content_budget,
     )
 
 
@@ -860,7 +970,7 @@ def search_from_vectors(
 
     searcher = _build_searcher(request)
     query_vector = _resolve_query_vector(request, searcher, file_vectors)
-    results, reranker = _rank_results(
+    results, reranker, content_budget = _rank_results(
         request,
         paths=paths,
         file_vectors=file_vectors,
@@ -879,6 +989,7 @@ def search_from_vectors(
         is_stale=is_stale,
         index_empty=False,
         reranker=reranker,
+        content_budget=content_budget,
     )
 
 

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -17,7 +17,8 @@ class Messages:
     HELP_SEARCH_PATH = "Root directory whose search will be performed."
     HELP_SEARCH_TOP = "Number of results to display."
     HELP_SEARCH_FORMAT = (
-        "Output format (rich=table, porcelain=tab-separated for scripts, porcelain-z=NUL-delimited)."
+        "Output format (rich=table, porcelain=tab-separated for scripts, "
+        "porcelain-z=NUL-delimited, json=full response including chunk content)."
     )
     HELP_NO_CACHE = "Disable all disk caches (index + embedding/query)."
     HELP_INCLUDE_HIDDEN = "Use the index built with hidden files included."
@@ -81,7 +82,8 @@ class Messages:
     MCP_TOOL_FAILED = "{tool} failed: {reason}"
     MCP_TOOL_SEARCH_DESCRIPTION = (
         "Find files or code from a natural-language description. Returns "
-        "ranked matches with paths, relevance scores, line ranges, and previews."
+        "ranked matches with paths, relevance scores, line ranges, and the "
+        "matching source text, so most results need no follow-up file read."
     )
     MCP_TOOL_INDEX_DESCRIPTION = (
         "Build or refresh the semantic index for a directory. Use it to warm "
@@ -95,6 +97,22 @@ class Messages:
     MCP_ARG_NO_CACHE = (
         "Build a temporary in-memory index and disable all disk caches for "
         "this search. Slower and may regenerate embeddings."
+    )
+    MCP_ARG_INCLUDE_CONTENT = (
+        "Return each match's source text alongside its path. Text is read "
+        "from the file at search time. A result carries "
+        "content_unavailable instead when the mode records no line range, "
+        "the file changed since indexing, or the budget ran out."
+    )
+    MCP_ARG_CONTENT_BUDGET = (
+        "Total characters of source text one response may return, spent on "
+        "the highest-ranked matches first."
+    )
+    CONTENT_HEADER = "Lines {start}-{end}"
+    CONTENT_TRUNCATED = "(truncated)"
+    CONTENT_UNAVAILABLE = "No content: {reason}"
+    HELP_SEARCH_CONTENT = (
+        "Show each match's source text below the results table."
     )
     MCP_ARG_PATH = (
         "Directory to operate on. Absolute, or relative to the server's "


### PR DESCRIPTION
Follow-up to #44, which made `full`-mode line numbers trustworthy enough to read back.

## Motivation

A search result carried a path, a line range, and a preview capped at 160 characters (`PREVIEW_CHAR_LIMIT`). An agent had to re-read every hit before it could act, which spends back most of what retrieval saved — the tool answered "where is it" when the caller needed "what is it".

The chunks were already good: `code` mode cuts on AST boundaries, `outline` on heading hierarchy. Only their *location* survived into the results; the text was discarded at index time.

## Approach

Results now carry the chunk's source text, **read back from the file at search time** by line range rather than stored in the index. Consequences of that choice:

- Index size is unchanged, nothing re-embeds, `CACHE_VERSION` is untouched, and no existing index is invalidated.
- Returned text always reflects what is on disk now, not what was indexed.
- Original indentation and line breaks are preserved — the indexing path's newline-flattening is for embeddings, not for readers.

**Validation before returning.** A line range can be wrong two ways: an index built before #44 carries the old offset, or the file was edited since indexing. Both would hand back plausible-looking text from the wrong part of the file, and an agent takes that at face value — worse than returning nothing. Re-read text is checked against the stored preview; on mismatch the result degrades to `content_unavailable="stale_line_range"` with the preview intact and the search still succeeding. The check is deliberately lenient (skipped when the preview is too short to identify a location): a false negative costs a preview fallback, a false positive corrupts an agent's context.

**Budget.** 2000 characters per result, 8000 per response, counted in characters — a tokenizer dependency would not earn its weight. Spent in rank order *after* reranking settles the order, so the budget goes to the results the caller actually sees first. Truncation always reports `content_truncated` and the last line actually returned; a silently-short chunk reads as a complete one.

Four reason codes cover every no-content case: `no_line_range`, `stale_line_range`, `budget_exhausted`, `unreadable`.

## Surfaces

| Surface | Flag / argument | Default |
|---|---|---|
| MCP `vexor_search` | `include_content`, `content_budget` | **on** |
| Python API | `include_content`, `content_chars_per_result`, `content_chars_total` | off |
| CLI (table) | `--content` | off |
| CLI (machine) | `--format json` | on with the format |
| `--format porcelain` / `-z` | unchanged | — |

MCP defaults to on because its consumer is an agent and the content is what it needs; defaulting to off would leave most callers on the old path-only behavior. The Python API defaults to off because its consumer is a program and new fields should be opt-in.

**Porcelain is untouched.** Chunk text is multi-line and would break the one-line-per-result contract that existing scripts parse, so content goes to JSON instead. A new test locks the porcelain column set so this cannot regress.

## Verification

**Unit + integration** — `python -m pytest`: 626 passed. Coverage `--cov=vexor`: 91% total.

Cases worth calling out:
- stale range → `content is None`, reason `stale_line_range`, preview preserved, search succeeds
- budget → later results report `budget_exhausted`; `used <= limit`
- truncation → `content_truncated` true and `content_end_line` < chunk end
- indentation preserved verbatim on re-read
- porcelain column contract locked (field list asserted exactly; also asserts content never leaks into the TSV)
- MCP `inputSchema` properties are asserted equal to the `_TOOL_ARGUMENTS` validation whitelist, so the advertised schema and the strict validator cannot drift — this closes an item from the roadmap's Engineering TODO

**Found by a test, then fixed:** with only a few characters of budget left, the reader returned a sliver that could never match its preview, so the result reported `stale_line_range` — telling the caller the file had changed when the budget had merely run out, and inviting a pointless rebuild. There is now a floor (`MIN_USEFUL_CONTENT_CHARS`) below which the result correctly reports `budget_exhausted`.

**End-to-end** — real provider (`custom` / SiliconFlow `BAAI/bge-m3`), `--mode code`:

```
$ vexor search "validate a JWT and return its claims" --mode code --top 2 --content
| # | Similarity | File path | Lines | Preview                     |
| 1 |      0.669 | ./auth.py |  L4-8 | def verify_token(token): …  |
| 2 |      0.620 | ./auth.py |  L1-3 | module :: import jwt        |

[1] ./auth.py
Lines 4-8
def verify_token(token):
    """Check a JWT and return its claims."""
    if not token:
        raise ValueError("empty token")
    return jwt.decode(token, algorithms=["HS256"])
```

Indentation, docstring, and quoting all survive the round trip. `--format json` verified against the same corpus, returning `content_budget: {limit: 8000, used: 174}`.

Stale-path checked live: overwriting the indexed file with unrelated content and searching again returns `content: None` / `content_unavailable: "stale_line_range"` with the preview intact, instead of handing back the unrelated lines now sitting at 4–8.

## Compatibility

- Porcelain column count and order unchanged; content never appears there.
- `CACHE_VERSION` unchanged; no index is invalidated and nothing re-embeds.
- New `SearchResult` / `SearchResponse` fields are additive with inert defaults; `_rank_results` gained a third return value (internal helper).
- MCP output schema is additive. `include_content` defaulting to on changes what existing MCP clients receive — bounded by the 8000-character cap.
- `mcp_service.DEFAULT_CONTENT_BUDGET` intentionally duplicates the service constant rather than importing it, to keep numpy off the MCP startup path; a test asserts the two stay equal.

## Docs

`docs/cli.md`, `docs/mcp.md`, `docs/api/python.md`, the bundled skill (`plugins/vexor/skills/vexor-cli/SKILL.md`), and `docs/roadmap.md` — which also records the two follow-ups this unblocks: feeding content to the rerankers (currently capped by preview length, and needs its own benchmark since it shifts ordering), and the token-cost evaluation, which was not worth running while results were path-only.
