### PR TITLE
fix(ci): unblock PyPI publish and allow release retries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_release:
+        description: >-
+          Publish the version currently on main even though it did not change in
+          the last commit. Use to retry a release whose publish step failed.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -101,7 +109,9 @@ jobs:
   prepare_release:
     name: Prepare release metadata
     needs: pytest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_release)
     runs-on: ubuntu-latest
     outputs:
       release_changed: ${{ steps.versions.outputs.release_changed }}
@@ -117,6 +127,8 @@ jobs:
       - name: Detect version changes
         id: versions
         shell: bash
+        env:
+          FORCE_RELEASE: ${{ inputs.force_release }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -143,13 +155,18 @@ jobs:
           current_init = pathlib.Path("vexor/__init__.py").read_text(encoding="utf-8")
           current_version = read_version_from_text(current_init)
 
+          # A manual run with force_release republishes whatever is on main, so a
+          # release whose publish step failed can be retried without burning a
+          # version number on a no-op bump.
+          forced = os.environ.get("FORCE_RELEASE", "").lower() == "true"
+
           prev_init = read_file_from_ref("HEAD^", "vexor/__init__.py")
           if prev_init is None:
               release_changed = True
               prev_version = ""
           else:
               prev_version = read_version_from_text(prev_init)
-              release_changed = current_version != prev_version
+              release_changed = forced or current_version != prev_version
 
           current_tag = f"v{current_version}"
           prev_tag = ""
@@ -408,5 +425,7 @@ jobs:
         run: |
           python -m build
 
+      # v1.13.0 bundles a twine that rejects Metadata-Version 2.5, which current
+      # hatchling emits; the 0.27.0 publish failed on exactly that.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2


### PR DESCRIPTION
The v0.27.0 release published the GitHub release and both binaries, but **PyPI never got 0.27.0** — `pip install vexor` still resolves to 0.26.0, and the MCP registry job was skipped because it depends on the PyPI job.

## What broke

```
Checking dist/vexor-0.27.0-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Nothing to do with the released code. hatchling now emits `Metadata-Version: 2.5`, and the twine bundled inside `gh-action-pypi-publish@v1.13.0` (Sept 2025) predates that metadata version and rejects the wheel.

Confirmed locally rather than assumed — built the same wheel with the repo's own build backend:

```
hatchling 1.32.0
wheel: vexor-0.27.0-py3-none-any.whl
  Metadata-Version: 2.5
```

Bumps the action to `v1.14.2` (2026-07-29).

## Why the workflow also needed a retry path

The failure was unrecoverable, which is the more interesting half. `prepare_release` sets `release_changed` by comparing `__version__` against the parent commit, and the workflow only triggers on `push` / `pull_request`. So once a tag exists:

- Re-running the failed job replays the *old* workflow file, so it fails identically.
- Pushing this fix to main is a no-op for publishing, because the version did not change in that commit.
- The only remaining route would be burning 0.27.1 on a version bump that changes nothing.

This adds `workflow_dispatch` with a `force_release` boolean that overrides the version-changed check and republishes whatever is on main. That makes 0.27.0 recoverable, and makes any future failed publish recoverable without a throwaway version.

## After this merges

Run the workflow manually on `main` with `force_release: true` to publish 0.27.0 to PyPI. The GitHub release and tag already exist and are untouched by that run; `softprops/action-gh-release` updates the existing release rather than failing.

## Verification

Workflow YAML parses, and the three changed points resolve as intended:

```
triggers: ['push', 'pull_request', 'workflow_dispatch']
prepare_release.if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.force_release)
pypi action: pypa/gh-action-pypi-publish@v1.14.2
```
