### PR TITLE
ci: allow an optional hand-written release note

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -284,10 +284,34 @@ jobs:
           set -euo pipefail
 
           CURRENT_TAG="v${VERSION}"
+          NOTE_FILE="docs/release-notes/${VERSION}.md"
+
+          # The hand-written note is optional, but a malformed one is an error:
+          # it has to open with its own level-2 heading so it reads as a section
+          # beside "## Changelog" rather than as untitled prose.
+          if [ -f "${NOTE_FILE}" ]; then
+            first_line="$(head -n 1 "${NOTE_FILE}")"
+            case "${first_line}" in
+              '## '[![:space:]]*) ;;
+              *)
+                echo "${NOTE_FILE} must start with a '## <title>' heading, got: ${first_line}" >&2
+                exit 1
+                ;;
+            esac
+            if [ -z "$(tail -n +2 "${NOTE_FILE}" | tr -d '[:space:]')" ]; then
+              echo "${NOTE_FILE} has a heading but no body; write the note or delete the file." >&2
+              exit 1
+            fi
+          fi
 
           {
             echo "Automated release for Vexor ${CURRENT_TAG}."
             echo
+            if [ -f "${NOTE_FILE}" ]; then
+              # Command substitution strips trailing newlines, so the spacing
+              # around the note stays the same whatever the file ends with.
+              printf '%s\n\n' "$(cat "${NOTE_FILE}")"
+            fi
             echo "## Changelog"
             echo
             if [ -n "${PREV_TAG}" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,5 +61,8 @@
 - PRs explain motivation and verification, link relevant issues, and include terminal output when
   CLI output changes. Call out compatibility-sensitive config, cache, Python API, provider,
   reranker, or bundled-skill changes.
+- A release may carry a hand-written section in `docs/release-notes/<version>.md`, published above
+  the generated changelog. It is optional, but a heading-only file fails the publish job; see
+  `docs/development.md`.
 - Update the documentation affected by a behavior or workflow change. The bundled skill is the
   easiest copy site to forget.

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,3 +31,22 @@ python scripts/benchmark_search_cache.py --vector-count 30000 --file-count 10000
 The harness reports first and process-cached vector loads, full snapshot
 validation, and event-backed freshness checks. Timing is diagnostic evidence,
 not a fixed CI threshold.
+
+## Releases
+
+Bump the version on a branch and land it through a PR; merging to `main`
+publishes the release. `.github/workflows/publish.yml` builds the release body
+from the commit subjects between the previous tag and the new one.
+
+To put a hand-written section above that generated changelog, add
+`docs/release-notes/<version>.md`. `--note` starts the file for you:
+
+```bash
+python scripts/bump_version.py 0.28.0 --note "Reranker now reads chunk text"
+```
+
+The file must open with its own `## <title>` line so the section sits beside
+`## Changelog`, and it must have a body — the publish job fails on a missing
+heading or an empty note rather than shipping a malformed release. Leave the
+file out entirely when a release needs no note. Because the note is committed
+with the bump, a `force_release` re-run publishes the same text.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -6,6 +6,11 @@ Updates the Python package, plugin manifest, and MCP server manifest.
 Usage:
     python scripts/bump_version.py 0.6.4
     python scripts/bump_version.py v0.6.4
+    python scripts/bump_version.py 0.6.4 --note "Reranker now reads chunk text"
+
+--note starts docs/release-notes/<version>.md, an optional hand-written section
+the release workflow publishes above the generated changelog. Fill in the body
+before opening the bump PR; a file with only a heading fails the release.
 """
 
 from __future__ import annotations
@@ -24,22 +29,44 @@ def main(argv: list[str]) -> int:
         print(__doc__.strip())
         return 2
 
-    version = _parse_args(argv)
-    return _run(version=version, repo_root=Path(__file__).resolve().parents[1])
+    version, note_title = _parse_args(argv)
+    return _run(
+        version=version,
+        repo_root=Path(__file__).resolve().parents[1],
+        note_title=note_title,
+    )
 
 
-def _parse_args(argv: list[str]) -> str:
+def _parse_args(argv: list[str]) -> tuple[str, str | None]:
     """Parse CLI args.
 
     Accepted forms:
       bump_version.py 0.1.2
       bump_version.py v0.1.2
+      bump_version.py 0.1.2 --note "Release note title"
+      bump_version.py 0.1.2 --note="Release note title"
     """
     positional: list[str] = []
+    note_title: str | None = None
+    pending_note = False
     for arg in argv[1:]:
-        if arg.startswith("-"):
+        if pending_note:
+            note_title = arg
+            pending_note = False
+            continue
+        if arg == "--note":
+            pending_note = True
+        elif arg.startswith("--note="):
+            note_title = arg[len("--note=") :]
+        elif arg.startswith("-"):
             raise SystemExit(f"Unknown option '{arg}'. Use --help for usage.")
-        positional.append(arg)
+        else:
+            positional.append(arg)
+
+    if pending_note:
+        raise SystemExit("Option '--note' requires a title. Use --help for usage.")
+    if note_title is not None and not note_title.strip():
+        raise SystemExit("Option '--note' requires a non-empty title.")
 
     if len(positional) != 1:
         print(__doc__.strip())
@@ -51,10 +78,10 @@ def _parse_args(argv: list[str]) -> str:
         raw = raw[1:]
     if not raw or not _VERSION_PATTERN.fullmatch(raw):
         raise SystemExit(f"Invalid version '{raw_input}'. Expected like 0.6.4")
-    return raw
+    return raw, note_title.strip() if note_title is not None else None
 
 
-def _run(*, version: str, repo_root: Path) -> int:
+def _run(*, version: str, repo_root: Path, note_title: str | None = None) -> int:
     package_init = repo_root / "vexor" / "__init__.py"
     plugin_manifest = repo_root / "plugins" / "vexor" / ".claude-plugin" / "plugin.json"
     mcp_server_manifest = repo_root / "server.json"
@@ -70,7 +97,21 @@ def _run(*, version: str, repo_root: Path) -> int:
         _set_mcp_server_version(mcp_server_manifest, version)
         print(f"- {mcp_server_manifest}")
 
+    if note_title is not None:
+        note_path = _start_release_note(repo_root, version=version, title=note_title)
+        print(f"- {note_path} (write the body before opening the bump PR)")
+
     return 0
+
+
+def _start_release_note(repo_root: Path, *, version: str, title: str) -> Path:
+    """Create the hand-written release note stub the publish workflow reads."""
+    path = repo_root / "docs" / "release-notes" / f"{version}.md"
+    if path.exists():
+        raise SystemExit(f"{path} already exists; edit it instead of re-running --note.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"## {title}\n\n", encoding="utf-8")
+    return path
 
 
 def _set_python_version(path: Path, version: str) -> None:

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -67,6 +67,8 @@ def _parse_args(argv: list[str]) -> tuple[str, str | None]:
         raise SystemExit("Option '--note' requires a title. Use --help for usage.")
     if note_title is not None and not note_title.strip():
         raise SystemExit("Option '--note' requires a non-empty title.")
+    if note_title is not None and len(note_title.strip().splitlines()) > 1:
+        raise SystemExit("Option '--note' requires a single-line title.")
 
     if len(positional) != 1:
         print(__doc__.strip())
@@ -86,6 +88,12 @@ def _run(*, version: str, repo_root: Path, note_title: str | None = None) -> int
     plugin_manifest = repo_root / "plugins" / "vexor" / ".claude-plugin" / "plugin.json"
     mcp_server_manifest = repo_root / "server.json"
 
+    # Refuse before writing anything: a bailout here must not leave the version
+    # half-bumped across the manifests.
+    note_path = _release_note_path(repo_root, version) if note_title is not None else None
+    if note_path is not None and note_path.exists():
+        raise SystemExit(f"{note_path} already exists; edit it instead of re-running --note.")
+
     _set_python_version(package_init, version)
     _set_plugin_version(plugin_manifest, version)
 
@@ -97,21 +105,17 @@ def _run(*, version: str, repo_root: Path, note_title: str | None = None) -> int
         _set_mcp_server_version(mcp_server_manifest, version)
         print(f"- {mcp_server_manifest}")
 
-    if note_title is not None:
-        note_path = _start_release_note(repo_root, version=version, title=note_title)
+    if note_path is not None:
+        note_path.parent.mkdir(parents=True, exist_ok=True)
+        note_path.write_text(f"## {note_title}\n\n", encoding="utf-8")
         print(f"- {note_path} (write the body before opening the bump PR)")
 
     return 0
 
 
-def _start_release_note(repo_root: Path, *, version: str, title: str) -> Path:
-    """Create the hand-written release note stub the publish workflow reads."""
-    path = repo_root / "docs" / "release-notes" / f"{version}.md"
-    if path.exists():
-        raise SystemExit(f"{path} already exists; edit it instead of re-running --note.")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f"## {title}\n\n", encoding="utf-8")
-    return path
+def _release_note_path(repo_root: Path, version: str) -> Path:
+    """Where the publish workflow looks for this version's hand-written note."""
+    return repo_root / "docs" / "release-notes" / f"{version}.md"
 
 
 def _set_python_version(path: Path, version: str) -> None:

--- a/tests/unit/test_bump_version_script.py
+++ b/tests/unit/test_bump_version_script.py
@@ -42,6 +42,82 @@ def test_bump_version_rejects_unknown_options():
         raise AssertionError("expected SystemExit for unknown option")
 
 
+def test_bump_version_parses_note_title():
+    bump = _load_bump_version_module()
+
+    assert bump._parse_args(["bump_version.py", "1.2.3"]) == ("1.2.3", None)
+    assert bump._parse_args(["bump_version.py", "1.2.3", "--note", "New title"]) == (
+        "1.2.3",
+        "New title",
+    )
+    assert bump._parse_args(["bump_version.py", "--note=New title", "v1.2.3"]) == (
+        "1.2.3",
+        "New title",
+    )
+
+
+def test_bump_version_rejects_empty_note_title():
+    bump = _load_bump_version_module()
+
+    for argv in (
+        ["bump_version.py", "1.2.3", "--note"],
+        ["bump_version.py", "1.2.3", "--note", "   "],
+        ["bump_version.py", "1.2.3", "--note="],
+    ):
+        try:
+            bump._parse_args(argv)
+        except SystemExit as exc:
+            assert "--note" in str(exc)
+        else:
+            raise AssertionError(f"expected SystemExit for {argv}")
+
+
+def _write_minimal_repo(tmp_path: Path) -> None:
+    (tmp_path / "vexor").mkdir(parents=True)
+    (tmp_path / "plugins" / "vexor" / ".claude-plugin").mkdir(parents=True)
+    (tmp_path / "vexor" / "__init__.py").write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    (tmp_path / "plugins" / "vexor" / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "0.1.0"}, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def test_bump_version_starts_release_note(tmp_path: Path):
+    bump = _load_bump_version_module()
+    _write_minimal_repo(tmp_path)
+
+    bump._run(version="1.2.3", repo_root=tmp_path, note_title="Chunk-aware reranking")
+
+    note = tmp_path / "docs" / "release-notes" / "1.2.3.md"
+    assert note.read_text(encoding="utf-8") == "## Chunk-aware reranking\n\n"
+
+
+def test_bump_version_skips_release_note_by_default(tmp_path: Path):
+    bump = _load_bump_version_module()
+    _write_minimal_repo(tmp_path)
+
+    bump._run(version="1.2.3", repo_root=tmp_path)
+
+    assert not (tmp_path / "docs" / "release-notes").exists()
+
+
+def test_bump_version_refuses_to_overwrite_release_note(tmp_path: Path):
+    bump = _load_bump_version_module()
+    _write_minimal_repo(tmp_path)
+
+    note = tmp_path / "docs" / "release-notes" / "1.2.3.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("## Existing\n\nHand-written body.\n", encoding="utf-8")
+
+    try:
+        bump._run(version="1.2.3", repo_root=tmp_path, note_title="Replacement")
+    except SystemExit as exc:
+        assert "already exists" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for existing release note")
+
+    assert note.read_text(encoding="utf-8") == "## Existing\n\nHand-written body.\n"
+
+
 def test_bump_version_syncs_mcp_server_manifest(tmp_path: Path):
     bump = _load_bump_version_module()
 

--- a/tests/unit/test_bump_version_script.py
+++ b/tests/unit/test_bump_version_script.py
@@ -72,6 +72,17 @@ def test_bump_version_rejects_empty_note_title():
             raise AssertionError(f"expected SystemExit for {argv}")
 
 
+def test_bump_version_rejects_multiline_note_title():
+    bump = _load_bump_version_module()
+
+    try:
+        bump._parse_args(["bump_version.py", "1.2.3", "--note", "first\nsecond"])
+    except SystemExit as exc:
+        assert "single-line" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for multi-line note title")
+
+
 def _write_minimal_repo(tmp_path: Path) -> None:
     (tmp_path / "vexor").mkdir(parents=True)
     (tmp_path / "plugins" / "vexor" / ".claude-plugin").mkdir(parents=True)
@@ -116,6 +127,11 @@ def test_bump_version_refuses_to_overwrite_release_note(tmp_path: Path):
         raise AssertionError("expected SystemExit for existing release note")
 
     assert note.read_text(encoding="utf-8") == "## Existing\n\nHand-written body.\n"
+    # The refusal lands before any manifest is touched, so no half-bumped state.
+    package_init = tmp_path / "vexor" / "__init__.py"
+    plugin_manifest = tmp_path / "plugins" / "vexor" / ".claude-plugin" / "plugin.json"
+    assert package_init.read_text(encoding="utf-8") == '__version__ = "0.1.0"\n'
+    assert json.loads(plugin_manifest.read_text(encoding="utf-8"))["version"] == "0.1.0"
 
 
 def test_bump_version_syncs_mcp_server_manifest(tmp_path: Path):


### PR DESCRIPTION
## Motivation

The publish workflow built the whole release body from commit subjects between
the previous tag and the new one. Anything worth saying to users in prose had
to live in the bump PR instead of the release itself, where nobody reads it.

This adds an optional hand-written section that sits beside `## Changelog`,
with its own title, and stays entirely opt-in.

## What changed

- `.github/workflows/publish.yml` reads `docs/release-notes/<version>.md` when
  it exists and places it above the generated changelog. The note is committed
  with the bump, so a `force_release` re-run publishes the same text.
- `scripts/bump_version.py` gains an optional `--note "<title>"` that starts
  the file (`--note=<title>` works too) and refuses to overwrite an existing
  one. Without the flag nothing is created and behavior is unchanged.
- `docs/development.md` gains a Releases section; `AGENTS.md` points at it.

A malformed note is an error rather than a silent degradation: the publish job
fails when the file does not open with its own `## <title>` line, or when it
has a heading but no body. A missing file produces the previous body verbatim.

## Example

`docs/release-notes/0.28.0.md`:

```markdown
## Reranker now reads chunk text

重排阶段改为直接使用 chunk 正文而非文件名标签。
```

Published body:

```
Automated release for Vexor v0.28.0.

## Reranker now reads chunk text

重排阶段改为直接使用 chunk 正文而非文件名标签。

## Changelog

Changes since v0.27.0:

- ...
```

## Verification

- `python -m pytest tests/unit/test_bump_version_script.py` — 9 passed, covering
  `--note` parsing, empty-title rejection, stub creation, the default no-op, and
  the refusal to overwrite an existing note.
- The workflow step is shell, so it was extracted from the YAML and run against
  9 cases in a real checkout: no note / valid note / file without a trailing
  newline all produce correct spacing; `# `, no heading, `##` without a space,
  an empty title, a heading-only file, and `### ` each exit 1 with a readable
  error.
- No runtime code is touched, so no provider or MCP end-to-end run applies.

## Compatibility

Release bodies for versions without a note file are byte-identical to before.
`bump_version.py` keeps its existing positional form; `--note` is additive.
