### PR TITLE
perf(search): reuse memory-mapped index state

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -18,15 +18,15 @@ for hit in response.results:
 
 ## Client sessions (library usage)
 
-For scoped configuration and per-call data directories, use `VexorClient`:
+For scoped configuration, reusable indexes, and per-call data directories, use
+`VexorClient` as a context manager:
 
 ```python
 from vexor import VexorClient
 
-client = VexorClient(data_dir="/tmp/vexor", use_config=False)
-client.set_config_json({"provider": "openai", "api_key": "YOUR_KEY"})
-
-response = client.search("config loader", path=".", mode="name")
+with VexorClient(data_dir="/tmp/vexor", use_config=False) as client:
+    client.set_config_json({"provider": "openai", "api_key": "YOUR_KEY"})
+    response = client.search("config loader", path=".", mode="name")
 ```
 
 Scoped overrides without global mutation:
@@ -59,10 +59,12 @@ Project resolution starts at the call's resolved `path` and uses the nearest
 API and runtime payloads retain the full schema below.
 
 Index cache location is resolved separately. Vexor walks upward from `path` and
-uses the nearest project `.vexor/index.db` when a `.vexor/` directory exists.
-Explicit per-call `cache_dir` or `data_dir` arguments, client-level overrides,
-and `set_cache_dir(...)` take precedence over project detection; otherwise the
-fallback is `~/.vexor/index.db`.
+uses the nearest project `.vexor/` cache when that directory exists. Explicit
+per-call `cache_dir` or `data_dir` arguments, client-level overrides, and
+`set_cache_dir(...)` take precedence over project detection; otherwise Vexor
+uses the global `~/.vexor/` cache. See
+[Cache Behavior](../cli.md#cache-behavior) for its generated layout and cleanup
+commands.
 
 ## API reference
 
@@ -138,7 +140,7 @@ Remove cached index entries for a directory. Returns the count removed.
 Set the base directory for Vexor data:
 
 - `config.json`
-- `index.db` and embedding/query caches
+- `index.db`, `vectors/`, and embedding/query caches
 - `flashrank/` and `models/` directories
 
 Pass `None` to reset to `~/.vexor`.
@@ -189,6 +191,12 @@ over the environment.
 - `temporary_index=True`: no index cache read/write; embedding/query caches still used.
 - `no_cache=True`: disables all disk caches; forces in-memory indexing and embeddings.
 - When `no_cache=False`, a process-local LRU may reuse recent embeddings.
+- A `VexorClient` reuses loaded index state and watches searched directories
+  for mutations. After the first full snapshot validation, unchanged searches
+  skip the repeated directory scan. Call `close()` when a client is not used as
+  a context manager.
+- Module-level `search(...)` calls do not retain a watcher between calls and
+  therefore keep the full snapshot validation behavior.
 
 ## Examples
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -191,10 +191,13 @@ over the environment.
 - `temporary_index=True`: no index cache read/write; embedding/query caches still used.
 - `no_cache=True`: disables all disk caches; forces in-memory indexing and embeddings.
 - When `no_cache=False`, a process-local LRU may reuse recent embeddings.
-- A `VexorClient` reuses loaded index state and watches searched directories
-  for mutations. After the first full snapshot validation, unchanged searches
-  skip the repeated directory scan. Call `close()` when a client is not used as
-  a context manager.
+- A `VexorClient` reuses loaded index state. Install `vexor[watch]` to also
+  monitor searched directories and skip repeated directory scans between
+  periodic full snapshot validations. Missing watcher support, watcher setup
+  failures, and expired watcher hints fall back to a full scan; they never make
+  an otherwise searchable directory fail. Source mutations invalidate the
+  hint, while generated `.vexor/` cache writes do not. Call `close()` when a
+  client is not used as a context manager.
 - Module-level `search(...)` calls do not retain a watcher between calls and
   therefore keep the full snapshot validation behavior.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -191,13 +191,12 @@ over the environment.
 - `temporary_index=True`: no index cache read/write; embedding/query caches still used.
 - `no_cache=True`: disables all disk caches; forces in-memory indexing and embeddings.
 - When `no_cache=False`, a process-local LRU may reuse recent embeddings.
-- A `VexorClient` reuses loaded index state. Install `vexor[watch]` to also
-  monitor searched directories and skip repeated directory scans between
-  periodic full snapshot validations. Missing watcher support, watcher setup
-  failures, and expired watcher hints fall back to a full scan; they never make
-  an otherwise searchable directory fail. Source mutations invalidate the
-  hint, while generated `.vexor/` cache writes do not. Call `close()` when a
-  client is not used as a context manager.
+- A `VexorClient` reuses loaded index state and monitors searched directories,
+  skipping repeated directory scans between periodic full snapshot
+  validations. Watcher setup failures and expired watcher hints fall back to a
+  full scan; they never make an otherwise searchable directory fail. Source
+  mutations invalidate the hint, while generated `.vexor/` cache writes do not.
+  Call `close()` when a client is not used as a context manager.
 - Module-level `search(...)` calls do not retain a watcher between calls and
   therefore keep the full snapshot validation behavior.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@
 | `--format json` | Full response as JSON, including chunk content |
 | `--content` | Print each match's source text below the results table |
 | `--no-cache` | In-memory only; do not read/write index cache |
-| `--local` | With `index`, create and use `<path>/.vexor/index.db` |
+| `--local` | With `index`, create and use `<path>/.vexor/` cache storage |
 
 Reranking is a config setting rather than a search flag — see
 [Configuration → Rerank](configuration.md#rerank) for the available
@@ -121,7 +121,8 @@ Index cache keys derive from: `--path`, `--mode`, `--include-hidden`,
 
 Keep flags consistent to reuse cache; changing flags creates a separate index.
 
-By default, indexes are stored in `~/.vexor/index.db`. Project-local caching is
+By default, index metadata is stored in `~/.vexor/index.db`, with dense vectors
+under `~/.vexor/vectors/`. Project-local caching is
 opt-in: create a `.vexor/` directory in a project root, or run
 `vexor index --local`. Either way, Vexor writes a `.gitignore` inside
 `.vexor/` on first use so generated indexes and caches cannot be committed by
@@ -140,7 +141,7 @@ data, FlashRank assets, and local embedding models remain under `~/.vexor/`.
 vexor config --show-index-all    # list all cached indexes
 vexor config --clear-index-all   # clear all cached indexes
 vexor index --path . --clear     # clear index for specific path
-vexor index --path . --local     # create/use ./.vexor/index.db
+vexor index --path . --local     # create/use ./.vexor/ cache storage
 ```
 
 Re-running `vexor index` only re-embeds changed files; >50% changes trigger

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,10 +6,12 @@ Vexor is configured through `vexor config` commands (or the interactive
 ## Where data lives
 
 Global configuration, update-check data, FlashRank assets, and local embedding
-models stay under `~/.vexor/`. Indexes normally use `~/.vexor/index.db`, but a
-project containing a `.vexor/` directory uses `<project>/.vexor/index.db` for
+models stay under `~/.vexor/`. Index caches normally use that global directory,
+but a project containing a `.vexor/` directory uses its project-local cache for
 searches and indexing within that project. The same directory may contain a
-tracked `config.json` with restricted project-level overrides.
+tracked `config.json` with restricted project-level overrides. See
+[Cache Behavior](cli.md#cache-behavior) for the generated layout and cleanup
+commands.
 
 Run `vexor index --local` to create the project directory and its ignore file.
 This does not create a project config. The generated index and caches remain

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,3 +14,20 @@ Global cache files and configuration live in `~/.vexor`. A project with a
 `config.json` overlay documented in `docs/configuration.md`. The text embedded
 for each chunk is built by the mode strategies in `vexor/modes.py`; adjust the
 strategy `label` construction there if you need to encode additional context.
+
+Index metadata, paths, BM25 postings, and query caches live in `index.db`.
+Dense vectors use generation-specific `vectors/*.npy` sidecars so searches can
+open them through NumPy mmap instead of reconstructing a matrix from SQLite
+BLOB rows. `CACHE_VERSION` changes invalidate older layouts and trigger a
+normal rebuild; do not add a silent compatibility path for corrupt sidecars.
+
+Run the local performance harness without provider credentials:
+
+```bash
+python scripts/benchmark_search_cache.py
+python scripts/benchmark_search_cache.py --vector-count 30000 --file-count 10000
+```
+
+The harness reports first and process-cached vector loads, full snapshot
+validation, and event-backed freshness checks. Timing is diagnostic evidence,
+not a fixed CI threshold.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -225,12 +225,9 @@ The tool returns `{path, mode, status, files_indexed}` where `status` is `stored
   database. With `no_cache=true`,
   `vexor_search` instead builds a temporary in-memory index and writes no
   index, embedding, or query caches.
-- The server keeps one `VexorClient` for the MCP session. It reuses loaded index
-  state and watches searched directories for mutations, so an unchanged
-  repeated search skips the full filesystem snapshot scan after initial
-  validation. Once the watcher reports a source mutation, a later search
-  revalidates and refreshes the index as required; generated `.vexor/` cache
-  writes do not invalidate it.
+- The server keeps one `VexorClient` for the MCP session, so tool calls share
+  the process-local index state and watcher behavior described by the Python
+  API's [cache contract](api/python.md#cache-behavior).
 - Execution failures (missing directory, provider errors, missing API key)
   are returned as tool results with `isError: true` so the agent can
   self-correct; malformed arguments (wrong types, out-of-range `top`,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -225,6 +225,12 @@ The tool returns `{path, mode, status, files_indexed}` where `status` is `stored
   database. With `no_cache=true`,
   `vexor_search` instead builds a temporary in-memory index and writes no
   index, embedding, or query caches.
+- The server keeps one `VexorClient` for the MCP session. It reuses loaded index
+  state and watches searched directories for mutations, so an unchanged
+  repeated search skips the full filesystem snapshot scan after initial
+  validation. Once the watcher reports a source mutation, a later search
+  revalidates and refreshes the index as required; generated `.vexor/` cache
+  writes do not invalidate it.
 - Execution failures (missing directory, provider errors, missing API key)
   are returned as tool results with `isError: true` so the agent can
   self-correct; malformed arguments (wrong types, out-of-range `top`,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -141,11 +141,10 @@ never leaving the machine.
 
 ## P1 — Performance & experience
 
-- `vexor watch`: background incremental indexing via a file watcher.
-  Also removes the per-search full-directory `stat()` staleness scan,
-  which is O(N) filesystem work on every query today.
-- Replace SQLite vector blobs with `vectors.npy` + `metadata.json`
-  (memmap) to reuse across searches.
+- Add a standalone `vexor watch` command for background incremental indexing
+  across separate CLI processes. Long-lived Python and MCP sessions already
+  track changes within their process, so this item specifically covers a
+  persistent CLI workflow.
 - Extend the MCP lazy-start path to other CLI commands; agents may invoke
   the CLI dozens of times per session so startup latency multiplies.
 - Dependency slimming: move document extractors (`pypdf`, `python-docx`,
@@ -160,8 +159,8 @@ never leaving the machine.
     concurrency to reduce thread overhead and improve connection reuse.
   - Adaptive embedding batch size for remote providers (guarded by safe
     min/max and backoff on 429/413).
-  - Batch query search API to embed multiple queries per call and reuse
-    loaded index vectors (reduce repeated I/O).
+  - Batch query search API to embed multiple queries per call. Client sessions
+    already reuse loaded index vectors; batching still reduces provider calls.
 
 ## P2 — Coverage & polish
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -142,9 +142,9 @@ never leaving the machine.
 ## P1 — Performance & experience
 
 - Add a standalone `vexor watch` command for background incremental indexing
-  across separate CLI processes. Long-lived Python and MCP sessions already
-  track changes within their process, so this item specifically covers a
-  persistent CLI workflow.
+  across separate CLI processes. This item specifically covers a persistent
+  cross-process CLI workflow; in-process behavior belongs to the Python API's
+  [cache contract](api/python.md#cache-behavior).
 - Extend the MCP lazy-start path to other CLI commands; agents may invoke
   the CLI dozens of times per session so startup latency multiplies.
 - Dependency slimming: move document extractors (`pypdf`, `python-docx`,

--- a/plugins/vexor/skills/vexor-cli/SKILL.md
+++ b/plugins/vexor/skills/vexor-cli/SKILL.md
@@ -34,7 +34,7 @@ vexor "<QUERY>" [--path <ROOT>] [--mode <MODE>] [--ext .py,.md] [--exclude-patte
 - `--format`: `rich` (default), `porcelain`/`porcelain-z` for scripts, `json` for full output with chunk content
 - `--content`: print each match's source text below the table — usually removes the need to read the files afterwards
 - `--no-cache`: in-memory only, do not read/write index cache
-- `vexor index --local`: create and use project-local `.vexor/index.db` storage
+- `vexor index --local`: create and use project-local `.vexor/` cache storage
 
 ## Project Config
 
@@ -98,7 +98,10 @@ vexor search "where JWT claims are validated" --path . --mode code --content
 
 ## Tips
 
-- First time search will index files (may take a minute). Subsequent searches are fast. Use longer timeouts if needed.
+- First time search will index files (may take a minute). Long-lived MCP or
+  Python client sessions reuse mapped vectors and monitor source changes;
+  separate CLI invocations still validate the filesystem. Use longer timeouts
+  if needed.
 - Results return similarity ranking, exact file location, line numbers, and matching snippet preview.
 - Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
 - Combine `--ext` with `--exclude-pattern` to focus on a subset (exclude rules apply on top).

--- a/plugins/vexor/skills/vexor-cli/SKILL.md
+++ b/plugins/vexor/skills/vexor-cli/SKILL.md
@@ -99,9 +99,10 @@ vexor search "where JWT claims are validated" --path . --mode code --content
 ## Tips
 
 - First time search will index files (may take a minute). Long-lived MCP or
-  Python client sessions reuse mapped vectors and monitor source changes;
-  separate CLI invocations still validate the filesystem. Use longer timeouts
-  if needed.
+  Python client sessions reuse mapped vectors. With `vexor[watch]` installed,
+  they also monitor source changes and skip some snapshot scans; watcher setup
+  failures fall back to scanning. Separate CLI invocations still validate the
+  filesystem. Use longer timeouts if needed.
 - Results return similarity ranking, exact file location, line numbers, and matching snippet preview.
 - Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
 - Combine `--ext` with `--exclude-pattern` to focus on a subset (exclude rules apply on top).

--- a/plugins/vexor/skills/vexor-cli/SKILL.md
+++ b/plugins/vexor/skills/vexor-cli/SKILL.md
@@ -99,10 +99,9 @@ vexor search "where JWT claims are validated" --path . --mode code --content
 ## Tips
 
 - First time search will index files (may take a minute). Long-lived MCP or
-  Python client sessions reuse mapped vectors. With `vexor[watch]` installed,
-  they also monitor source changes and skip some snapshot scans; watcher setup
-  failures fall back to scanning. Separate CLI invocations still validate the
-  filesystem. Use longer timeouts if needed.
+  Python client sessions reuse mapped vectors, monitor source changes, and skip
+  some snapshot scans. Watcher setup failures fall back to scanning. Separate
+  CLI invocations still validate the filesystem. Use longer timeouts if needed.
 - Results return similarity ranking, exact file location, line numbers, and matching snippet preview.
 - Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
 - Combine `--ext` with `--exclude-pattern` to focus on a subset (exclude rules apply on top).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "tree-sitter>=0.23.0",
     "tree-sitter-javascript>=0.23.0",
     "tree-sitter-typescript>=0.23.0",
+    "watchdog>=6.0.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "tree-sitter>=0.23.0",
     "tree-sitter-javascript>=0.23.0",
     "tree-sitter-typescript>=0.23.0",
-    "watchdog>=6.0.0",
 ]
 dynamic = ["version"]
 
@@ -62,6 +61,10 @@ dev = [
     "build>=1.2.1",
     "twine>=5.1.1",
     "pyinstaller>=6.0.0",
+    "watchdog>=6.0.0",
+]
+watch = [
+    "watchdog>=6.0.0",
 ]
 flashrank = [
     "flashrank>=0.2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "tree-sitter>=0.23.0",
     "tree-sitter-javascript>=0.23.0",
     "tree-sitter-typescript>=0.23.0",
+    "watchdog>=6.0.0",
 ]
 dynamic = ["version"]
 
@@ -61,10 +62,6 @@ dev = [
     "build>=1.2.1",
     "twine>=5.1.1",
     "pyinstaller>=6.0.0",
-    "watchdog>=6.0.0",
-]
-watch = [
-    "watchdog>=6.0.0",
 ]
 flashrank = [
     "flashrank>=0.2.9",

--- a/scripts/benchmark_search_cache.py
+++ b/scripts/benchmark_search_cache.py
@@ -1,0 +1,184 @@
+"""Measure Vexor index-loading and freshness-check costs locally."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+from pathlib import Path
+from statistics import median
+from tempfile import TemporaryDirectory
+from time import perf_counter
+
+import numpy as np
+
+from vexor.cache import (
+    IndexedChunk,
+    IndexVectorCache,
+    cache_dir_context,
+    compare_snapshot,
+    load_index_vectors,
+    store_index,
+)
+from vexor.services.index_service import _snapshot_current_files
+from vexor.services.freshness_service import FreshnessTracker
+from vexor.utils import collect_files
+
+
+def _milliseconds(samples: list[float]) -> str:
+    return f"min={min(samples) * 1000:.2f} median={median(samples) * 1000:.2f}"
+
+
+def _measure(repeats: int, operation) -> tuple[list[float], object]:
+    samples: list[float] = []
+    result = None
+    for _ in range(repeats):
+        started = perf_counter()
+        result = operation()
+        samples.append(perf_counter() - started)
+    return samples, result
+
+
+def _build_files(root: Path, count: int) -> None:
+    directory_count = max(min(count // 100, 100), 1)
+    per_directory = (count + directory_count - 1) // directory_count
+    created = 0
+    for directory_index in range(directory_count):
+        directory = root / f"d{directory_index:03d}"
+        directory.mkdir()
+        for file_index in range(per_directory):
+            if created >= count:
+                return
+            (directory / f"f{file_index:05d}.py").touch()
+            created += 1
+
+
+def run_benchmark(
+    *,
+    vector_count: int,
+    dimension: int,
+    file_count: int,
+    repeats: int,
+) -> None:
+    rng = np.random.default_rng(7)
+    with TemporaryDirectory(prefix="vexor-search-benchmark-") as temporary:
+        base = Path(temporary)
+        project = base / "project"
+        project.mkdir()
+        cache_dir = base / "cache"
+        cache_dir.mkdir()
+        vector = rng.standard_normal(dimension, dtype=np.float32)
+        entries = [
+            IndexedChunk(
+                path=project / f"vector-{index}.py",
+                rel_path=f"vector-{index}.py",
+                chunk_index=0,
+                preview="",
+                embedding=vector,
+                size_bytes=1,
+                mtime=1.0,
+            )
+            for index in range(vector_count)
+        ]
+        memory_cache = IndexVectorCache()
+        with cache_dir_context(cache_dir):
+            started = perf_counter()
+            database = store_index(
+                root=project,
+                model="benchmark",
+                include_hidden=False,
+                respect_gitignore=False,
+                mode="full",
+                recursive=True,
+                entries=entries,
+            )
+            store_seconds = perf_counter() - started
+            first_samples, loaded = _measure(
+                1,
+                lambda: load_index_vectors(
+                    project,
+                    "benchmark",
+                    False,
+                    "full",
+                    True,
+                    respect_gitignore=False,
+                    memory_cache=memory_cache,
+                ),
+            )
+            repeated_samples, loaded = _measure(
+                repeats,
+                lambda: load_index_vectors(
+                    project,
+                    "benchmark",
+                    False,
+                    "full",
+                    True,
+                    respect_gitignore=False,
+                    memory_cache=memory_cache,
+                ),
+            )
+            vectors = loaded[1]
+            vector_file = cache_dir / loaded[2]["vector_file"]
+            print(
+                f"vectors rows={vector_count} dimension={dimension} "
+                f"database_mb={database.stat().st_size / 1024 / 1024:.1f} "
+                f"sidecar_mb={vector_file.stat().st_size / 1024 / 1024:.1f}"
+            )
+            print(f"store seconds={store_seconds:.3f}")
+            print(f"first_load_ms {_milliseconds(first_samples)}")
+            print(f"cached_load_ms {_milliseconds(repeated_samples)}")
+            del vectors
+            del loaded
+            memory_cache.clear()
+            gc.collect()
+
+        scan_root = base / "scan"
+        scan_root.mkdir()
+        _build_files(scan_root, file_count)
+        files = collect_files(scan_root, recursive=True, respect_gitignore=False)
+        snapshot = _snapshot_current_files(files, scan_root)
+        cached_files = [
+            {"path": relative, "mtime": entry.mtime, "size": entry.size}
+            for relative, entry in snapshot.items()
+        ]
+        snapshot_samples, current = _measure(
+            repeats,
+            lambda: compare_snapshot(
+                scan_root,
+                False,
+                cached_files,
+                recursive=True,
+                respect_gitignore=False,
+            ),
+        )
+        tracker = FreshnessTracker()
+        token = tracker.begin_validation(scan_root)
+        tracker.finish_validation(scan_root, "benchmark", token)
+        event_samples, fresh = _measure(
+            repeats,
+            lambda: tracker.is_fresh(scan_root, "benchmark"),
+        )
+        tracker.close()
+        print(f"snapshot files={file_count} current={current} {_milliseconds(snapshot_samples)}")
+        print(f"event_check fresh={fresh} {_milliseconds(event_samples)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vector-count", type=int, default=10_000)
+    parser.add_argument("--dimension", type=int, default=384)
+    parser.add_argument("--file-count", type=int, default=2_000)
+    parser.add_argument("--repeats", type=int, default=5)
+    arguments = parser.parse_args()
+    for name in ("vector_count", "dimension", "file_count", "repeats"):
+        if getattr(arguments, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be greater than zero")
+    run_benchmark(
+        vector_count=arguments.vector_count,
+        dimension=arguments.dimension,
+        file_count=arguments.file_count,
+        repeats=arguments.repeats,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -75,6 +75,7 @@ def test_store_and_load_index(tmp_path, monkeypatch):
     )
 
     assert [p.name for p in loaded_paths] == ["a.txt", "b.txt", "c.txt"]
+    assert isinstance(loaded_vectors, np.memmap)
     assert np.allclose(loaded_vectors, embeddings)
     assert meta["model"] == "test-model"
     chunk_ids = meta.get("chunk_ids", [])
@@ -83,6 +84,114 @@ def test_store_and_load_index(tmp_path, monkeypatch):
     assert chunk_meta[chunk_ids[0]]["preview"] == "preview-a.txt"
     assert meta["exclude_patterns"] == ()
     assert meta["extensions"] == ()
+    vector_path = cache.cache_db_path().parent / meta["vector_file"]
+    assert vector_path.is_file()
+    connection = cache._connect(cache.cache_db_path(), readonly=True)
+    try:
+        count = connection.execute(
+            "SELECT COUNT(*) AS total FROM chunk_embedding"
+        ).fetchone()["total"]
+    finally:
+        connection.close()
+    assert count == 0
+
+
+def test_index_vector_memory_cache_tracks_immutable_generations(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / "cache")
+    root = tmp_path / "project"
+    root.mkdir()
+    file_path = root / "a.txt"
+    file_path.write_text("data")
+    memory_cache = cache.IndexVectorCache()
+
+    cache.store_index(
+        root=root,
+        model="model",
+        include_hidden=False,
+        mode=MODE,
+        recursive=True,
+        entries=_entries_for_files(
+            root,
+            [file_path],
+            np.array([[1.0, 0.0]], dtype=np.float32),
+        ),
+    )
+    first = cache.load_index_vectors(
+        root,
+        "model",
+        False,
+        MODE,
+        True,
+        memory_cache=memory_cache,
+    )
+    repeated = cache.load_index_vectors(
+        root,
+        "model",
+        False,
+        MODE,
+        True,
+        memory_cache=memory_cache,
+    )
+    assert repeated[1] is first[1]
+
+    cache.store_index(
+        root=root,
+        model="model",
+        include_hidden=False,
+        mode=MODE,
+        recursive=True,
+        entries=_entries_for_files(
+            root,
+            [file_path],
+            np.array([[0.0, 1.0]], dtype=np.float32),
+        ),
+    )
+    rebuilt = cache.load_index_vectors(
+        root,
+        "model",
+        False,
+        MODE,
+        True,
+        memory_cache=memory_cache,
+    )
+    assert rebuilt[1] is not first[1]
+    assert np.allclose(rebuilt[1], [[0.0, 1.0]])
+    del first
+    del repeated
+    memory_cache.prune()
+    vector_dir = cache.cache_db_path().parent / cache.VECTOR_DIRNAME
+    assert len(list(vector_dir.glob("*.npy"))) == 1
+
+
+def test_index_vector_cache_rejects_unsafe_sidecar_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / "cache")
+    root = tmp_path / "project"
+    root.mkdir()
+    file_path = root / "a.txt"
+    file_path.write_text("data")
+    cache.store_index(
+        root=root,
+        model="model",
+        include_hidden=False,
+        mode=MODE,
+        recursive=True,
+        entries=_entries_for_files(
+            root,
+            [file_path],
+            np.array([[1.0]], dtype=np.float32),
+        ),
+    )
+    connection = cache._connect(cache.cache_db_path())
+    try:
+        with connection:
+            connection.execute(
+                "UPDATE index_metadata SET vector_file = '../outside.npy'"
+            )
+    finally:
+        connection.close()
+
+    with pytest.raises(RuntimeError, match="Invalid cached vector path"):
+        cache.load_index_vectors(root, "model", False, MODE, True)
 
 
 def test_store_and_load_bm25_statistics(tmp_path, monkeypatch):
@@ -173,6 +282,18 @@ def test_embedding_cache_memory_fallback(tmp_path, monkeypatch):
     loaded = cache.load_embedding_cache("model", [text_hash])
     assert text_hash in loaded
     assert np.allclose(loaded[text_hash], vector)
+
+
+def test_embedding_memory_cache_is_scoped_to_cache_directory(tmp_path):
+    cache._clear_embedding_memory_cache()
+    with cache.cache_dir_context(tmp_path / "one"):
+        cache._store_embedding_memory_cache(
+            model="model",
+            embeddings={"hash": np.array([1.0], dtype=np.float32)},
+        )
+        assert "hash" in cache._load_embedding_memory_cache("model", ["hash"])
+    with cache.cache_dir_context(tmp_path / "two"):
+        assert cache._load_embedding_memory_cache("model", ["hash"]) == {}
 
 
 def test_embedding_cache_prunes_by_ttl_and_capacity(tmp_path, monkeypatch):
@@ -383,6 +504,8 @@ def test_clear_index_removes_cached_entries(tmp_path, monkeypatch):
 
     removed = cache.clear_index(root=root, include_hidden=False, mode=MODE, recursive=True)
     assert removed == 2
+    vector_dir = cache.cache_db_path().parent / cache.VECTOR_DIRNAME
+    assert not list(vector_dir.glob("*.npy"))
 
     with pytest.raises(FileNotFoundError):
         cache.load_index(root=root, model="model-a", include_hidden=False, mode=MODE, recursive=True)
@@ -750,6 +873,7 @@ def test_clear_all_cache_removes_database(tmp_path, monkeypatch):
     assert removed == 2
     db_path = cache_dir / cache.DB_FILENAME
     assert not db_path.exists()
+    assert not (cache_dir / cache.VECTOR_DIRNAME).exists()
     assert cache.list_cache_entries() == []
     assert cache.clear_all_cache() == 0
 

--- a/tests/unit/test_cache_upgrade_and_lines.py
+++ b/tests/unit/test_cache_upgrade_and_lines.py
@@ -124,3 +124,59 @@ def test_backfill_chunk_lines_missing_db_raises(tmp_path, monkeypatch):
             recursive=True,
             updates=[],
         )
+
+
+def test_old_blob_cache_version_requires_rebuild(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / "cache")
+    root = tmp_path / "project"
+    root.mkdir()
+    file_path = root / "a.txt"
+    file_path.write_text("data", encoding="utf-8")
+    cache.store_index(
+        root=root,
+        model="model",
+        include_hidden=False,
+        mode="name",
+        recursive=True,
+        entries=[
+            cache.IndexedChunk(
+                path=file_path,
+                rel_path="a.txt",
+                chunk_index=0,
+                preview="a",
+                embedding=np.array([1.0], dtype=np.float32),
+            )
+        ],
+    )
+    connection = cache._connect(cache.cache_db_path())
+    try:
+        with connection:
+            connection.execute(
+                "UPDATE index_metadata SET version = ?",
+                (cache.CACHE_VERSION - 1,),
+            )
+    finally:
+        connection.close()
+
+    with pytest.raises(FileNotFoundError):
+        cache.load_index_vectors(root, "model", False, "name", True)
+
+
+def test_legacy_schema_without_vector_file_requires_rebuild(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / "cache")
+    root = tmp_path / "project"
+    root.mkdir()
+    connection = sqlite3.connect(cache.cache_db_path())
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE index_metadata (id INTEGER PRIMARY KEY);
+            CREATE TABLE indexed_file (id INTEGER PRIMARY KEY);
+            CREATE TABLE indexed_chunk (id INTEGER PRIMARY KEY);
+            """
+        )
+    finally:
+        connection.close()
+
+    with pytest.raises(FileNotFoundError):
+        cache.load_index_vectors(root, "model", False, "name", True)

--- a/tests/unit/test_freshness_service.py
+++ b/tests/unit/test_freshness_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Event, Lock, Thread
 from types import SimpleNamespace
 
 import numpy as np
@@ -45,6 +46,34 @@ class FakeObserver:
         )
         for handler in self.handlers:
             handler.on_any_event(event)
+
+
+class LockingObserver(FakeObserver):
+    """Model watchdog's dispatcher/schedule lock ordering."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.internal_lock = Lock()
+        self.schedule_attempted = Event()
+        self.dispatch_ready = Event()
+        self.dispatch_handler = Event()
+
+    def schedule(self, handler, _path: str, *, recursive: bool) -> None:
+        assert recursive is True
+        self.schedule_attempted.set()
+        with self.internal_lock:
+            self.handlers.append(handler)
+
+    def dispatch(self, path: Path) -> None:
+        with self.internal_lock:
+            self.dispatch_ready.set()
+            assert self.dispatch_handler.wait(2)
+            event = SimpleNamespace(
+                event_type="modified",
+                src_path=str(path),
+                dest_path=None,
+            )
+            self.handlers[0].on_any_event(event)
 
 
 def _request(tmp_path: Path, tracker: FreshnessTracker) -> SearchRequest:
@@ -195,4 +224,158 @@ def test_event_during_snapshot_validation_marks_index_stale(
         list_cache_entries=lambda: [],
     )
     assert state.stale is True
+    tracker.close()
+
+
+def test_registering_second_root_does_not_deadlock_dispatcher(tmp_path: Path) -> None:
+    observer = LockingObserver()
+    tracker = FreshnessTracker(observer_factory=lambda: observer)
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first_root.mkdir()
+    second_root.mkdir()
+    assert tracker.begin_validation(first_root) == 0
+    observer.schedule_attempted.clear()
+
+    dispatcher = Thread(
+        target=observer.dispatch,
+        args=(first_root / "changed.py",),
+        daemon=True,
+    )
+    dispatcher.start()
+    assert observer.dispatch_ready.wait(2)
+
+    registration_result: list[int | None] = []
+    registration = Thread(
+        target=lambda: registration_result.append(tracker.begin_validation(second_root)),
+        daemon=True,
+    )
+    registration.start()
+    assert observer.schedule_attempted.wait(2)
+    observer.dispatch_handler.set()
+
+    dispatcher.join(2)
+    registration.join(2)
+    assert dispatcher.is_alive() is False
+    assert registration.is_alive() is False
+    assert registration_result == [0]
+    tracker.close()
+
+
+def test_schedule_failure_falls_back_to_snapshot_scans(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    class FailingObserver(FakeObserver):
+        def __init__(self) -> None:
+            super().__init__()
+            self.schedule_calls = 0
+
+        def schedule(self, handler, _path: str, *, recursive: bool) -> None:
+            self.schedule_calls += 1
+            raise OSError(28, "inotify watch limit reached")
+
+    observer = FailingObserver()
+    tracker = FreshnessTracker(observer_factory=lambda: observer)
+    request = _request(tmp_path, tracker)
+    snapshot_calls = 0
+
+    def load_index_vectors(*_args, **_kwargs):
+        return (
+            [tmp_path / "a.py"],
+            np.array([[1.0, 0.0]], dtype=np.float32),
+            {
+                "index_id": 1,
+                "generated_at": "generation-1",
+                "vector_file": "vectors/one.npy",
+                "files": [{"path": "a.py", "mtime": 1.0, "size": 1}],
+                "chunks": [],
+                "chunk_ids": [1],
+            },
+        )
+
+    def is_cache_current(*_args, **_kwargs) -> bool:
+        nonlocal snapshot_calls
+        snapshot_calls += 1
+        return True
+
+    monkeypatch.setattr(search_service, "is_cache_current", is_cache_current)
+    for _ in range(2):
+        state = search_service._load_filtered_index(
+            request,
+            None,
+            load_index_vectors=load_index_vectors,
+            list_cache_entries=lambda: [],
+        )
+        assert state.stale is False
+
+    assert observer.schedule_calls == 1
+    assert snapshot_calls == 2
+    tracker.close()
+
+
+def test_missing_watchdog_falls_back_without_creating_observer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    observer_created = False
+
+    def create_observer():
+        nonlocal observer_created
+        observer_created = True
+        return FakeObserver()
+
+    def missing_handler(*_args, **_kwargs):
+        raise ModuleNotFoundError("No module named 'watchdog'", name="watchdog")
+
+    monkeypatch.setattr(
+        "vexor.services.freshness_service._build_event_handler",
+        missing_handler,
+    )
+    tracker = FreshnessTracker(observer_factory=create_observer)
+
+    assert tracker.begin_validation(tmp_path) is None
+    assert tracker.begin_validation(tmp_path) is None
+    assert observer_created is False
+    tracker.close()
+
+
+def test_fresh_hint_expires_by_age_and_reuse_budget(tmp_path: Path) -> None:
+    observer = FakeObserver()
+    now = [10.0]
+    tracker = FreshnessTracker(
+        observer_factory=lambda: observer,
+        max_reuses=1,
+        max_age_seconds=5.0,
+        clock=lambda: now[0],
+    )
+    token = tracker.begin_validation(tmp_path)
+    assert token == 0
+    assert tracker.finish_validation(tmp_path, "by-count", token) is True
+    assert tracker.is_fresh(tmp_path, "by-count") is True
+    assert tracker.is_fresh(tmp_path, "by-count") is False
+
+    assert tracker.finish_validation(tmp_path, "by-age", token) is True
+    now[0] += 5.0
+    assert tracker.is_fresh(tmp_path, "by-age") is False
+    tracker.close()
+
+
+def test_validation_cache_is_bounded_and_dirty_event_clears_root(tmp_path: Path) -> None:
+    observer = FakeObserver()
+    tracker = FreshnessTracker(
+        observer_factory=lambda: observer,
+        max_validations=2,
+    )
+    token = tracker.begin_validation(tmp_path)
+    assert token == 0
+    for key in ("old", "middle", "new"):
+        assert tracker.finish_validation(tmp_path, key, token) is True
+
+    assert tracker.is_fresh(tmp_path, "old") is False
+    assert tracker.is_fresh(tmp_path, "middle") is True
+    assert tracker.is_fresh(tmp_path, "new") is True
+    observer.emit("modified", tmp_path / "a.py")
+    assert tracker.is_fresh(tmp_path, "middle") is False
+    assert tracker.is_fresh(tmp_path, "new") is False
     tracker.close()

--- a/tests/unit/test_freshness_service.py
+++ b/tests/unit/test_freshness_service.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vexor.services import search_service
+from vexor.services.freshness_service import FreshnessTracker
+from vexor.services.search_service import SearchRequest
+
+
+class FakeObserver:
+    def __init__(self) -> None:
+        self.handlers: list[object] = []
+        self.started = False
+        self.stopped = False
+        self.joined = False
+
+    def schedule(self, handler, _path: str, *, recursive: bool) -> None:
+        assert recursive is True
+        self.handlers.append(handler)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def join(self) -> None:
+        self.joined = True
+
+    def emit(
+        self,
+        event_type: str,
+        path: Path,
+        *,
+        destination: Path | None = None,
+    ) -> None:
+        event = SimpleNamespace(
+            event_type=event_type,
+            src_path=str(path),
+            dest_path=str(destination) if destination is not None else None,
+        )
+        for handler in self.handlers:
+            handler.on_any_event(event)
+
+
+def _request(tmp_path: Path, tracker: FreshnessTracker) -> SearchRequest:
+    return SearchRequest(
+        query="alpha",
+        directory=tmp_path,
+        include_hidden=False,
+        respect_gitignore=True,
+        mode="name",
+        recursive=True,
+        top_k=2,
+        model_name="model",
+        batch_size=0,
+        provider="openai",
+        base_url=None,
+        api_key="key",
+        local_cuda=False,
+        exclude_patterns=(),
+        extensions=(),
+        auto_index=False,
+        freshness_tracker=tracker,
+    )
+
+
+def test_tracker_invalidates_only_on_source_mutations(tmp_path: Path) -> None:
+    observer = FakeObserver()
+    tracker = FreshnessTracker(observer_factory=lambda: observer)
+    key = ("index", 1)
+
+    token = tracker.begin_validation(tmp_path)
+    assert tracker.finish_validation(tmp_path, key, token) is True
+    assert tracker.is_fresh(tmp_path, key) is True
+
+    observer.emit("opened", tmp_path / "a.py")
+    observer.emit("modified", tmp_path / ".vexor" / "index.db")
+    assert tracker.is_fresh(tmp_path, key) is True
+
+    observer.emit("modified", tmp_path / "a.py")
+    assert tracker.is_fresh(tmp_path, key) is False
+
+    tracker.close()
+    tracker.close()
+    assert observer.started is True
+    assert observer.stopped is True
+    assert observer.joined is True
+    with pytest.raises(RuntimeError, match="closed"):
+        tracker.begin_validation(tmp_path)
+
+
+def test_repeated_index_load_skips_snapshot_scan_until_event(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    observer = FakeObserver()
+    tracker = FreshnessTracker(observer_factory=lambda: observer)
+    request = _request(tmp_path, tracker)
+    calls = {"snapshots": 0}
+
+    def load_index_vectors(*_args, **_kwargs):
+        paths = [tmp_path / "a.py"]
+        vectors = np.array([[1.0, 0.0]], dtype=np.float32)
+        metadata = {
+            "index_id": 1,
+            "generated_at": "generation-1",
+            "vector_file": "vectors/one.npy",
+            "files": [
+                {
+                    "path": "a.py",
+                    "absolute": str(paths[0]),
+                    "mtime": 1.0,
+                    "size": 1,
+                }
+            ],
+            "chunks": [],
+            "chunk_ids": [1],
+        }
+        return paths, vectors, metadata
+
+    def is_cache_current(*_args, **_kwargs) -> bool:
+        calls["snapshots"] += 1
+        return True
+
+    monkeypatch.setattr(search_service, "is_cache_current", is_cache_current)
+
+    first = search_service._load_filtered_index(
+        request,
+        None,
+        load_index_vectors=load_index_vectors,
+        list_cache_entries=lambda: [],
+    )
+    second = search_service._load_filtered_index(
+        request,
+        None,
+        load_index_vectors=load_index_vectors,
+        list_cache_entries=lambda: [],
+    )
+    assert first.stale is False
+    assert second.stale is False
+    assert calls["snapshots"] == 1
+
+    observer.emit("modified", tmp_path / "a.py")
+    third = search_service._load_filtered_index(
+        request,
+        None,
+        load_index_vectors=load_index_vectors,
+        list_cache_entries=lambda: [],
+    )
+    assert third.stale is False
+    assert calls["snapshots"] == 2
+    tracker.close()
+
+
+def test_event_during_snapshot_validation_marks_index_stale(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    observer = FakeObserver()
+    tracker = FreshnessTracker(observer_factory=lambda: observer)
+    request = _request(tmp_path, tracker)
+
+    def load_index_vectors(*_args, **_kwargs):
+        return (
+            [tmp_path / "a.py"],
+            np.array([[1.0, 0.0]], dtype=np.float32),
+            {
+                "index_id": 1,
+                "generated_at": "generation-1",
+                "vector_file": "vectors/one.npy",
+                "files": [{"path": "a.py", "mtime": 1.0, "size": 1}],
+                "chunks": [],
+                "chunk_ids": [1],
+            },
+        )
+
+    def mutate_during_validation(*_args, **_kwargs) -> bool:
+        observer.emit("modified", tmp_path / "a.py")
+        return True
+
+    monkeypatch.setattr(
+        search_service,
+        "is_cache_current",
+        mutate_during_validation,
+    )
+    state = search_service._load_filtered_index(
+        request,
+        None,
+        load_index_vectors=load_index_vectors,
+        list_cache_entries=lambda: [],
+    )
+    assert state.stale is True
+    tracker.close()

--- a/tests/unit/test_index_service.py
+++ b/tests/unit/test_index_service.py
@@ -123,6 +123,54 @@ def test_embed_labels_with_cache_reuses_embeddings(tmp_path, monkeypatch):
     assert np.allclose(first, second)
 
 
+def test_legacy_index_rebuild_reuses_embedding_cache(tmp_path, monkeypatch):
+    _patch_cache_dir(tmp_path, monkeypatch)
+    _patch_searcher(monkeypatch)
+    DummySearcher.calls = []
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "a.txt").write_text("a", encoding="utf-8")
+    kwargs = dict(provider="gemini", base_url=None, api_key=None)
+
+    first = build_index(
+        root,
+        include_hidden=False,
+        mode="name",
+        recursive=True,
+        model_name="model",
+        batch_size=0,
+        **kwargs,
+    )
+    assert first.status == IndexStatus.STORED
+    assert len(DummySearcher.calls) == 1
+
+    connection = cache._connect(cache.cache_db_path())
+    try:
+        with connection:
+            connection.execute(
+                "UPDATE index_metadata SET version = ?",
+                (cache.CACHE_VERSION - 1,),
+            )
+    finally:
+        connection.close()
+
+    DummySearcher.calls = []
+    rebuilt = build_index(
+        root,
+        include_hidden=False,
+        mode="name",
+        recursive=True,
+        model_name="model",
+        batch_size=0,
+        **kwargs,
+    )
+
+    assert rebuilt.status == IndexStatus.STORED
+    assert DummySearcher.calls == []
+    metadata = cache.load_index(root, "model", False, "name", True)
+    assert metadata["version"] == cache.CACHE_VERSION
+
+
 def test_build_index_falls_back_to_full_rebuild(tmp_path, monkeypatch):
     _patch_cache_dir(tmp_path, monkeypatch)
     _patch_searcher(monkeypatch)

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -382,7 +382,21 @@ def test_perform_search_missing_index_raises_when_auto_index_disabled(monkeypatc
 
 
 def test_perform_search_auto_indexes_when_stale(monkeypatch, tmp_path: Path) -> None:
-    calls: dict[str, int] = {"load": 0, "indexed": 0, "cache_checks": 0}
+    calls: dict[str, int] = {
+        "load": 0,
+        "indexed": 0,
+        "cache_checks": 0,
+        "vector_cache_clears": 0,
+    }
+
+    class TrackingVectorCache:
+        def clear(self) -> None:
+            calls["vector_cache_clears"] += 1
+
+        def prune(self) -> None:
+            return None
+
+    vector_cache = TrackingVectorCache()
 
     def fake_load_index_vectors(*_args, **_kwargs):
         calls["load"] += 1
@@ -430,12 +444,14 @@ def test_perform_search_auto_indexes_when_stale(monkeypatch, tmp_path: Path) -> 
         exclude_patterns=(),
         extensions=(),
         auto_index=True,
+        index_vector_cache=vector_cache,
     )
     response = perform_search(request)
 
     assert response.index_empty is False
     assert response.is_stale is False
     assert calls["indexed"] == 1
+    assert calls["vector_cache_clears"] == 1
     assert calls["load"] == 2
     assert response.results[0].path.name == "b.txt"
 
@@ -559,7 +575,7 @@ def test_perform_search_uses_cached_query_vector(monkeypatch, tmp_path: Path) ->
         entries=entries,
     )
 
-    calls = {"embeds": 0}
+    calls = {"embeds": 0, "query_cache_stores": 0}
 
     class CountingSearcher:
         device = "dummy-backend"
@@ -573,6 +589,13 @@ def test_perform_search_uses_cached_query_vector(monkeypatch, tmp_path: Path) ->
 
     monkeypatch.setattr(search_module, "VexorSearcher", CountingSearcher)
     monkeypatch.setattr("vexor.services.search_service.is_cache_current", lambda *_a, **_k: True)
+    original_store_query_vector = cache.store_query_vector
+
+    def count_store_query_vector(*args, **kwargs):
+        calls["query_cache_stores"] += 1
+        return original_store_query_vector(*args, **kwargs)
+
+    monkeypatch.setattr(cache, "store_query_vector", count_store_query_vector)
 
     request = SearchRequest(
         query="alpha",
@@ -599,6 +622,7 @@ def test_perform_search_uses_cached_query_vector(monkeypatch, tmp_path: Path) ->
     assert response1.index_empty is False
     assert response2.index_empty is False
     assert calls["embeds"] == 1
+    assert calls["query_cache_stores"] == 1
 
 
 def test_perform_search_reuses_superset_index_for_extension_filter(

--- a/vexor.spec
+++ b/vexor.spec
@@ -114,6 +114,7 @@ hiddenimports = []
 hiddenimports += collect_submodules("google.genai")
 hiddenimports += collect_submodules("tokenizers")
 hiddenimports += collect_submodules("tree_sitter")
+hiddenimports += collect_submodules("watchdog")
 hiddenimports += ["tree_sitter_javascript", "tree_sitter_typescript"]
 hiddenimports += ["rank_bm25"]
 

--- a/vexor/api.py
+++ b/vexor/api.py
@@ -25,6 +25,7 @@ from .config import (
     set_config_dir,
 )
 from .cache import (
+    IndexVectorCache,
     cache_dir_context,
     create_project_cache_dir,
     project_cache_context,
@@ -42,6 +43,7 @@ from .services.index_service import (
     build_index_in_memory,
     clear_index_entries,
 )
+from .services.freshness_service import FreshnessTracker
 from .services.search_service import (
     DEFAULT_CONTENT_CHARS_PER_RESULT,
     DEFAULT_CONTENT_CHARS_TOTAL,
@@ -270,6 +272,20 @@ class VexorClient:
         self.cache_dir = cache_dir
         self.use_config = use_config
         self._runtime_config: _RuntimeConfigOverride | None = None
+        self._index_vector_cache = IndexVectorCache()
+        self._freshness_tracker = FreshnessTracker()
+
+    def close(self) -> None:
+        """Release background resources owned by this client."""
+
+        self._freshness_tracker.close()
+        self._index_vector_cache.clear()
+
+    def __enter__(self) -> VexorClient:
+        return self
+
+    def __exit__(self, *_exc_info) -> None:
+        self.close()
 
     def set_config_json(
         self,
@@ -385,6 +401,8 @@ class VexorClient:
             data_dir=resolved_data_dir,
             config_dir=resolved_config_dir,
             cache_dir=resolved_cache_dir,
+            index_vector_cache=self._index_vector_cache,
+            freshness_tracker=self._freshness_tracker,
         )
 
     def index(
@@ -420,6 +438,7 @@ class VexorClient:
         resolved_data_dir, resolved_config_dir, resolved_cache_dir = (
             self._resolve_dir_overrides(data_dir, config_dir, cache_dir)
         )
+        self._index_vector_cache.clear()
         return _index_with_settings(
             path=path,
             include_hidden=include_hidden,
@@ -526,6 +545,7 @@ class VexorClient:
         resolved_data_dir, resolved_config_dir, resolved_cache_dir = (
             self._resolve_dir_overrides(data_dir, config_dir, cache_dir)
         )
+        self._index_vector_cache.clear()
         return _clear_index_with_settings(
             path=path,
             include_hidden=include_hidden,
@@ -562,6 +582,7 @@ def config_context(
         yield client
     finally:
         client.set_config_json(None)
+        client.close()
 
 
 def search(
@@ -804,6 +825,8 @@ def _search_with_settings(
     data_dir: Path | str | None,
     config_dir: Path | str | None,
     cache_dir: Path | str | None,
+    index_vector_cache: IndexVectorCache | None = None,
+    freshness_tracker: FreshnessTracker | None = None,
 ) -> SearchResponse:
     with (
         _data_dir_context(data_dir, config_dir=config_dir, cache_dir=cache_dir),
@@ -870,6 +893,8 @@ def _search_with_settings(
             include_content=include_content,
             content_chars_per_result=content_chars_per_result,
             content_chars_total=content_chars_total,
+            index_vector_cache=index_vector_cache,
+            freshness_tracker=freshness_tracker,
         )
         return perform_search(request)
 

--- a/vexor/cache.py
+++ b/vexor/cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 import sqlite3
+import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
 from contextlib import contextmanager
@@ -27,13 +28,16 @@ _CACHE_DIR_OVERRIDE: ContextVar[Path | None] = ContextVar(
     "vexor_cache_dir_override",
     default=None,
 )
-CACHE_VERSION = 7
+CACHE_VERSION = 8
 DB_FILENAME = "index.db"
+VECTOR_DIRNAME = "vectors"
 EMBED_CACHE_TTL_DAYS = 30
 EMBED_CACHE_MAX_ENTRIES = 50_000
 EMBED_MEMORY_CACHE_MAX_ENTRIES = 2_048
 
-_EMBED_MEMORY_CACHE: "OrderedDict[tuple[str, int | None, str], np.ndarray]" = OrderedDict()
+_EMBED_MEMORY_CACHE: "OrderedDict[tuple[str, str, int | None, str], np.ndarray]" = (
+    OrderedDict()
+)
 _EMBED_MEMORY_LOCK = Lock()
 
 
@@ -51,6 +55,64 @@ class IndexedChunk:
     end_line: int | None = None
     bm25_terms: Mapping[str, int] | None = None
     bm25_doc_len: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _LoadedIndexVectors:
+    paths: tuple[Path, ...]
+    vectors: np.ndarray
+    metadata: dict
+
+
+class IndexVectorCache:
+    """Small process-local cache for immutable loaded index generations."""
+
+    def __init__(self, max_entries: int = 4) -> None:
+        self.max_entries = max(int(max_entries), 1)
+        self._entries: OrderedDict[tuple[object, ...], _LoadedIndexVectors] = OrderedDict()
+        self._database_paths: set[Path] = set()
+        self._lock = Lock()
+
+    def get(self, key: tuple[object, ...]) -> _LoadedIndexVectors | None:
+        with self._lock:
+            loaded = self._entries.pop(key, None)
+            if loaded is None:
+                return None
+            self._entries[key] = loaded
+            return loaded
+
+    def store(
+        self,
+        key: tuple[object, ...],
+        loaded: _LoadedIndexVectors,
+    ) -> None:
+        logical_key = key[:3]
+        with self._lock:
+            self._database_paths.add(Path(str(key[0])))
+            for existing_key in list(self._entries):
+                if existing_key[:3] == logical_key:
+                    self._entries.pop(existing_key, None)
+            self._entries[key] = loaded
+            while len(self._entries) > self.max_entries:
+                self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def prune(self) -> None:
+        """Remove unreferenced sidecars after callers release older generations."""
+
+        with self._lock:
+            database_paths = set(self._database_paths)
+        for db_path in database_paths:
+            if not db_path.is_file():
+                continue
+            connection = _connect(db_path, readonly=True)
+            try:
+                _prune_unreferenced_vector_files(connection, db_path)
+            finally:
+                connection.close()
 
 
 def _cache_key(
@@ -125,12 +187,13 @@ def _load_embedding_memory_cache(
     if EMBED_MEMORY_CACHE_MAX_ENTRIES <= 0:
         return {}
     results: dict[str, np.ndarray] = {}
+    cache_namespace = str(_resolve_cache_dir())
     with _EMBED_MEMORY_LOCK:
         for text_hash in text_hashes:
             if not text_hash:
                 continue
             # Include dimension in cache key to prevent cross-dimension pollution
-            key = (model, dimension, text_hash)
+            key = (cache_namespace, model, dimension, text_hash)
             vector = _EMBED_MEMORY_CACHE.pop(key, None)
             if vector is None:
                 continue
@@ -147,6 +210,7 @@ def _store_embedding_memory_cache(
 ) -> None:
     if EMBED_MEMORY_CACHE_MAX_ENTRIES <= 0 or not embeddings:
         return
+    cache_namespace = str(_resolve_cache_dir())
     with _EMBED_MEMORY_LOCK:
         for text_hash, vector in embeddings.items():
             if not text_hash:
@@ -155,7 +219,7 @@ def _store_embedding_memory_cache(
             if array.size == 0:
                 continue
             # Include dimension in cache key to prevent cross-dimension pollution
-            key = (model, dimension, text_hash)
+            key = (cache_namespace, model, dimension, text_hash)
             if key in _EMBED_MEMORY_CACHE:
                 _EMBED_MEMORY_CACHE.pop(key, None)
             _EMBED_MEMORY_CACHE[key] = array
@@ -354,6 +418,13 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     return row is not None
 
 
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    if not _table_exists(conn, table):
+        return False
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(row[1] == column for row in rows)
+
+
 def _schema_needs_reset(conn: sqlite3.Connection) -> bool:
     if _table_exists(conn, "indexed_chunk"):
         return False
@@ -400,6 +471,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             generated_at TEXT NOT NULL,
             exclude_patterns TEXT DEFAULT '',
             extensions TEXT DEFAULT '',
+            vector_file TEXT NOT NULL DEFAULT '',
             UNIQUE(cache_key, model)
         );
 
@@ -483,6 +555,118 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             ON bm25_posting(chunk_id);
         """
     )
+    if not _column_exists(conn, "index_metadata", "vector_file"):
+        conn.execute(
+            "ALTER TABLE index_metadata ADD COLUMN vector_file TEXT NOT NULL DEFAULT ''"
+        )
+
+
+def _vector_directory(db_path: Path) -> Path:
+    return db_path.parent / VECTOR_DIRNAME
+
+
+def _resolve_vector_file(db_path: Path, stored_path: str) -> Path:
+    relative = Path(stored_path)
+    if not stored_path or relative.is_absolute() or ".." in relative.parts:
+        raise RuntimeError(f"Invalid cached vector path: {stored_path!r}")
+    vector_dir = _vector_directory(db_path).resolve()
+    candidate = (db_path.parent / relative).resolve()
+    try:
+        candidate.relative_to(vector_dir)
+    except ValueError as exc:
+        raise RuntimeError(f"Cached vector path escapes {vector_dir}: {stored_path!r}") from exc
+    if candidate.suffix.lower() != ".npy":
+        raise RuntimeError(f"Cached vector file must use the .npy format: {stored_path!r}")
+    return candidate
+
+
+def _write_vector_file(
+    db_path: Path,
+    vectors: Sequence[Sequence[float] | np.ndarray],
+    dimension: int,
+) -> str:
+    vector_dir = _vector_directory(db_path)
+    vector_dir.mkdir(parents=True, exist_ok=True)
+    token = uuid.uuid4().hex
+    final_path = vector_dir / f"{token}.npy"
+    temporary_path = vector_dir / f".{token}.tmp.npy"
+    try:
+        if len(vectors) > 0:
+            mapped = np.lib.format.open_memmap(
+                temporary_path,
+                mode="w+",
+                dtype=np.float32,
+                shape=(len(vectors), dimension),
+            )
+            for row, vector in enumerate(vectors):
+                array = np.asarray(vector, dtype=np.float32).ravel()
+                if array.size != dimension:
+                    raise ValueError(
+                        f"Embedding dimension mismatch at row {row}: "
+                        f"expected {dimension}, got {array.size}"
+                    )
+                mapped[row] = array
+            mapped.flush()
+            del mapped
+        else:
+            np.save(
+                temporary_path,
+                np.empty((0, dimension), dtype=np.float32),
+                allow_pickle=False,
+            )
+        temporary_path.replace(final_path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        final_path.unlink(missing_ok=True)
+        raise
+    return final_path.relative_to(db_path.parent).as_posix()
+
+
+def _load_vector_file(
+    db_path: Path,
+    stored_path: str,
+    *,
+    rows: int,
+    dimension: int,
+) -> np.ndarray:
+    vector_path = _resolve_vector_file(db_path, stored_path)
+    if not vector_path.is_file():
+        raise FileNotFoundError(vector_path)
+    try:
+        mmap_mode = None if rows == 0 else "r"
+        vectors = np.load(vector_path, mmap_mode=mmap_mode, allow_pickle=False)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"Invalid cached vector file: {vector_path}") from exc
+    expected_shape = (rows, dimension)
+    if vectors.dtype != np.float32 or vectors.shape != expected_shape:
+        raise RuntimeError(
+            f"Cached vector file {vector_path} has dtype {vectors.dtype} and shape "
+            f"{vectors.shape}; expected float32 {expected_shape}"
+        )
+    return vectors
+
+
+def _prune_unreferenced_vector_files(
+    conn: sqlite3.Connection,
+    db_path: Path,
+) -> None:
+    vector_dir = _vector_directory(db_path)
+    if not vector_dir.is_dir() or not _column_exists(conn, "index_metadata", "vector_file"):
+        return
+    referenced = {
+        _resolve_vector_file(db_path, str(row["vector_file"]))
+        for row in conn.execute(
+            "SELECT vector_file FROM index_metadata WHERE vector_file <> ''"
+        ).fetchall()
+    }
+    for candidate in vector_dir.glob("*.npy"):
+        resolved = candidate.resolve()
+        if resolved not in referenced:
+            try:
+                candidate.unlink()
+            except PermissionError:
+                # A live API client may still hold this generation as a read-only mmap.
+                continue
 
 
 def store_index(
@@ -499,6 +683,8 @@ def store_index(
 ) -> Path:
     db_path = cache_file(root, model, include_hidden)
     conn = _connect(db_path)
+    vector_file = ""
+    vector_committed = False
     try:
         _ensure_schema(conn)
         key = _cache_key(
@@ -511,7 +697,16 @@ def store_index(
             exclude_patterns,
         )
         generated_at = datetime.now(timezone.utc).isoformat()
-        dimension = int(len(entries[0].embedding) if entries else 0)
+        dimension = int(
+            np.asarray(entries[0].embedding, dtype=np.float32).size if entries else 0
+        )
+        if entries and dimension <= 0:
+            raise ValueError("Indexed embeddings must contain at least one value")
+        vector_file = _write_vector_file(
+            db_path,
+            [entry.embedding for entry in entries],
+            dimension,
+        )
         include_flag = 1 if include_hidden else 0
         gitignore_flag = 1 if respect_gitignore else 0
         recursive_flag = 1 if recursive else 0
@@ -538,8 +733,9 @@ def store_index(
                     version,
                     generated_at,
                     exclude_patterns,
-                    extensions
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    extensions,
+                    vector_file
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     key,
@@ -554,6 +750,7 @@ def store_index(
                     generated_at,
                     exclude_patterns_value,
                     extensions_value,
+                    vector_file,
                 ),
             )
             index_id = cursor.lastrowid
@@ -605,7 +802,6 @@ def store_index(
                     file_id_map[row["rel_path"]] = int(row["id"])
 
             chunk_rows: list[tuple] = []
-            vector_blobs: list[bytes] = []
             meta_rows: list[tuple] = []
             for position, entry in enumerate(entries):
                 file_id = file_id_map.get(entry.rel_path)
@@ -613,9 +809,6 @@ def store_index(
                     continue
                 chunk_rows.append(
                     (index_id, file_id, entry.chunk_index, position)
-                )
-                vector_blobs.append(
-                    np.asarray(entry.embedding, dtype=np.float32).tobytes()
                 )
                 meta_rows.append(
                     (
@@ -642,13 +835,6 @@ def store_index(
                 "SELECT id FROM indexed_chunk WHERE index_id = ? ORDER BY position ASC",
                 (index_id,),
             ).fetchall()
-            conn.executemany(
-                "INSERT OR REPLACE INTO chunk_embedding (chunk_id, vector_blob) VALUES (?, ?)",
-                (
-                    (row["id"], vector_blobs[idx])
-                    for idx, row in enumerate(inserted_ids)
-                ),
-            )
             bm25_doc_rows: list[tuple[int, int]] = []
             bm25_posting_rows: list[tuple[int, int, str, int]] = []
             for idx, row in enumerate(inserted_ids):
@@ -689,7 +875,13 @@ def store_index(
                 ),
             )
 
+        vector_committed = True
+        _prune_unreferenced_vector_files(conn, db_path)
         return db_path
+    except Exception:
+        if vector_file and not vector_committed:
+            _resolve_vector_file(db_path, vector_file).unlink(missing_ok=True)
+        raise
     finally:
         conn.close()
 
@@ -718,6 +910,8 @@ def apply_index_updates(
         raise FileNotFoundError(db_path)
 
     conn = _connect(db_path)
+    vector_file = ""
+    vector_committed = False
     try:
         _ensure_schema(conn)
         key = _cache_key(
@@ -737,7 +931,7 @@ def apply_index_updates(
             conn.execute("BEGIN IMMEDIATE;")
             meta = conn.execute(
                 """
-                SELECT id, dimension
+                SELECT id, dimension, vector_file
                 FROM index_metadata
                 WHERE cache_key = ? AND model = ? AND include_hidden = ? AND respect_gitignore = ? AND recursive = ? AND mode = ?
                 """,
@@ -747,6 +941,66 @@ def apply_index_updates(
                 raise FileNotFoundError(db_path)
             index_id = meta["id"]
             existing_dimension = int(meta["dimension"])
+            existing_rows = conn.execute(
+                """
+                SELECT f.rel_path, c.chunk_index
+                FROM indexed_chunk AS c
+                JOIN indexed_file AS f ON f.id = c.file_id
+                WHERE c.index_id = ?
+                ORDER BY c.position ASC
+                """,
+                (index_id,),
+            ).fetchall()
+            existing_vectors = _load_vector_file(
+                db_path,
+                str(meta["vector_file"]),
+                rows=len(existing_rows),
+                dimension=existing_dimension,
+            )
+            existing_positions = {
+                (row["rel_path"], int(row["chunk_index"])): position
+                for position, row in enumerate(existing_rows)
+            }
+            changed_vectors: dict[tuple[str, int], np.ndarray] = {}
+            vector_dimension = existing_dimension
+            for entry in changed_entries:
+                vector = np.asarray(entry.embedding, dtype=np.float32).ravel()
+                if vector_dimension == 0:
+                    vector_dimension = int(vector.size)
+                if vector.size != vector_dimension:
+                    raise ValueError(
+                        f"Embedding dimension mismatch for {entry.rel_path}: "
+                        f"expected {vector_dimension}, got {vector.size}"
+                    )
+                changed_vectors[(entry.rel_path, entry.chunk_index)] = vector
+
+            if existing_dimension and vector_dimension != existing_dimension:
+                raise ValueError(
+                    f"Embedding dimension mismatch: existing index has "
+                    f"{existing_dimension}, got {vector_dimension}"
+                )
+            if ordered_entries or removed_rel_paths or changed_entries:
+                final_keys = list(ordered_entries)
+            else:
+                final_keys = list(existing_positions)
+            final_vectors: list[np.ndarray] = []
+            for entry_key in final_keys:
+                vector = changed_vectors.get(entry_key)
+                if vector is None:
+                    position = existing_positions.get(entry_key)
+                    if position is None:
+                        raise RuntimeError(
+                            f"Missing cached vector for {entry_key[0]} chunk {entry_key[1]}"
+                        )
+                    vector = existing_vectors[position]
+                final_vectors.append(vector)
+            vector_file = _write_vector_file(
+                db_path,
+                final_vectors,
+                vector_dimension,
+            )
+            del final_vectors
+            del existing_vectors
 
             if removed_rel_paths:
                 conn.executemany(
@@ -754,7 +1008,6 @@ def apply_index_updates(
                     ((index_id, rel) for rel in removed_rel_paths),
                 )
 
-            vector_dimension = None
             if changed_entries:
                 chunk_map: dict[str, list[IndexedChunk]] = {}
                 for entry in changed_entries:
@@ -819,16 +1072,11 @@ def apply_index_updates(
                         continue
                     chunk_list.sort(key=lambda item: item.chunk_index)
                     chunk_rows: list[tuple] = []
-                    vector_blobs: list[bytes] = []
                     meta_rows: list[tuple] = []
                     for chunk in chunk_list:
-                        vector = np.asarray(chunk.embedding, dtype=np.float32)
-                        if vector_dimension is None:
-                            vector_dimension = vector.shape[0]
                         chunk_rows.append(
                             (index_id, file_id, chunk.chunk_index, 0)
                         )
-                        vector_blobs.append(vector.tobytes())
                         meta_rows.append(
                             (
                                 chunk.preview or "",
@@ -858,13 +1106,6 @@ def apply_index_updates(
                         """,
                         (index_id, file_id),
                     ).fetchall()
-                    conn.executemany(
-                        "INSERT OR REPLACE INTO chunk_embedding (chunk_id, vector_blob) VALUES (?, ?)",
-                        (
-                            (row["id"], vector_blobs[idx])
-                            for idx, row in enumerate(inserted_ids)
-                        ),
-                    )
                     bm25_doc_rows: list[tuple[int, int]] = []
                     bm25_posting_rows: list[tuple[int, int, str, int]] = []
                     for idx, row in enumerate(inserted_ids):
@@ -1000,17 +1241,28 @@ def apply_index_updates(
                     )
 
             generated_at = datetime.now(timezone.utc).isoformat()
-            new_dimension = vector_dimension or existing_dimension
             conn.execute(
                 """
                 UPDATE index_metadata
-                SET generated_at = ?, dimension = ?, version = ?
+                SET generated_at = ?, dimension = ?, version = ?, vector_file = ?
                 WHERE id = ?
                 """,
-                (generated_at, new_dimension, CACHE_VERSION, index_id),
+                (
+                    generated_at,
+                    vector_dimension,
+                    CACHE_VERSION,
+                    vector_file,
+                    index_id,
+                ),
             )
 
+        vector_committed = True
+        _prune_unreferenced_vector_files(conn, db_path)
         return db_path
+    except Exception:
+        if vector_file and not vector_committed:
+            _resolve_vector_file(db_path, vector_file).unlink(missing_ok=True)
+        raise
     finally:
         conn.close()
 
@@ -1249,6 +1501,7 @@ def load_index_vectors(
     extensions: Sequence[str] | None = None,
     *,
     respect_gitignore: bool = True,
+    memory_cache: IndexVectorCache | None = None,
 ):
     db_path = cache_file(root, model, include_hidden)
     if not db_path.exists():
@@ -1263,9 +1516,10 @@ def load_index_vectors(
                     "index_metadata",
                     "indexed_file",
                     "indexed_chunk",
-                    "chunk_embedding",
                 ),
             )
+            if not _column_exists(conn, "index_metadata", "vector_file"):
+                raise sqlite3.OperationalError("Missing column: index_metadata.vector_file")
         except sqlite3.OperationalError:
             raise FileNotFoundError(db_path)
         key = _cache_key(
@@ -1282,7 +1536,8 @@ def load_index_vectors(
         recursive_flag = 1 if recursive else 0
         meta = conn.execute(
             """
-            SELECT id, root_path, model, include_hidden, respect_gitignore, recursive, mode, dimension, version, generated_at, exclude_patterns, extensions
+            SELECT id, root_path, model, include_hidden, respect_gitignore, recursive, mode,
+                   dimension, version, generated_at, exclude_patterns, extensions, vector_file
             FROM index_metadata
             WHERE cache_key = ? AND model = ? AND include_hidden = ? AND respect_gitignore = ? AND recursive = ? AND mode = ?
             """,
@@ -1296,6 +1551,17 @@ def load_index_vectors(
 
         index_id = meta["id"]
         dimension = int(meta["dimension"])
+        memory_key = (
+            str(db_path.resolve()),
+            model,
+            key,
+            str(meta["generated_at"]),
+            str(meta["vector_file"]),
+        )
+        if memory_cache is not None:
+            cached = memory_cache.get(memory_key)
+            if cached is not None:
+                return cached.paths, cached.vectors, cached.metadata
         chunk_count = conn.execute(
             "SELECT COUNT(*) AS count FROM indexed_chunk WHERE index_id = ?",
             (index_id,),
@@ -1303,6 +1569,9 @@ def load_index_vectors(
         chunk_total = int(chunk_count or 0)
 
         if chunk_total == 0 or dimension == 0:
+            vector_path = _resolve_vector_file(db_path, str(meta["vector_file"]))
+            if not vector_path.is_file():
+                raise FileNotFoundError(vector_path)
             empty = np.empty((0, dimension), dtype=np.float32)
             metadata = {
                 "index_id": int(index_id),
@@ -1320,10 +1589,22 @@ def load_index_vectors(
                 "files": [],
                 "chunks": [],
                 "chunk_ids": [],
+                "vector_file": meta["vector_file"],
             }
+            if memory_cache is not None:
+                memory_cache.store(
+                    memory_key,
+                    _LoadedIndexVectors((), empty, metadata),
+                )
+                _prune_unreferenced_vector_files(conn, db_path)
             return [], empty, metadata
 
-        embeddings = np.empty((chunk_total, dimension), dtype=np.float32)
+        embeddings = _load_vector_file(
+            db_path,
+            str(meta["vector_file"]),
+            rows=chunk_total,
+            dimension=dimension,
+        )
         paths: list[Path] = []
         chunk_ids: list[int] = []
         file_snapshot: list[dict] = []
@@ -1348,25 +1629,18 @@ def load_index_vectors(
 
         cursor = conn.execute(
             """
-            SELECT c.id AS chunk_id, f.rel_path, e.vector_blob
+            SELECT c.id AS chunk_id, f.rel_path
             FROM indexed_chunk AS c
             JOIN indexed_file AS f ON f.id = c.file_id
-            JOIN chunk_embedding AS e ON e.chunk_id = c.id
             WHERE c.index_id = ?
             ORDER BY c.position ASC
             """,
             (index_id,),
         )
 
-        for idx, row in enumerate(cursor):
+        for row in cursor:
             rel_path = row["rel_path"]
             chunk_id = int(row["chunk_id"])
-            vector = np.frombuffer(row["vector_blob"], dtype=np.float32)
-            if vector.size != dimension:
-                raise RuntimeError(
-                    f"Cached embedding dimension {vector.size} does not match index metadata {dimension}"
-                )
-            embeddings[idx] = vector
             paths.append(root / Path(rel_path))
             chunk_ids.append(chunk_id)
             if rel_path not in seen_files:
@@ -1391,7 +1665,13 @@ def load_index_vectors(
             "files": file_snapshot,
             "chunks": [],
             "chunk_ids": chunk_ids,
+            "vector_file": meta["vector_file"],
         }
+        if memory_cache is not None:
+            loaded = _LoadedIndexVectors(tuple(paths), embeddings, metadata)
+            memory_cache.store(memory_key, loaded)
+            _prune_unreferenced_vector_files(conn, db_path)
+            return loaded.paths, loaded.vectors, loaded.metadata
         return paths, embeddings, metadata
     finally:
         conn.close()
@@ -1805,6 +2085,7 @@ def clear_index(
             params = (key, model, mode)
         with conn:
             cursor = conn.execute(query, params)
+        _prune_unreferenced_vector_files(conn, db_path)
         return cursor.rowcount
     finally:
         conn.close()
@@ -1896,6 +2177,12 @@ def clear_all_cache() -> int:
         sidecar = Path(f"{db_path}{suffix}")
         if sidecar.exists():
             sidecar.unlink()
+    vector_dir = _vector_directory(db_path)
+    if vector_dir.is_dir():
+        for vector_file in vector_dir.iterdir():
+            if vector_file.is_file():
+                vector_file.unlink()
+        vector_dir.rmdir()
 
     return total
 

--- a/vexor/services/freshness_service.py
+++ b/vexor/services/freshness_service.py
@@ -1,0 +1,103 @@
+"""Process-local filesystem freshness tracking for repeated searches."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from typing import Callable, Hashable
+
+
+_MUTATION_EVENTS = {"created", "deleted", "modified", "moved"}
+
+
+def _is_cache_event(root: Path, raw_path: str | bytes | None) -> bool:
+    if not raw_path:
+        return False
+    try:
+        relative = Path(raw_path).resolve().relative_to(root)
+    except (OSError, ValueError):
+        return False
+    return bool(relative.parts) and relative.parts[0] == ".vexor"
+
+
+def _build_event_handler(root: Path, callback: Callable[[], None]):
+    from watchdog.events import FileSystemEventHandler
+
+    class MutationHandler(FileSystemEventHandler):
+        def on_any_event(self, event) -> None:
+            if event.event_type not in _MUTATION_EVENTS:
+                return
+            paths = (getattr(event, "src_path", None), getattr(event, "dest_path", None))
+            if all(_is_cache_event(root, path) for path in paths if path):
+                return
+            callback()
+
+    return MutationHandler()
+
+
+class FreshnessTracker:
+    """Track whether a validated filesystem snapshot has received mutations."""
+
+    def __init__(self, observer_factory=None) -> None:
+        if observer_factory is None:
+            from watchdog.observers import Observer
+
+            observer_factory = Observer
+        self._observer = observer_factory()
+        self._lock = Lock()
+        self._versions: dict[Path, int] = {}
+        self._validated: dict[tuple[Path, Hashable], int] = {}
+        self._started = False
+        self._closed = False
+
+    def _mark_dirty(self, root: Path) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._versions[root] = self._versions.get(root, 0) + 1
+
+    def _ensure_root(self, root: Path) -> Path:
+        resolved = root.resolve()
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Freshness tracker is closed")
+            if resolved in self._versions:
+                return resolved
+            handler = _build_event_handler(
+                resolved,
+                lambda: self._mark_dirty(resolved),
+            )
+            self._observer.schedule(handler, str(resolved), recursive=True)
+            self._versions[resolved] = 0
+            if not self._started:
+                self._observer.start()
+                self._started = True
+        return resolved
+
+    def begin_validation(self, root: Path) -> int:
+        resolved = self._ensure_root(root)
+        with self._lock:
+            return self._versions[resolved]
+
+    def is_fresh(self, root: Path, key: Hashable) -> bool:
+        resolved = self._ensure_root(root)
+        with self._lock:
+            return self._validated.get((resolved, key)) == self._versions[resolved]
+
+    def finish_validation(self, root: Path, key: Hashable, token: int) -> bool:
+        resolved = self._ensure_root(root)
+        with self._lock:
+            if self._versions[resolved] != token:
+                return False
+            self._validated[(resolved, key)] = token
+            return True
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            started = self._started
+        if started:
+            self._observer.stop()
+            self._observer.join()

--- a/vexor/services/freshness_service.py
+++ b/vexor/services/freshness_service.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
-from threading import Lock
+from threading import Event, Lock
+from time import monotonic
 from typing import Callable, Hashable
 
 
 _MUTATION_EVENTS = {"created", "deleted", "modified", "moved"}
+DEFAULT_MAX_REUSES = 32
+DEFAULT_MAX_AGE_SECONDS = 5.0
+DEFAULT_MAX_VALIDATIONS = 128
+
+
+@dataclass(slots=True)
+class _ValidationState:
+    version: int
+    validated_at: float
+    reuse_count: int = 0
 
 
 def _is_cache_event(root: Path, raw_path: str | bytes | None) -> bool:
@@ -35,61 +48,203 @@ def _build_event_handler(root: Path, callback: Callable[[], None]):
     return MutationHandler()
 
 
+def _is_missing_watchdog(exc: ModuleNotFoundError) -> bool:
+    return bool(
+        exc.name
+        and (exc.name == "watchdog" or exc.name.startswith("watchdog."))
+    )
+
+
+class _WatchingUnavailable(Exception):
+    """Signal that this tracker cannot start a filesystem observer."""
+
+
 class FreshnessTracker:
-    """Track whether a validated filesystem snapshot has received mutations."""
+    """Use filesystem events as a bounded hint between full snapshot scans."""
 
-    def __init__(self, observer_factory=None) -> None:
-        if observer_factory is None:
-            from watchdog.observers import Observer
-
-            observer_factory = Observer
-        self._observer = observer_factory()
+    def __init__(
+        self,
+        observer_factory=None,
+        *,
+        max_reuses: int = DEFAULT_MAX_REUSES,
+        max_age_seconds: float = DEFAULT_MAX_AGE_SECONDS,
+        max_validations: int = DEFAULT_MAX_VALIDATIONS,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        if max_reuses < 0:
+            raise ValueError("max_reuses must be non-negative")
+        if max_age_seconds <= 0:
+            raise ValueError("max_age_seconds must be positive")
+        if max_validations <= 0:
+            raise ValueError("max_validations must be positive")
+        self._observer_factory = observer_factory
+        self._observer = None
+        self._observer_lock = Lock()
         self._lock = Lock()
         self._versions: dict[Path, int] = {}
-        self._validated: dict[tuple[Path, Hashable], int] = {}
+        self._validated: OrderedDict[
+            tuple[Path, Hashable], _ValidationState
+        ] = OrderedDict()
+        self._pending_roots: set[Path] = set()
+        self._disabled_roots: set[Path] = set()
         self._started = False
         self._closed = False
+        self._closed_event = Event()
+        self._watching_unavailable = Event()
+        self._max_reuses = max_reuses
+        self._max_age_seconds = max_age_seconds
+        self._max_validations = max_validations
+        self._clock = clock
 
     def _mark_dirty(self, root: Path) -> None:
         with self._lock:
             if self._closed:
                 return
             self._versions[root] = self._versions.get(root, 0) + 1
+            stale_keys = [key for key in self._validated if key[0] == root]
+            for key in stale_keys:
+                del self._validated[key]
 
-    def _ensure_root(self, root: Path) -> Path:
+    def _disable_root(self, root: Path, *, watching_unavailable: bool = False) -> None:
+        with self._lock:
+            self._pending_roots.discard(root)
+            self._disabled_roots.add(root)
+            if watching_unavailable:
+                self._watching_unavailable.set()
+
+    def _new_observer(self):
+        if self._observer_factory is None:
+            try:
+                from watchdog.observers import Observer
+            except ModuleNotFoundError as exc:
+                if _is_missing_watchdog(exc):
+                    self._watching_unavailable.set()
+                raise
+
+            return Observer()
+        return self._observer_factory()
+
+    def _ensure_root(self, root: Path) -> Path | None:
         resolved = root.resolve()
         with self._lock:
             if self._closed:
                 raise RuntimeError("Freshness tracker is closed")
+            if (
+                self._watching_unavailable.is_set()
+                or resolved in self._disabled_roots
+            ):
+                return None
             if resolved in self._versions:
                 return resolved
+            if resolved in self._pending_roots:
+                return None
+            self._pending_roots.add(resolved)
+
+        try:
             handler = _build_event_handler(
                 resolved,
                 lambda: self._mark_dirty(resolved),
             )
-            self._observer.schedule(handler, str(resolved), recursive=True)
-            self._versions[resolved] = 0
-            if not self._started:
-                self._observer.start()
-                self._started = True
+        except ModuleNotFoundError as exc:
+            if not _is_missing_watchdog(exc):
+                with self._lock:
+                    self._pending_roots.discard(resolved)
+                raise
+            self._disable_root(resolved, watching_unavailable=True)
+            return None
+
+        watch = None
+        start_failed = False
+        try:
+            # Never acquire the tracker lock while calling into watchdog. Its
+            # dispatcher invokes handlers while holding watchdog's own lock.
+            with self._observer_lock:
+                if self._closed_event.is_set():
+                    raise RuntimeError("Freshness tracker is closed")
+                if self._watching_unavailable.is_set():
+                    raise _WatchingUnavailable
+                if self._observer is None:
+                    self._observer = self._new_observer()
+                watch = self._observer.schedule(handler, str(resolved), recursive=True)
+                if not self._started:
+                    try:
+                        self._observer.start()
+                    except OSError:
+                        start_failed = True
+                        self._watching_unavailable.set()
+                        unschedule = getattr(self._observer, "unschedule", None)
+                        if watch is not None and callable(unschedule):
+                            try:
+                                unschedule(watch)
+                            except OSError:
+                                pass
+                        raise
+                    self._started = True
+        except _WatchingUnavailable:
+            self._disable_root(resolved, watching_unavailable=True)
+            return None
+        except ModuleNotFoundError as exc:
+            if not _is_missing_watchdog(exc):
+                with self._lock:
+                    self._pending_roots.discard(resolved)
+                raise
+            self._disable_root(resolved, watching_unavailable=True)
+            return None
+        except OSError:
+            self._disable_root(resolved, watching_unavailable=start_failed)
+            return None
+        except Exception:
+            with self._lock:
+                self._pending_roots.discard(resolved)
+            raise
+
+        with self._lock:
+            self._pending_roots.discard(resolved)
+            if self._closed:
+                raise RuntimeError("Freshness tracker is closed")
+            self._versions.setdefault(resolved, 0)
         return resolved
 
-    def begin_validation(self, root: Path) -> int:
+    def begin_validation(self, root: Path) -> int | None:
         resolved = self._ensure_root(root)
+        if resolved is None:
+            return None
         with self._lock:
             return self._versions[resolved]
 
     def is_fresh(self, root: Path, key: Hashable) -> bool:
         resolved = self._ensure_root(root)
+        if resolved is None:
+            return False
+        validation_key = (resolved, key)
         with self._lock:
-            return self._validated.get((resolved, key)) == self._versions[resolved]
+            state = self._validated.get(validation_key)
+            if state is None or state.version != self._versions[resolved]:
+                return False
+            expired = self._clock() - state.validated_at >= self._max_age_seconds
+            exhausted = state.reuse_count >= self._max_reuses
+            if expired or exhausted:
+                del self._validated[validation_key]
+                return False
+            state.reuse_count += 1
+            self._validated.move_to_end(validation_key)
+            return True
 
     def finish_validation(self, root: Path, key: Hashable, token: int) -> bool:
         resolved = self._ensure_root(root)
+        if resolved is None:
+            return False
         with self._lock:
             if self._versions[resolved] != token:
                 return False
-            self._validated[(resolved, key)] = token
+            validation_key = (resolved, key)
+            self._validated[validation_key] = _ValidationState(
+                version=token,
+                validated_at=self._clock(),
+            )
+            self._validated.move_to_end(validation_key)
+            while len(self._validated) > self._max_validations:
+                self._validated.popitem(last=False)
             return True
 
     def close(self) -> None:
@@ -97,7 +252,8 @@ class FreshnessTracker:
             if self._closed:
                 return
             self._closed = True
-            started = self._started
-        if started:
-            self._observer.stop()
-            self._observer.join()
+            self._closed_event.set()
+        with self._observer_lock:
+            if self._started:
+                self._observer.stop()
+                self._observer.join()

--- a/vexor/services/index_service.py
+++ b/vexor/services/index_service.py
@@ -206,7 +206,6 @@ def build_index(
             cached_files = []
             force_no_cache = True
     if cached_files:
-        cached_version = int(existing_meta.get("version", 0) or 0) if existing_meta else 0
         full_max_bytes = (
             getattr(strategy, "full_max_bytes", 10_000) if mode == "auto" else None
         )
@@ -233,23 +232,6 @@ def build_index(
                     mode=mode,
                     recursive=recursive,
                     updates=updates,
-                    exclude_patterns=exclude_patterns,
-                    extensions=extensions,
-                )
-                return IndexResult(
-                    status=IndexStatus.STORED,
-                    cache_path=cache_path,
-                    files_indexed=len(files),
-                )
-            if cached_version < CACHE_VERSION:
-                cache_path = backfill_chunk_lines(
-                    root=directory,
-                    model=model_name,
-                    include_hidden=include_hidden,
-                    respect_gitignore=respect_gitignore,
-                    mode=mode,
-                    recursive=recursive,
-                    updates=[],
                     exclude_patterns=exclude_patterns,
                     extensions=extensions,
                 )

--- a/vexor/services/mcp_service.py
+++ b/vexor/services/mcp_service.py
@@ -364,6 +364,14 @@ class VexorMcpServer:
             self._client = VexorClient()
         return self._client
 
+    def close(self) -> None:
+        """Release resources owned by the session client."""
+
+        close = getattr(self._client, "close", None)
+        if callable(close):
+            close()
+        self._client = None
+
     # -- JSON-RPC plumbing -------------------------------------------------
 
     def handle_message(self, message: Any) -> dict[str, Any] | None:
@@ -708,4 +716,7 @@ def serve_stdio(default_path: Path | str | None = None) -> None:
         flush=True,
     )
     _start_update_notice_thread()
-    serve(server, stdin, stdout)
+    try:
+        serve(server, stdin, stdout)
+    finally:
+        server.close()

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -874,11 +874,15 @@ def _load_filtered_index(
                 extensions=request.extensions,
             )
             stable = True
-            if current and freshness_tracker is not None:
+            if (
+                current
+                and freshness_tracker is not None
+                and validation_token is not None
+            ):
                 stable = freshness_tracker.finish_validation(
                     request.directory,
                     freshness_key,
-                    int(validation_token),
+                    validation_token,
                 )
             stale = not current or not stable
     return _IndexState(

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 import json
@@ -27,7 +27,9 @@ from ..utils import build_exclude_spec, is_excluded_path, normalize_exclude_patt
 from .cache_service import is_cache_current
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..cache import IndexVectorCache
     from ..search import SearchResult
+    from .freshness_service import FreshnessTracker
 
 # Chunk text is returned to callers verbatim, so it has to be capped or a single
 # search could bury an agent's context window. Counted in characters rather than
@@ -84,6 +86,16 @@ class SearchRequest:
     include_content: bool = False
     content_chars_per_result: int = DEFAULT_CONTENT_CHARS_PER_RESULT
     content_chars_total: int = DEFAULT_CONTENT_CHARS_TOTAL
+    index_vector_cache: IndexVectorCache | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    freshness_tracker: FreshnessTracker | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
 
 @dataclass(slots=True)
@@ -572,6 +584,7 @@ def _resolve_query_vector(
     query_vector = None
     query_hash = None
     query_text_hash = None
+    query_cache_hit = False
     if index_id is not None and not request.no_cache:
         query_hash = query_cache_key(request.query, request.model_name)
         try:
@@ -580,6 +593,8 @@ def _resolve_query_vector(
             query_vector = None
         if query_vector is not None and query_vector.size != expected_dim:
             query_vector = None
+        elif query_vector is not None:
+            query_cache_hit = True
 
     if query_vector is None and not request.no_cache:
         query_text_hash = embedding_cache_key(
@@ -609,6 +624,7 @@ def _resolve_query_vector(
                 pass
     if (
         not request.no_cache
+        and not query_cache_hit
         and query_vector is not None
         and index_id is not None
         and query_hash is not None
@@ -777,6 +793,20 @@ class _IndexState:
     index_extensions: tuple
 
 
+def _freshness_key(request: SearchRequest, metadata: dict) -> tuple[object, ...]:
+    return (
+        str(request.directory.resolve()),
+        request.include_hidden,
+        request.respect_gitignore,
+        request.recursive,
+        request.exclude_patterns,
+        request.extensions,
+        metadata.get("index_id"),
+        metadata.get("generated_at"),
+        metadata.get("vector_file"),
+    )
+
+
 def _load_filtered_index(
     request: SearchRequest,
     exclude_spec,
@@ -824,15 +854,33 @@ def _load_filtered_index(
             exclude_spec,
         )
     file_snapshot = metadata.get("files", [])
-    stale = bool(file_snapshot) and not is_cache_current(
-        request.directory,
-        request.include_hidden,
-        request.respect_gitignore,
-        file_snapshot,
-        recursive=request.recursive,
-        exclude_patterns=request.exclude_patterns,
-        extensions=request.extensions,
-    )
+    stale = False
+    if file_snapshot:
+        freshness_tracker = request.freshness_tracker
+        freshness_key = _freshness_key(request, metadata)
+        validation_token = None
+        if freshness_tracker is not None:
+            validation_token = freshness_tracker.begin_validation(request.directory)
+            if freshness_tracker.is_fresh(request.directory, freshness_key):
+                file_snapshot = []
+        if file_snapshot:
+            current = is_cache_current(
+                request.directory,
+                request.include_hidden,
+                request.respect_gitignore,
+                file_snapshot,
+                recursive=request.recursive,
+                exclude_patterns=request.exclude_patterns,
+                extensions=request.extensions,
+            )
+            stable = True
+            if current and freshness_tracker is not None:
+                stable = freshness_tracker.finish_validation(
+                    request.directory,
+                    freshness_key,
+                    int(validation_token),
+                )
+            stale = not current or not stable
     return _IndexState(
         paths=paths,
         file_vectors=file_vectors,
@@ -915,6 +963,8 @@ def perform_search(request: SearchRequest) -> SearchResponse:
         state = load_state()
 
     if state.stale and request.auto_index:
+        if request.index_vector_cache is not None:
+            request.index_vector_cache.clear()
         result = _build_index_for_request(
             request,
             build_index,
@@ -924,8 +974,13 @@ def perform_search(request: SearchRequest) -> SearchResponse:
             extensions=state.index_extensions,
         )
         if result.status == IndexStatus.EMPTY:
+            del state
+            if request.index_vector_cache is not None:
+                request.index_vector_cache.prune()
             return _empty_response(request.directory, is_stale=False)
         state = load_state()
+        if request.index_vector_cache is not None:
+            request.index_vector_cache.prune()
 
     if not len(state.paths):
         return _empty_response(request.directory, is_stale=state.stale)
@@ -1047,16 +1102,32 @@ def _load_index_vectors_for_request(
     bool,
     tuple[str, ...],
 ]:
-    try:
-        paths, file_vectors, metadata = load_index_vectors(
-            request.directory,
+    def load_vectors(
+        root: Path,
+        recursive: bool,
+        exclude_patterns: Sequence[str],
+        extensions: Sequence[str],
+    ):
+        kwargs = {"respect_gitignore": request.respect_gitignore}
+        if request.index_vector_cache is not None:
+            kwargs["memory_cache"] = request.index_vector_cache
+        return load_index_vectors(
+            root,
             request.model_name,
             request.include_hidden,
             request.mode,
+            recursive,
+            exclude_patterns,
+            extensions,
+            **kwargs,
+        )
+
+    try:
+        paths, file_vectors, metadata = load_vectors(
+            request.directory,
             request.recursive,
             request.exclude_patterns,
             request.extensions,
-            respect_gitignore=request.respect_gitignore,
         )
         # Check dimension compatibility when user explicitly requests a specific dimension
         cached_dimension = metadata.get("dimension")
@@ -1089,15 +1160,11 @@ def _load_index_vectors_for_request(
     superset_recursive = bool(superset_entry.get("recursive"))
     superset_extensions = tuple(superset_entry.get("extensions") or ())
     superset_excludes = tuple(superset_entry.get("exclude_patterns") or ())
-    paths, file_vectors, metadata = load_index_vectors(
+    paths, file_vectors, metadata = load_vectors(
         superset_root,
-        request.model_name,
-        request.include_hidden,
-        request.mode,
         superset_recursive,
         superset_excludes,
         superset_extensions,
-        respect_gitignore=request.respect_gitignore,
     )
     ext_filter = None
     if request.extensions and request.extensions != superset_extensions:


### PR DESCRIPTION
## Summary

- move dense index vectors from SQLite BLOB rows into generation-specific NumPy sidecars loaded through read-only mmap
- reuse immutable loaded index generations in long-lived `VexorClient` and MCP sessions
- use filesystem events as bounded freshness hints between periodic full snapshot scans
- avoid rewriting query-cache hits and isolate the process-local embedding cache by cache directory
- add an offline performance harness, packaging support, regression coverage, and responsibility-scoped documentation

## Motivation

Cached searches reconstructed the complete dense matrix from SQLite BLOBs and performed an O(N) filesystem freshness scan for every query. On larger indexes, those two operations dominated local retrieval overhead even when neither the index nor the source tree had changed.

## Compatibility and impact

- Rebases on #45 and preserves its chunk-content result contract.
- `CACHE_VERSION` advances to 8; older file indexes rebuild automatically while reusable embedding cache entries remain available.
- CLI, Python API, MCP schemas, and machine-readable output contracts are unchanged relative to the new base.
- `watchdog>=6.0.0` is installed by default so long-lived Python and MCP sessions receive the event-backed fast path without an extra installation step.
- Watchdog remains lazily imported. Missing watcher support and watcher setup failures fall back to full snapshot validation instead of failing search.
- Watcher trust is bounded by both age and reuse count, so periodic scans recover from missed filesystem events.

Representative local benchmark, using 30,000 vectors at 384 dimensions and 10,000 files:

- first mmap load: 137.33 ms
- process-cached load: 6.66 ms median
- full snapshot validation: 569.45 ms median
- event-backed freshness check after validation: 0.09 ms median

## Validation

- `.venv\Scripts\python.exe -m pytest --cov=vexor --cov-report=term-missing` — 643 passed, 91% total coverage on the rebased #45 + #46 tree
- deterministic lock-order regression — dispatcher callback and second-root `schedule()` both complete without deadlock
- watcher degradation regressions — missing watchdog and `schedule()` `OSError` both preserve full snapshot scanning
- v7-to-v8 regression — full index rebuild reuses the embedding cache without a provider embedding call
- `.venv\Scripts\python.exe -m build --no-isolation` — sdist and wheel built; wheel metadata requires watchdog by default
- `.venv\Scripts\python.exe -m PyInstaller vexor.spec --noconfirm` and `dist\vexor.exe --help` — standalone executable built and started
- configured-provider `VexorClient` E2E — repeated search reused the freshness hint; mutation forced revalidation; #45 chunk content remained present before and after refresh
- `git diff --check` and `.venv\Scripts\python.exe -m pip check` — passed