### PR TITLE
docs(readme): note that MCP search returns source text

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ and any config overrides via `env` (no `vexor init` needed):
 }
 ```
 
-The server exposes two tools: `vexor_search` (semantic file search) and `vexor_index` (explicit index warm-up). No extra dependencies are required. Vexor is listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.scarletkc/vexor`. See [`docs/mcp.md`](https://github.com/scarletkc/vexor/tree/main/docs/mcp.md) for tool schemas, environment variables, and client setup details.
+The server exposes two tools: `vexor_search` (semantic file search, returning the matching source text so an agent rarely needs a follow-up file read) and `vexor_index` (explicit index warm-up). No extra dependencies are required. Vexor is listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.scarletkc/vexor`. See [`docs/mcp.md`](https://github.com/scarletkc/vexor/tree/main/docs/mcp.md) for tool schemas, environment variables, and client setup details.
 
 ## Configuration
 


### PR DESCRIPTION
0.27.0's biggest user-visible change — `vexor_search` returning matching source text by default over MCP — was invisible in the README, which is where agent users land. The roadmap positions MCP as the primary distribution channel, so that paragraph is the load-bearing one for the stated strategy.

One clause, in the MCP section only:

> The server exposes two tools: `vexor_search` (semantic file search, **returning the matching source text so an agent rarely needs a follow-up file read**) and `vexor_index` (explicit index warm-up).

Factual rather than promotional — it states what the tool returns. Full behavior (budget, `content_unavailable` reasons, `include_content`) stays in `docs/mcp.md`, per the README-stays-lean convention.

Docs only; no version change, so this does not trigger a release.
