### PR TITLE
refactor(search): extract a result-agnostic reranker seam

### DIFF
--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -50,6 +50,9 @@ def test_cli_small_helpers_and_version_callback(capsys):
 
 
 def test_cli_flashrank_prepare_success_and_errors(monkeypatch, tmp_path):
+    # See test_search_service_extra: assert the missing-extra path deterministically
+    # rather than relying on ``flashrank`` being absent from the environment.
+    monkeypatch.setitem(sys.modules, "flashrank", None)
     with pytest.raises(RuntimeError):
         cli._prepare_flashrank_model(None)
 

--- a/tests/unit/test_search_service_extra.py
+++ b/tests/unit/test_search_service_extra.py
@@ -47,6 +47,30 @@ def test_rank_documents_bm25_is_independent_of_search_results():
     assert all(0.0 <= score <= 1.0 for _, score in ranking)
 
 
+def test_rank_documents_bm25_rejects_mismatched_score_count():
+    """Documents and scores are built separately, so a mismatch has to be loud.
+
+    Zipping them would silently rank only the shorter half and leave the rest
+    holding unfused retrieval scores.
+    """
+    with pytest.raises(ValueError, match="line up"):
+        search_service._rank_documents_bm25("alpha", ["one", "two"], [0.5])
+
+
+def test_rank_documents_answer_an_empty_document_list_locally(monkeypatch):
+    """Neither ranker should load a model or call a provider to rank nothing."""
+
+    def fail(**_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("no request should be sent")
+
+    monkeypatch.setattr(search_service, "_remote_rerank_request", fail)
+    monkeypatch.setitem(sys.modules, "flashrank", None)
+    search_service._get_flashranker.cache_clear()
+
+    assert search_service._rank_documents_remote("alpha", [], None) == []
+    assert search_service._rank_documents_flashrank("alpha", [], None) == []
+
+
 def test_apply_ranking_drops_bad_indices_and_keeps_the_tail():
     results = [_result("a.txt", 0.1), _result("b.txt", 0.2), _result("c.txt", 0.3)]
 
@@ -85,6 +109,7 @@ def test_flashrank_rerank_import_error_and_success(monkeypatch, tmp_path):
             assert request.query == "alpha"
             return [
                 {"id": None, "score": 0.0},
+                {"id": "not-an-index", "score": 0.0},
                 {"id": 99, "score": 0.0},
                 {"id": 1, "score": 0.95},
             ]

--- a/tests/unit/test_search_service_extra.py
+++ b/tests/unit/test_search_service_extra.py
@@ -62,6 +62,11 @@ def test_apply_ranking_drops_bad_indices_and_keeps_the_tail():
 
 
 def test_flashrank_rerank_import_error_and_success(monkeypatch, tmp_path):
+    # Simulate the extra being absent instead of depending on it being absent: a
+    # ``None`` entry in sys.modules makes the import raise whether or not the
+    # machine running the suite has ``flashrank`` installed.
+    monkeypatch.setitem(sys.modules, "flashrank", None)
+    search_service._get_flashranker.cache_clear()
     with pytest.raises(RuntimeError):
         search_service._apply_flashrank_rerank("q", [_result("a.txt", 0.1)], None)
 

--- a/tests/unit/test_search_service_extra.py
+++ b/tests/unit/test_search_service_extra.py
@@ -35,6 +35,32 @@ def test_bm25_helpers_fallbacks(monkeypatch):
     ]
 
 
+def test_rank_documents_bm25_is_independent_of_search_results():
+    documents = ["alpha alpha beta", "gamma delta", "beta gamma"]
+    base_scores = [0.1, 0.9, 0.2]
+
+    assert search_service._rank_documents_bm25("", documents, base_scores) is None
+
+    ranking = search_service._rank_documents_bm25("alpha", documents, base_scores)
+
+    assert [index for index, _ in ranking] == [1, 0, 2]
+    assert all(0.0 <= score <= 1.0 for _, score in ranking)
+
+
+def test_apply_ranking_drops_bad_indices_and_keeps_the_tail():
+    results = [_result("a.txt", 0.1), _result("b.txt", 0.2), _result("c.txt", 0.3)]
+
+    ordered = search_service._apply_ranking(
+        results,
+        [(2, 0.9), (99, 1.0), (-1, 1.0), (2, 0.5), (0, None)],
+    )
+
+    assert [item.path.name for item in ordered] == ["c.txt", "a.txt", "b.txt"]
+    assert ordered[0].score == 0.9
+    # A reranker that returns no score leaves the retrieval score in place.
+    assert ordered[1].score == 0.1
+
+
 def test_flashrank_rerank_import_error_and_success(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError):
         search_service._apply_flashrank_rerank("q", [_result("a.txt", 0.1)], None)

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -279,8 +279,7 @@ def _attach_chunk_content(
 
 def _build_rerank_document(result: SearchResult) -> str:
     preview = result.preview or ""
-    document = f"{result.path.name} {result.path.as_posix()} {preview}".strip()
-    return document or result.path.as_posix()
+    return f"{result.path.name} {result.path.as_posix()} {preview}".strip()
 
 
 def _build_rerank_documents(results: Sequence[SearchResult]) -> list[str]:
@@ -363,6 +362,11 @@ def _rank_documents_bm25(
     caller's original order untouched.
     """
 
+    if len(documents) != len(base_scores):
+        raise ValueError(
+            "rerank documents and base scores must line up: "
+            f"got {len(documents)} documents and {len(base_scores)} scores"
+        )
     query_tokens = _bm25_tokenize(query)
     if not query_tokens:
         return None
@@ -411,6 +415,9 @@ def _rank_documents_flashrank(
     documents: Sequence[str],
     model_name: str | None,
 ) -> list[tuple[int, float | None]]:
+    if not documents:
+        # Nothing to rank, and loading a ranker model to say so would be waste.
+        return []
     try:
         from flashrank import RerankRequest
     except ImportError as exc:
@@ -559,6 +566,10 @@ def _rank_documents_remote(
     documents: Sequence[str],
     config: RemoteRerankConfig | None,
 ) -> list[tuple[int, float | None]]:
+    if not documents:
+        # Rerank endpoints reject an empty document array, so answer locally
+        # rather than turning "nothing to rank" into a provider error.
+        return []
     resolved = _resolve_remote_rerank_config(config)
     payload = _remote_rerank_request(
         config=resolved,
@@ -580,8 +591,6 @@ def _apply_remote_rerank(
         _build_rerank_documents(results),
         config,
     )
-    if not ranking:
-        return list(results)
     return _apply_ranking(results, ranking)
 
 

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -279,7 +279,40 @@ def _attach_chunk_content(
 
 def _build_rerank_document(result: SearchResult) -> str:
     preview = result.preview or ""
-    return f"{result.path.name} {result.path.as_posix()} {preview}".strip()
+    document = f"{result.path.name} {result.path.as_posix()} {preview}".strip()
+    return document or result.path.as_posix()
+
+
+def _build_rerank_documents(results: Sequence[SearchResult]) -> list[str]:
+    return [_build_rerank_document(result) for result in results]
+
+
+def _apply_ranking(
+    results: Sequence[SearchResult],
+    ranking: Sequence[tuple[int, float | None]],
+) -> list[SearchResult]:
+    """Reorder *results* by a reranker's ``(index, score)`` pairs.
+
+    Unknown, duplicate, and out-of-range indices are dropped, and anything the
+    reranker left out keeps its original relative order at the tail, so a partial
+    response degrades to "reranked head, dense tail" instead of losing results.
+    """
+
+    ordered: list[SearchResult] = []
+    seen: set[int] = set()
+    for index, score in ranking:
+        if index < 0 or index >= len(results) or index in seen:
+            continue
+        result = results[index]
+        if score is not None:
+            result.score = float(score)
+        ordered.append(result)
+        seen.add(index)
+    if len(ordered) < len(results):
+        for index, result in enumerate(results):
+            if index not in seen:
+                ordered.append(result)
+    return ordered
 
 
 def _normalize_by_max(scores: Sequence[float]) -> list[float]:
@@ -319,26 +352,46 @@ def _bm25_scores(
     return [float(score) for score in scores]
 
 
+def _rank_documents_bm25(
+    query: str,
+    documents: Sequence[str],
+    base_scores: Sequence[float],
+) -> list[tuple[int, float]] | None:
+    """Fuse lexical scores over *documents* with the retrieval scores behind them.
+
+    Returns ``None`` when the query carries no usable tokens, which leaves the
+    caller's original order untouched.
+    """
+
+    query_tokens = _bm25_tokenize(query)
+    if not query_tokens:
+        return None
+    tokenized = [_bm25_tokenize(document) for document in documents]
+    lexical_norm = _normalize_by_max(_bm25_scores(query_tokens, tokenized))
+    base_norm = _normalize_by_max([max(score, 0.0) for score in base_scores])
+    fused = [
+        (
+            index,
+            _FUSION_SEMANTIC_WEIGHT * base
+            + (1.0 - _FUSION_SEMANTIC_WEIGHT) * lexical,
+        )
+        for index, (base, lexical) in enumerate(zip(base_norm, lexical_norm))
+    ]
+    fused.sort(key=lambda item: item[1], reverse=True)
+    return fused
+
+
 def _apply_bm25_rerank(query: str, results: Sequence[SearchResult]) -> list[SearchResult]:
     if not results:
         return []
-    query_tokens = _bm25_tokenize(query)
-    if not query_tokens:
+    ranking = _rank_documents_bm25(
+        query,
+        _build_rerank_documents(results),
+        [result.score for result in results],
+    )
+    if ranking is None:
         return list(results)
-    documents = [_bm25_tokenize(_build_rerank_document(result)) for result in results]
-    bm25_scores = _bm25_scores(query_tokens, documents)
-    semantic_scores = [max(result.score, 0.0) for result in results]
-    semantic_norm = _normalize_by_max(semantic_scores)
-    bm25_norm = _normalize_by_max(bm25_scores)
-    fused: list[SearchResult] = []
-    for result, sem_score, bm25_score in zip(results, semantic_norm, bm25_norm):
-        fused_score = _FUSION_SEMANTIC_WEIGHT * sem_score + (
-            (1.0 - _FUSION_SEMANTIC_WEIGHT) * bm25_score
-        )
-        result.score = float(fused_score)
-        fused.append(result)
-    fused.sort(key=lambda item: item.score, reverse=True)
-    return fused
+    return _apply_ranking(results, ranking)
 
 
 @lru_cache(maxsize=4)
@@ -353,13 +406,11 @@ def _get_flashranker(model_name: str | None, max_length: int):
     return Ranker(**kwargs)
 
 
-def _apply_flashrank_rerank(
+def _rank_documents_flashrank(
     query: str,
-    results: Sequence[SearchResult],
+    documents: Sequence[str],
     model_name: str | None,
-) -> list[SearchResult]:
-    if not results:
-        return []
+) -> list[tuple[int, float | None]]:
     try:
         from flashrank import RerankRequest
     except ImportError as exc:
@@ -373,32 +424,37 @@ def _apply_flashrank_rerank(
         from ..text import Messages
 
         raise RuntimeError(Messages.ERROR_FLASHRANK_MISSING) from exc
-    passages = []
-    for idx, result in enumerate(results):
-        text = _build_rerank_document(result) or result.path.as_posix()
-        passages.append({"id": idx, "text": text})
-    rerank_request = RerankRequest(query=query, passages=passages)
-    reranked = ranker.rerank(rerank_request)
-    id_to_result = {idx: result for idx, result in enumerate(results)}
-    ordered: list[SearchResult] = []
-    seen: set[int] = set()
+    passages = [
+        {"id": index, "text": document} for index, document in enumerate(documents)
+    ]
+    reranked = ranker.rerank(RerankRequest(query=query, passages=passages))
+    ranking: list[tuple[int, float | None]] = []
     for item in reranked:
-        idx = item.get("id")
-        if idx is None:
+        index = item.get("id")
+        if index is None:
             continue
-        result = id_to_result.get(idx)
-        if result is None:
+        try:
+            position = int(index)
+        except (TypeError, ValueError):
             continue
         score = item.get("score")
-        if score is not None:
-            result.score = float(score)
-        ordered.append(result)
-        seen.add(idx)
-    if len(ordered) < len(results):
-        for idx, result in enumerate(results):
-            if idx not in seen:
-                ordered.append(result)
-    return ordered
+        ranking.append((position, float(score) if score is not None else None))
+    return ranking
+
+
+def _apply_flashrank_rerank(
+    query: str,
+    results: Sequence[SearchResult],
+    model_name: str | None,
+) -> list[SearchResult]:
+    if not results:
+        return []
+    ranking = _rank_documents_flashrank(
+        query,
+        _build_rerank_documents(results),
+        model_name,
+    )
+    return _apply_ranking(results, ranking)
 
 
 def _resolve_remote_rerank_config(
@@ -498,6 +554,20 @@ def _extract_remote_rerank_items(payload: object) -> list[tuple[int, float | Non
     return parsed
 
 
+def _rank_documents_remote(
+    query: str,
+    documents: Sequence[str],
+    config: RemoteRerankConfig | None,
+) -> list[tuple[int, float | None]]:
+    resolved = _resolve_remote_rerank_config(config)
+    payload = _remote_rerank_request(
+        config=resolved,
+        query=query,
+        documents=documents,
+    )
+    return _extract_remote_rerank_items(payload)
+
+
 def _apply_remote_rerank(
     query: str,
     results: Sequence[SearchResult],
@@ -505,32 +575,14 @@ def _apply_remote_rerank(
 ) -> list[SearchResult]:
     if not results:
         return []
-    resolved = _resolve_remote_rerank_config(config)
-    documents = [
-        _build_rerank_document(result) or result.path.as_posix() for result in results
-    ]
-    payload = _remote_rerank_request(
-        config=resolved,
-        query=query,
-        documents=documents,
+    ranking = _rank_documents_remote(
+        query,
+        _build_rerank_documents(results),
+        config,
     )
-    items = _extract_remote_rerank_items(payload)
-    if not items:
+    if not ranking:
         return list(results)
-    ordered: list[SearchResult] = []
-    seen: set[int] = set()
-    for idx, score in items:
-        if idx < 0 or idx >= len(results) or idx in seen:
-            continue
-        result = results[idx]
-        if score is not None:
-            result.score = score
-        ordered.append(result)
-        seen.add(idx)
-    for idx, result in enumerate(results):
-        if idx not in seen:
-            ordered.append(result)
-    return ordered
+    return _apply_ranking(results, ranking)
 
 
 def _empty_response(directory: Path, *, is_stale: bool) -> SearchResponse:


### PR DESCRIPTION
## Motivation

The three rerankers each mixed three concerns: building a document per `SearchResult`, calling the ranker, and reordering results. Two roadmap items need the middle one on its own:

- the collection API (P0) has to run the same rerankers over records that have no path, and
- the "feed chunk content to the rerankers" follow-up needed documents built from something other than the stored preview.

`docs/roadmap.md` asks for this refactor to land as its own PR, ahead of both.

## What changed

- `_rank_documents_bm25` / `_rank_documents_flashrank` / `_rank_documents_remote` take `(query, documents)` and return `(index, score)` pairs. BM25 also takes the retrieval scores it fuses against, so the fusion stays where it was. It raises when documents and scores do not line up, since those two lists arrive from different places once collections use this seam.
- `_apply_ranking` reorders results from those pairs, dropping unknown, duplicate, and out-of-range indices, and keeping anything the ranker left out at the tail in its original order. This was duplicated in the FlashRank and remote paths.
- Both remote-model rankers answer an empty document list locally instead of asking a provider (rerank endpoints reject an empty `documents` array) or loading a FlashRank model to rank nothing.
- `_build_rerank_document` keeps the filename/path/preview format. Its `or result.path.as_posix()` fallback is gone: `as_posix()` is never empty, so the branch was dead at both old call sites.
- Two tests opened by expecting a `RuntimeError` from the FlashRank path, which only holds when the optional extra is *not* installed — `pip install vexor[flashrank]` turned them red. They now simulate the absent import.

**One behavior change, in the FlashRank path only.** The old `_apply_flashrank_rerank` had no "already seen" guard — only the remote path did — so a reranker that returned the same id twice appended the same `SearchResult` object twice, showing a duplicate row and pushing a distinct result out of the `top_k` slice. Routing through `_apply_ranking` fixes that. Ordering and scores are otherwise identical for all three rerankers, and no CLI output, config, or Python API surface changes.

## Verification

- `python -m pytest` — 647 passed, both with and without `flashrank` installed. `search_service.py` coverage 90% → 91%.
- End-to-end on this repository (30-query set, `BAAI/bge-m3` embeddings, `BAAI/bge-reranker-v2-m3` remote rerank, top 10): MRR@10 `off` 0.628, `remote` 0.686, `flashrank` 0.671, `bm25` 0.605 — matching the pre-refactor run query for query.