### PR TITLE
fix(search): read each split chunk window from its own lines

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -116,7 +116,10 @@ the indexed line range, preserving the original indentation.
 changed since indexing), `budget_exhausted`, or `unreadable`. The `preview`
 is still populated in all of these cases and the search still succeeds.
 Check `content_truncated` before assuming a chunk is complete;
-`content_end_line` reports the last line actually returned.
+`content_start_line` and `content_end_line` report the lines the returned text
+actually covers. A symbol too long to embed in one piece is indexed as several
+chunks that all carry its line range, so `content_start_line` can be later than
+the result's `start_line`.
 
 ### index(...)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,6 +71,10 @@ short, `content_truncated` is `true` and `content_end_line` reports the last
 line actually returned. The `content_budget` object reports the limit and how
 much was used.
 
+A symbol too long to embed in one piece is indexed as several chunks that all
+carry its line range, so `content_start_line` can be later than the result's
+`start_line`: it reports where the returned text actually begins.
+
 ## Project Configuration
 
 Search and index commands walk upward from their resolved `--path` and apply

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -194,6 +194,11 @@ search itself still succeeds. When a result is cut short,
 `content_truncated` is `true` and `content_end_line` reports the last line
 actually returned — always check it before assuming you have the whole chunk.
 
+Read the returned text at `content_start_line`..`content_end_line`, not at the
+result's `start_line`: a symbol too long to embed in one piece is indexed as
+several chunks that all carry its line range, so the text of a later chunk
+begins further down.
+
 ### `vexor_index`
 
 Build or refresh the index for a directory. Use it to warm the cache or when

--- a/plugins/vexor/skills/vexor-cli/SKILL.md
+++ b/plugins/vexor/skills/vexor-cli/SKILL.md
@@ -103,5 +103,5 @@ vexor search "where JWT claims are validated" --path . --mode code --content
   some snapshot scans. Watcher setup failures fall back to scanning. Separate
   CLI invocations still validate the filesystem. Use longer timeouts if needed.
 - Results return similarity ranking, exact file location, line numbers, and matching snippet preview.
-- Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
+- Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. The text sits at `content_start_line`..`content_end_line`, which can begin later than the result's `start_line` when a long symbol was indexed as several chunks. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
 - Combine `--ext` with `--exclude-pattern` to focus on a subset (exclude rules apply on top).

--- a/tests/unit/test_content_extract_service.py
+++ b/tests/unit/test_content_extract_service.py
@@ -33,6 +33,41 @@ def test_read_chunk_content_preserves_indentation(tmp_path):
     assert chunk.truncated is False
 
 
+def test_read_chunk_content_starts_at_the_anchor(tmp_path):
+    source = tmp_path / "mod.py"
+    source.write_text(
+        "def outer():\n\n    first = compute()\n    second = refine(first)\n",
+        encoding="utf-8",
+    )
+
+    chunk = read_chunk_content(source, 1, 4, max_chars=1000, anchor="second = refine")
+
+    assert chunk.text == "    second = refine(first)"
+    assert (chunk.start_line, chunk.end_line) == (4, 4)
+
+
+def test_read_chunk_content_ignores_an_anchor_it_cannot_find(tmp_path):
+    source = tmp_path / "mod.py"
+    source.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    chunk = read_chunk_content(source, 1, 2, max_chars=1000, anchor="gamma")
+
+    assert chunk.start_line == 1
+    assert chunk.text == "alpha\nbeta"
+
+
+def test_locate_anchor_line_matches_across_the_flattened_lines():
+    lines = ["def outer():", "", "    value = compute(", "        argument,", "    )"]
+
+    # Blank lines drop out and the rest join with single spaces, so an anchor can
+    # span what were two lines in the file.
+    assert ces.locate_anchor_line(lines, "compute( argument,") == 2
+    assert ces.locate_anchor_line(lines, "def outer():") == 0
+    assert ces.locate_anchor_line(lines, "missing") == 0
+    assert ces.locate_anchor_line(lines, "") == 0
+    assert ces.locate_anchor_line([], "anything") == 0
+
+
 def test_read_chunk_content_truncates_on_line_boundary(tmp_path):
     source = tmp_path / "long.txt"
     source.write_text("".join(f"line-{idx}\n" for idx in range(30)), encoding="utf-8")

--- a/tests/unit/test_modes_misc.py
+++ b/tests/unit/test_modes_misc.py
@@ -13,6 +13,26 @@ def test_get_strategy_rejects_invalid_mode():
         modes.get_strategy("nope")
 
 
+def test_code_chunk_extensions_match_the_parsers():
+    """The search path reads this set to know which previews carry chunk markers.
+
+    Teaching a new language to the AST chunkers without adding it here would leave
+    those files' split windows reading back as their symbol's first window.
+    """
+    from vexor.services.js_parser import JSTS_EXTENSIONS
+
+    assert modes.CODE_CHUNK_EXTENSIONS == JSTS_EXTENSIONS | {".py"}
+
+
+def test_uses_code_chunking_follows_the_strategy_that_ran():
+    assert modes.uses_code_chunking("auto", Path("a.py")) is True
+    assert modes.uses_code_chunking("code", Path("a.tsx")) is True
+    # `code` mode falls back to full chunking for anything the parsers refuse.
+    assert modes.uses_code_chunking("code", Path("notes.txt")) is False
+    assert modes.uses_code_chunking("full", Path("a.py")) is False
+    assert modes.uses_code_chunking(None, Path("a.py")) is False
+
+
 def test_available_modes_contains_auto_and_is_sorted():
     available = modes.available_modes()
     assert "auto" in available

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -1292,6 +1292,74 @@ def test_content_is_read_back_with_original_indentation(tmp_path: Path) -> None:
     assert budget.used == len(results[0].content)
 
 
+def _split_chunk_source(tmp_path: Path) -> Path:
+    source = tmp_path / "registry.py"
+    lines = ["class Registry:"]
+    lines += [
+        f'    SETTING_{index} = "value number {index} for the registry entry"'
+        for index in range(40)
+    ]
+    source.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return source
+
+
+def test_split_chunk_windows_read_back_their_own_lines(tmp_path: Path) -> None:
+    """Each window of a split chunk must return its own text, not the first window's.
+
+    A chunk too long to embed in one piece is split into overlapping windows that
+    all store their symbol's line range, so reading from the range's first line
+    returns window 1 for every one of them -- identical content on several results,
+    and a preview check that then reports the index as stale.
+    """
+    source = _split_chunk_source(tmp_path)
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": 'class Registry: [#1] :: class Registry: SETTING_0 = "value number 0 for the registry entry"',
+            "start_line": 1,
+            "end_line": 41,
+        },
+        {
+            "chunk_index": 1,
+            "preview": 'class Registry: [#2] :: SETTING_20 = "value number 20 for the registry entry" SETTING_21 =',
+            "start_line": 1,
+            "end_line": 41,
+        },
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source, source], chunks)
+
+    first, second = results[0], results[1]
+    assert [item.content_unavailable for item in results] == [None, None]
+    assert first.content_start_line == 1
+    assert first.content.startswith("class Registry:")
+    assert second.content_start_line == 22
+    assert second.content.startswith('    SETTING_20 = "value number 20')
+    assert first.content != second.content
+
+
+def test_content_is_not_anchored_for_chunks_with_real_line_ranges(tmp_path: Path) -> None:
+    """Only split windows are anchored; an outline chunk keeps its heading."""
+    source = tmp_path / "guide.md"
+    source.write_text(
+        "## Providers\n\nThe provider table lists every supported backend.\n",
+        encoding="utf-8",
+    )
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": "Providers :: The provider table lists every supported backend.",
+            "start_line": 1,
+            "end_line": 3,
+        }
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source], chunks)
+
+    assert results[0].content_start_line == 1
+    assert results[0].content.startswith("## Providers")
+
+
 def test_content_absent_when_not_requested(tmp_path: Path) -> None:
     source = tmp_path / "a.txt"
     source.write_text("alpha beta gamma\n", encoding="utf-8")

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -1327,7 +1327,9 @@ def test_split_chunk_windows_read_back_their_own_lines(tmp_path: Path) -> None:
         },
     ]
 
-    results, _, _ = _rank_with_content(_content_request(tmp_path), [source, source], chunks)
+    results, _, _ = _rank_with_content(
+        _content_request(tmp_path, mode="code"), [source, source], chunks
+    )
 
     first, second = results[0], results[1]
     assert [item.content_unavailable for item in results] == [None, None]
@@ -1336,6 +1338,44 @@ def test_split_chunk_windows_read_back_their_own_lines(tmp_path: Path) -> None:
     assert second.content_start_line == 22
     assert second.content.startswith('    SETTING_20 = "value number 20')
     assert first.content != second.content
+
+
+def test_split_window_anchor_prefers_the_occurrence_at_its_own_offset(
+    tmp_path: Path,
+) -> None:
+    """Repeated code must not pull a later window back to an earlier copy of itself."""
+    source = tmp_path / "handlers.py"
+    body = [
+        "        respect_gitignore=respect_gitignore,",
+        "        include_hidden=include_hidden,",
+    ]
+    lines = ["def dispatch():"]
+    for index in range(3):
+        lines.append(f"    branch_{index} = call(")
+        lines.extend(body)
+        lines.append("    )")
+        lines.extend(f"    filler_{index}_{step} = {step}" for step in range(30))
+    source.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    # The anchor also occurs in branch 0 at line 2; window 3 starts in branch 2.
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": (
+                "def dispatch(): [#3] :: respect_gitignore=respect_gitignore, "
+                "include_hidden=include_hidden,"
+            ),
+            "start_line": 1,
+            "end_line": len(lines),
+        }
+    ]
+
+    results, _, _ = _rank_with_content(
+        _content_request(tmp_path, mode="code"), [source], chunks
+    )
+
+    assert results[0].content_unavailable is None
+    assert results[0].content_start_line > 60
 
 
 def test_content_is_not_anchored_for_chunks_with_real_line_ranges(tmp_path: Path) -> None:
@@ -1358,6 +1398,38 @@ def test_content_is_not_anchored_for_chunks_with_real_line_ranges(tmp_path: Path
 
     assert results[0].content_start_line == 1
     assert results[0].content.startswith("## Providers")
+
+
+def test_file_text_that_looks_like_a_window_marker_is_not_anchored(
+    tmp_path: Path,
+) -> None:
+    """A `[#N] :: ` inside indexed text is file content, not a chunking marker.
+
+    `full` mode flattens raw file text into the preview, so a file that documents
+    the marker format would otherwise be anchored and lose its leading lines.
+    """
+    source = tmp_path / "notes.txt"
+    source.write_text(
+        "Chunk previews look like\nthis: 'class Registry: [#1] :: class Registry:'\n"
+        "and the marker is only meaningful in code mode.\n",
+        encoding="utf-8",
+    )
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": (
+                "Chunk previews look like this: 'class Registry: [#1] :: class Registry:' "
+                "and the marker is only meaningful in code mode."
+            ),
+            "start_line": 1,
+            "end_line": 3,
+        }
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source], chunks)
+
+    assert results[0].content_start_line == 1
+    assert results[0].content.startswith("Chunk previews look like")
 
 
 def test_content_absent_when_not_requested(tmp_path: Path) -> None:

--- a/vexor/modes.py
+++ b/vexor/modes.py
@@ -24,6 +24,22 @@ from .services.keyword_service import (
 PREVIEW_CHAR_LIMIT = 160
 BRIEF_PREVIEW_LIMIT = 10
 
+# Extensions `CodeStrategy` can chunk by syntax; anything else falls back to
+# `FullStrategy` even under `--mode code`. The search path reads this to tell a
+# `display [#N] :: snippet` preview apart from file text that merely looks like one.
+# ``test_code_chunk_extensions_match_the_parsers`` pins it to the parsers.
+CODE_CHUNK_EXTENSIONS = frozenset(
+    {".py", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}
+)
+
+
+def uses_code_chunking(mode: str | None, file: Path) -> bool:
+    """Report whether *file* was chunked by :class:`CodeStrategy` under *mode*."""
+
+    if (mode or "").strip().lower() not in {"auto", "code"}:
+        return False
+    return file.suffix.lower() in CODE_CHUNK_EXTENSIONS
+
 
 @dataclass(slots=True)
 class ModePayload:
@@ -251,9 +267,7 @@ class AutoStrategy(IndexModeStrategy):
 
     def _payloads_for_file(self, file: Path) -> list[ModePayload]:
         suffix = file.suffix.lower()
-        if suffix == ".py":
-            return self.code.payloads_for_files([file])
-        if suffix in {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}:
+        if suffix in CODE_CHUNK_EXTENSIONS:
             return self.code.payloads_for_files([file])
         if suffix in {".md", ".markdown", ".mdx"}:
             return self.outline.payloads_for_files([file])

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import ast
 import codecs
-from bisect import bisect_left
+from bisect import bisect_left, bisect_right
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Protocol
+from typing import Dict, Protocol, Sequence
 
 HEAD_CHAR_LIMIT = 1000
 # Also bounds how far ``read_chunk_content`` will read back: no indexer chunks past
@@ -286,12 +286,46 @@ def _read_text_through_line(path: Path, last_line: int) -> str | None:
     return text or None
 
 
+def locate_anchor_line(lines: Sequence[str], anchor: str) -> int:
+    """Return the index within *lines* where *anchor* starts, or 0 when absent.
+
+    *anchor* is matched against the lines flattened the way previews are stored --
+    stripped, blank lines dropped, joined by single spaces -- because that is the
+    form the caller has to anchor with.
+    """
+
+    if not anchor:
+        return 0
+    starts: list[int] = []
+    line_indices: list[int] = []
+    parts: list[str] = []
+    position = 0
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if parts:
+            # The space the join puts between two lines.
+            position += 1
+        starts.append(position)
+        line_indices.append(index)
+        parts.append(stripped)
+        position += len(stripped)
+    if not parts:
+        return 0
+    found = " ".join(parts).find(anchor)
+    if found < 0:
+        return 0
+    return line_indices[max(bisect_right(starts, found) - 1, 0)]
+
+
 def read_chunk_content(
     path: Path,
     start_line: int,
     end_line: int,
     *,
     max_chars: int,
+    anchor: str | None = None,
 ) -> ChunkContent | None:
     """Read lines ``start_line``..``end_line`` (1-based, inclusive) back out of *path*.
 
@@ -299,6 +333,11 @@ def read_chunk_content(
     breaks: the text is meant to be read by a caller, not embedded. Returns ``None``
     when the file cannot be read or the range does not resolve to any line, so callers
     can fall back to the stored preview instead of surfacing an error.
+
+    *anchor* moves the starting line to where that text appears inside the range. A
+    chunk too long to embed in one piece is split into overlapping windows that all
+    carry their symbol's line range, so without an anchor every window of a symbol
+    reads back as the symbol's first window.
     """
 
     if start_line < 1 or end_line < start_line or max_chars <= 0:
@@ -314,6 +353,11 @@ def read_chunk_content(
     selected = lines[start_line - 1 : end_line]
     if not selected:
         return None
+    if anchor:
+        offset = locate_anchor_line(selected, anchor)
+        if offset:
+            selected = selected[offset:]
+            start_line += offset
 
     kept: list[str] = []
     used = 0

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -286,12 +286,24 @@ def _read_text_through_line(path: Path, last_line: int) -> str | None:
     return text or None
 
 
-def locate_anchor_line(lines: Sequence[str], anchor: str) -> int:
+def locate_anchor_line(
+    lines: Sequence[str],
+    anchor: str,
+    *,
+    expected_offset: int = 0,
+) -> int:
     """Return the index within *lines* where *anchor* starts, or 0 when absent.
 
     *anchor* is matched against the lines flattened the way previews are stored --
     stripped, blank lines dropped, joined by single spaces -- because that is the
     form the caller has to anchor with.
+
+    *expected_offset* is roughly how far into the unflattened text the caller
+    expects the match. Code repeats itself, so a 40-character anchor taken from
+    late in a symbol often occurs early in it as well; with no hint the first
+    match wins and the caller gets an earlier region that still passes every
+    downstream check. The occurrence nearest the hint is picked instead, which at
+    the default of 0 is simply the first one.
     """
 
     if not anchor:
@@ -313,7 +325,17 @@ def locate_anchor_line(lines: Sequence[str], anchor: str) -> int:
         position += len(stripped)
     if not parts:
         return 0
-    found = " ".join(parts).find(anchor)
+    flattened = " ".join(parts)
+    # Flattening drops indentation and blank lines, so an offset into the original
+    # text has to be scaled down before it means anything in this one.
+    original_length = sum(len(line) + 1 for line in lines)
+    target = expected_offset * len(flattened) / original_length if original_length else 0
+    found = -1
+    position = flattened.find(anchor)
+    while position >= 0:
+        if found < 0 or abs(position - target) < abs(found - target):
+            found = position
+        position = flattened.find(anchor, position + 1)
     if found < 0:
         return 0
     return line_indices[max(bisect_right(starts, found) - 1, 0)]
@@ -326,6 +348,7 @@ def read_chunk_content(
     *,
     max_chars: int,
     anchor: str | None = None,
+    anchor_offset: int = 0,
 ) -> ChunkContent | None:
     """Read lines ``start_line``..``end_line`` (1-based, inclusive) back out of *path*.
 
@@ -334,10 +357,11 @@ def read_chunk_content(
     when the file cannot be read or the range does not resolve to any line, so callers
     can fall back to the stored preview instead of surfacing an error.
 
-    *anchor* moves the starting line to where that text appears inside the range. A
-    chunk too long to embed in one piece is split into overlapping windows that all
-    carry their symbol's line range, so without an anchor every window of a symbol
-    reads back as the symbol's first window.
+    *anchor* moves the starting line to where that text appears inside the range,
+    and *anchor_offset* says how far into the range to expect it. A chunk too long
+    to embed in one piece is split into overlapping windows that all carry their
+    symbol's line range, so without an anchor every window of a symbol reads back
+    as the symbol's first window.
     """
 
     if start_line < 1 or end_line < start_line or max_chars <= 0:
@@ -354,7 +378,7 @@ def read_chunk_content(
     if not selected:
         return None
     if anchor:
-        offset = locate_anchor_line(selected, anchor)
+        offset = locate_anchor_line(selected, anchor, expected_offset=anchor_offset)
         if offset:
             selected = selected[offset:]
             start_line += offset

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 import json
+import re
+
 import numpy as np
 from typing import Callable, Sequence, TYPE_CHECKING
 from urllib import error as urlerror
@@ -41,6 +43,10 @@ DEFAULT_CONTENT_CHARS_TOTAL = 8000
 # anything — and too small to survive the preview check, which would then misreport the
 # result as stale rather than as out of budget.
 MIN_USEFUL_CONTENT_CHARS = 200
+
+# Marks one window of a chunk that was split to fit the embedding window; see
+# CodeStrategy in modes.py, which tags them ``display [#N] :: snippet``.
+_CHUNK_WINDOW_RE = re.compile(r"\[#\d+\]")
 
 # How much of a stored preview is compared against re-read text, and the shortest
 # probe worth comparing at all. Both are heuristics: the check exists to catch text
@@ -215,6 +221,29 @@ def _preview_probe(preview: str | None) -> str:
     return preview.rsplit(" :: ", 1)[-1].rstrip("…").strip()
 
 
+def _chunk_window_anchor(preview: str | None) -> str | None:
+    """Return the text that locates a split chunk's window inside its symbol.
+
+    A ``code`` chunk too long to embed in one piece is split into overlapping
+    windows tagged ``[#N]``, and every window carries its whole symbol's line
+    range, so reading from the first line hands back window 1 whatever matched.
+    The preview snippet says where the window actually starts.
+
+    Only these windows are anchored. The other modes chunk with per-chunk ranges
+    that are already right, and anchoring them would move content that is correct
+    where it is: an ``outline`` chunk's snippet starts one line below its own
+    ``start_line``, so the heading would drop out of the content.
+    """
+
+    label, separator, _ = (preview or "").rpartition(" :: ")
+    if not separator or not _CHUNK_WINDOW_RE.search(label):
+        return None
+    probe = _preview_probe(preview)
+    if len(probe) < PREVIEW_PROBE_MIN_CHARS:
+        return None
+    return probe[:PREVIEW_PROBE_CHARS]
+
+
 def _content_matches_preview(content: str, preview: str | None) -> bool:
     """Check that re-read text still looks like what was indexed at that line range.
 
@@ -260,6 +289,7 @@ def _attach_chunk_content(
                 result.start_line,
                 result.end_line,
                 max_chars=min(per_result, remaining),
+                anchor=_chunk_window_anchor(result.preview),
             )
         except OSError:
             chunk = None

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -238,6 +238,12 @@ def _chunk_window_anchor(
     anchoring them would move content that is correct where it is: an ``outline``
     chunk's snippet starts one line below its own ``start_line``, so the heading
     would drop out of the content.
+
+    ``class`` chunks are the one code case this cannot help. Their text is
+    assembled rather than sliced -- class line, dedented docstring, class-level
+    statements, then a synthetic ``Methods: ...`` line -- so a window opening
+    inside the assembled seams has no counterpart in the file, the anchor is not
+    found, and the read falls back to the symbol's first lines as before.
     """
 
     from ..modes import uses_code_chunking  # local import
@@ -272,6 +278,12 @@ def _content_matches_preview(content: str, preview: str | None) -> bool:
     before the full-mode line offset fix, and files edited since they were indexed.
     Deliberately lenient — a false negative only costs the caller a preview fallback,
     while a false positive hands an agent code from the wrong part of the file.
+
+    An anchored read seeks to this same text, so for those chunks the check passes
+    whenever the anchor was found at all. What it still guarantees there is the part
+    that matters: the returned text is what was indexed. A file edited since then
+    either still holds that text somewhere in the range, and the read finds it, or
+    does not, and the read falls back to the range's first lines and is caught here.
     """
 
     probe = _preview_probe(preview)

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -46,7 +46,7 @@ MIN_USEFUL_CONTENT_CHARS = 200
 
 # Marks one window of a chunk that was split to fit the embedding window; see
 # CodeStrategy in modes.py, which tags them ``display [#N] :: snippet``.
-_CHUNK_WINDOW_RE = re.compile(r"\[#\d+\]")
+_CHUNK_WINDOW_RE = re.compile(r"\[#(\d+)\]")
 
 # How much of a stored preview is compared against re-read text, and the shortest
 # probe worth comparing at all. Both are heuristics: the check exists to catch text
@@ -221,27 +221,48 @@ def _preview_probe(preview: str | None) -> str:
     return preview.rsplit(" :: ", 1)[-1].rstrip("…").strip()
 
 
-def _chunk_window_anchor(preview: str | None) -> str | None:
-    """Return the text that locates a split chunk's window inside its symbol.
+def _chunk_window_anchor(
+    result: SearchResult,
+    mode: str | None,
+) -> tuple[str, int] | None:
+    """Return where a split chunk's window starts, as ``(anchor text, offset hint)``.
 
     A ``code`` chunk too long to embed in one piece is split into overlapping
     windows tagged ``[#N]``, and every window carries its whole symbol's line
     range, so reading from the first line hands back window 1 whatever matched.
-    The preview snippet says where the window actually starts.
+    The preview says which window this is and how it opens.
 
-    Only these windows are anchored. The other modes chunk with per-chunk ranges
-    that are already right, and anchoring them would move content that is correct
-    where it is: an ``outline`` chunk's snippet starts one line below its own
-    ``start_line``, so the heading would drop out of the content.
+    Only files that ``CodeStrategy`` actually chunks are considered, because a
+    ``[#N] :: `` in any other preview is file text that merely looks like a marker.
+    The other modes chunk with per-chunk ranges that are already right, and
+    anchoring them would move content that is correct where it is: an ``outline``
+    chunk's snippet starts one line below its own ``start_line``, so the heading
+    would drop out of the content.
     """
 
-    label, separator, _ = (preview or "").rpartition(" :: ")
-    if not separator or not _CHUNK_WINDOW_RE.search(label):
+    from ..modes import uses_code_chunking  # local import
+
+    if not uses_code_chunking(mode, result.path):
         return None
-    probe = _preview_probe(preview)
+    # The marker sits at the end of the display, immediately before the first
+    # separator; a later one belongs to the snippet, i.e. to the file's own text.
+    label, separator, snippet = (result.preview or "").partition(" :: ")
+    if not separator:
+        return None
+    marker = _CHUNK_WINDOW_RE.search(label)
+    if marker is None or marker.end() != len(label):
+        return None
+    probe = snippet.rstrip("…").strip()
     if len(probe) < PREVIEW_PROBE_MIN_CHARS:
         return None
-    return probe[:PREVIEW_PROBE_CHARS]
+    # Windows advance by one stride each, so window N opens about that far into
+    # the chunk. Only a hint: it disambiguates repeated code, and the strategy may
+    # have been built with a different stride.
+    from .content_extract_service import DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE
+
+    stride = max(DEFAULT_CHUNK_SIZE - DEFAULT_CHUNK_OVERLAP, 1)
+    offset = (int(marker.group(1)) - 1) * stride
+    return probe[:PREVIEW_PROBE_CHARS], offset
 
 
 def _content_matches_preview(content: str, preview: str | None) -> bool:
@@ -283,13 +304,15 @@ def _attach_chunk_content(
         if remaining < min(MIN_USEFUL_CONTENT_CHARS, per_result):
             result.content_unavailable = CONTENT_BUDGET_EXHAUSTED
             continue
+        anchor, anchor_offset = _chunk_window_anchor(result, request.mode) or ("", 0)
         try:
             chunk = read_chunk_content(
                 result.path,
                 result.start_line,
                 result.end_line,
                 max_chars=min(per_result, remaining),
-                anchor=_chunk_window_anchor(result.preview),
+                anchor=anchor,
+                anchor_offset=anchor_offset,
             )
         except OSError:
             chunk = None


### PR DESCRIPTION
## The bug

A `code` chunk longer than the embedding window is split into overlapping windows tagged `[#N]` (`CodeStrategy` in `modes.py`), and **every window stores its whole symbol's line range**. The `--content` / `--format json` / MCP `include_content` path reads from the range's first line, so for a symbol split into five windows it reads the same first lines five times.

Three user-visible effects, all in shipped 0.27.0:

1. Windows whose preview is not inside that first read are reported as `content_unavailable: stale_line_range`, which the docs and the bundled skill tell agents to fix by re-running `vexor index` — on an index that is perfectly current.
2. Several results of the same symbol come back with byte-identical `content`.
3. That duplicated text spends the shared content budget, so lower-ranked results hit `budget_exhausted` sooner.

Reproduced before the fix, one query against this repository — five results, one line range, three identical bodies:

```
search.py  chunk=134-200  content=134-179  unavailable=None
search.py  chunk=134-200  content=None     unavailable=stale_line_range
search.py  chunk=134-200  content=134-179  unavailable=None
search.py  chunk=134-200  content=None     unavailable=stale_line_range
```

## The fix

The stored preview says which window this is and how it opens, so it is passed to `read_chunk_content` as an anchor and the read begins at the line where that text appears.

Two things make the anchor exact rather than merely plausible:

- **Repeated code.** A 40-character anchor from late in a symbol often occurs early in it as well — kwargs forwarding and dict literals repeat verbatim. Taking the first match sent window 4 of `build_index_in_memory` to line 406 instead of 445, inside window 2's text, and the preview check passed there too, so it looked correct. Windows advance one stride each, so that offset is passed as a hint and the occurrence nearest it wins. Across this repository's 802 split windows, backward jumps drop from 12 to 0.
- **Marker lookalikes.** `[#N] :: ` is a chunking marker in a `code` preview and ordinary file text everywhere else; matching it anywhere in the preview anchored chunks that should not be, dropping their leading lines. Only files `CodeStrategy` actually chunks are considered (`CODE_CHUNK_EXTENSIONS`, pinned to the parsers by a test), and the marker has to sit at the end of the display, before the first separator.

An anchor that cannot be found falls back to the old first-line read, so the worst case is today's behavior.

Same query after the fix — each window reads back its own lines:

```
search.py  chunk=134-200  content=134-179  unavailable=None
search.py  chunk=134-200  content=197-200  unavailable=None
search.py  chunk=134-200  content=156-200  unavailable=None
search.py  chunk=134-200  content=176-196  unavailable=None
```

No index change, so no rebuild and no re-embedding: the window's line range in the index stays coarse, and `content_start_line` / `content_end_line` now report where the returned text actually came from. That is a visible contract detail for JSON/MCP consumers, so the CLI, Python API, and MCP references and the bundled skill now say `content_start_line` can be later than the result's `start_line`.

## Verification

- `python -m pytest` — 656 passed. Two pre-existing failures (`test_cli_flashrank_prepare_success_and_errors`, `test_flashrank_rerank_import_error_and_success`) appear only when the optional `flashrank` extra is installed; #51 fixes those.
- New tests: a split chunk's second window reads back its own lines (fails without the fix), a repeated anchor resolves to the window's own copy, file text that looks like a marker is not anchored, an outline chunk keeps its heading, and `locate_anchor_line` / `read_chunk_content(anchor=...)` directly.
- End-to-end on this repository with the configured provider (`BAAI/bge-m3`, fresh index, 30 queries × top 10 = 300 results): `stale_line_range` **40 → 0**, results carrying content **209 → 242**, results whose text duplicates another result **47 → 19** (the remainder is the windows' real 100-character overlap).

Found while benchmarking the roadmap's "feed chunk content to the rerankers" item, which is what surfaced the false stale reports.