### PR TITLE
chore(release): bump version to 0.27.0

### DIFF
--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/scarletkc/vexor",
     "source": "github"
   },
-  "version": "0.26.0",
+  "version": "0.27.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vexor",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 _API_EXPORTS = frozenset(
     {


### PR DESCRIPTION
Releases 0.27.0. Merging this triggers the automated tag, build, PyPI publish, and GitHub release.

Bumps `vexor/__init__.py`, `plugins/vexor/.claude-plugin/plugin.json`, and `server.json` via `scripts/bump_version.py`.

---

# What's in v0.27.0

Search results now carry the matching source text, so an agent can act on a hit without reading the file again. Repeated searches from a long-lived client reuse memory-mapped index state instead of rescanning the directory.

## Search results include chunk content

`vexor_search` (MCP), the Python API, and `vexor search --content` / `--format json` return the source text for each match, read from the file at search time using the indexed line range. Indentation and line breaks are preserved.

**MCP clients receive content by default.** `include_content` defaults to `true` for `vexor_search`, because the consumer there is an agent and the content is what it needs. Output is bounded: 2000 characters per result, 8000 per response, spent on the highest-ranked matches first. Tune with `content_budget` (500–40000) or turn it off with `include_content: false`. Responses carry a `content_budget` object reporting the limit and how much was used.

The Python API defaults to `include_content=False`; pass it explicitly, along with `content_chars_per_result` / `content_chars_total` if the defaults do not suit.

When content cannot be returned, the result carries `content_unavailable` instead and the preview is still present:

| Reason | Meaning |
|---|---|
| `no_line_range` | Mode records no line range (`name`, `head`, `brief`), or the format has no stable lines (PDF, docx, pptx) |
| `stale_line_range` | The file changed since indexing; re-run `vexor index` |
| `budget_exhausted` | The response budget went to higher-ranked results |
| `unreadable` | File deleted, unreadable, or failed to decode |

Truncated content sets `content_truncated` and reports the last line actually returned in `content_end_line`. Check it before assuming a chunk is complete.

`--format porcelain` and `--format porcelain-z` are unchanged — same columns, same order, no content. Use `--format json` when you need the text.

## Faster repeated searches

A `VexorClient` reuses loaded index state and watches searched directories, skipping the repeated directory scan between periodic full snapshot validations. Vector data moved from SQLite blobs to memory-mapped `.npy` files.

The watcher is a bounded hint, not a source of truth: it expires after 32 reuses or 5 seconds, and any failure path — watchdog missing, watch registration failing, inotify limits — falls back to the full scan rather than failing the search. Source mutations invalidate the hint; writes to the generated `.vexor/` cache do not.

Module-level `search(...)` calls do not retain a watcher between calls and keep the previous full-validation behavior.

Adds `watchdog>=6.0.0` as a dependency.

## Index rebuild on first use

`CACHE_VERSION` moves from 7 to 8. Every existing index is rebuilt the first time it is searched or indexed after upgrading.

**This does not call your embedding provider.** The rebuild reuses the existing `embedding_cache`, so it costs local CPU and I/O only. Measured by counting provider calls across the upgrade on a 12-file / 24-chunk corpus indexed under 0.26.0: 1 embedding request to build it, then **0 requests and 0 texts** through the 7 → 8 rebuild, with all 24 `embedding_cache` rows intact. You will only be charged again if the embedding cache was cleared (for example via `vexor config --clear-index-all`) or the embedding model or dimensions changed.

## Fixes

- `full`-mode chunks reported line ranges shifted up by the number of leading blank lines in the file: a file whose content started on line 5 was indexed as starting on line 1. Only `full` was affected — `code` (AST) and `outline` (raw line scan) were already correct — but `auto` routes every non-py/js/md small file through `full`, so the reach was wider than the mode name suggests. Existing indexes pick up corrected line numbers when they rebuild for the 7 → 8 upgrade.
- Reading a chunk's text back no longer pulls up to 200,000 characters into memory to slice out a few lines; it stops once it has read the requested range.

---

## Contents since v0.26.0

- `fix(index)`: correct full-mode chunk line numbers (#44)
- `feat(search)`: return chunk content in search results (#45)
- `perf(search)`: reuse memory-mapped index state (#46)

## Verification

`python -m pytest`: 643 passed. `python -m vexor --version` reports `Vexor v0.27.0`.
