### PR TITLE
chore(eval): measure reranking on chunk text against previews

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -116,7 +116,10 @@ the indexed line range, preserving the original indentation.
 changed since indexing), `budget_exhausted`, or `unreadable`. The `preview`
 is still populated in all of these cases and the search still succeeds.
 Check `content_truncated` before assuming a chunk is complete;
-`content_end_line` reports the last line actually returned.
+`content_start_line` and `content_end_line` report the lines the returned text
+actually covers. A symbol too long to embed in one piece is indexed as several
+chunks that all carry its line range, so `content_start_line` can be later than
+the result's `start_line`.
 
 ### index(...)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,6 +71,10 @@ short, `content_truncated` is `true` and `content_end_line` reports the last
 line actually returned. The `content_budget` object reports the limit and how
 much was used.
 
+A symbol too long to embed in one piece is indexed as several chunks that all
+carry its line range, so `content_start_line` can be later than the result's
+`start_line`: it reports where the returned text actually begins.
+
 ## Project Configuration
 
 Search and index commands walk upward from their resolved `--path` and apply

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,6 +32,22 @@ The harness reports first and process-cached vector loads, full snapshot
 validation, and event-backed freshness checks. Timing is diagnostic evidence,
 not a fixed CI threshold.
 
+Ranking changes are argued with numbers, not intuition. Two scripts score the
+same 30-query set in `scripts/eval_queries.jsonl` against whatever provider the
+config resolves to, and report MRR@10, Hit@1, and Hit@5:
+
+```bash
+python scripts/eval_hybrid.py --path .            # dense vs BM25 rerank vs hybrid
+python scripts/eval_rerank_content.py --path . --rerank remote --chars 0 1000
+```
+
+`eval_rerank_content.py` compares what each reranker scores: the stored preview
+against the chunk's source text, at a per-document character cap. Both scripts
+index first, so point `--path` at the repository you want measured and expect
+provider calls when the model is remote. Record the table in the PR, and keep
+the query set fixed while comparing arms — 30 queries is small enough that one
+rank change moves MRR@10 by about 0.03.
+
 ## Releases
 
 Bump the version on a branch and land it through a PR; merging to `main`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -194,6 +194,11 @@ search itself still succeeds. When a result is cut short,
 `content_truncated` is `true` and `content_end_line` reports the last line
 actually returned — always check it before assuming you have the whole chunk.
 
+Read the returned text at `content_start_line`..`content_end_line`, not at the
+result's `start_line`: a symbol too long to embed in one piece is indexed as
+several chunks that all carry its line range, so the text of a later chunk
+begins further down.
+
 ### `vexor_index`
 
 Build or refresh the index for a directory. Use it to warm the cache or when

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,11 +16,23 @@ never leaving the machine.
   caller got a path plus a 160-character preview and had to re-read the file,
   which spent back most of what retrieval saved. Porcelain output is
   unchanged. Follow-ups this unblocks:
-  - Feed chunk content to the rerankers. `_build_rerank_document` still scores
-    against filename, path, and the truncated preview, so rerank quality is
-    capped by preview length. Changing it shifts existing result ordering, so
-    it needs its own benchmark — and the collection API work below already
-    requires extracting that seam.
+  - Feeding chunk content to the rerankers was measured and rejected. The
+    premise was that scoring filename, path, and a 160-character preview caps
+    rerank quality. It does not: replacing the preview with the chunk's source
+    text lost on every reranker and both embedding models. MRR@10 on this
+    repository (`scripts/eval_rerank_content.py`, 30 queries, top 10,
+    bge-m3 / e5-small): remote 0.686/0.634 → 0.591/0.550, FlashRank
+    0.669/0.623 → 0.611/0.563, BM25 0.605/0.509 → 0.520/0.514. No
+    per-document cap between 300 and 2000 characters recovered it, and
+    neither did keeping the preview alongside the body. A preview is not just
+    a truncated chunk: for `code` and `outline` chunks it leads with the
+    symbol signature or heading breadcrumb, which is the most discriminative
+    text available, and the body dilutes it while the reranker truncates
+    anyway (FlashRank at 256 tokens). Re-run the script before revisiting —
+    the query set is small and code-heavy, and a prose corpus, where a
+    preview really is only the first 160 characters, may not behave the same.
+    The `(query, documents) -> [(index, score)]` seam the experiment needed
+    was extracted anyway, since the collection API below depends on it.
   - The token-cost evaluation below is only worth running after this: with
     path-only results, agent+Vexor could not show much saving over grep
     because the follow-up reads dominated.
@@ -99,13 +111,12 @@ never leaving the machine.
     Resolve the query embedding through the shared `embedding_cache`; the
     per-index `query_cache` layer is index-scoped and not worth
     duplicating here.
-  - Reranker seam: extract the result-agnostic core of the three
-    `_apply_*_rerank` functions into a helper that takes
-    `(query, documents)` and returns ranked `(index, score)` pairs. The
-    file path stays inside `_build_rerank_document` and collections pass
-    record text instead. This is a behavior-preserving refactor guarded
-    by the existing `tests/unit/test_search_service.py` cases, and it is
-    the only change to a code path users already depend on.
+  - Reranker seam (done): `_rank_documents_bm25`,
+    `_rank_documents_flashrank`, and `_rank_documents_remote` take
+    `(query, documents)` and return ranked `(index, score)` pairs, and
+    `_apply_ranking` maps those back onto results. The file path stays
+    inside `_build_rerank_document`; collections build documents from
+    record text and reuse the three rankers unchanged.
   - Surface: `vexor/collection_store.py` for the SQLite layer beside
     `cache.py`, `vexor/services/collection_service.py` for orchestration,
     and a `VexorClient.collection(name)` handle exposing `upsert_many`,
@@ -117,8 +128,8 @@ never leaving the machine.
     the existing `_resolve_settings` so config precedence matches every
     other entry point. Results are a
     `RecordResult(id, text, metadata, score)`.
-  - Delivery: land the reranker refactor first as its own PR, then the
-    store, service, and Python API with tests, then
+  - Delivery: the reranker refactor has landed, so next are the store,
+    service, and Python API with tests, then
     `vexor collection list|info|search|delete|drop` plus an
     `upsert --json -` NDJSON stdin path for bulk import from a database
     dump. Tests must cover strict pre-filtering (a record ranked first

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,10 +19,12 @@ never leaving the machine.
   - Feeding chunk content to the rerankers was measured and rejected. The
     premise was that scoring filename, path, and a 160-character preview caps
     rerank quality. It does not: replacing the preview with the chunk's source
-    text lost on every reranker and both embedding models. MRR@10 on this
-    repository (`scripts/eval_rerank_content.py`, 30 queries, top 10,
-    bge-m3 / e5-small): remote 0.686/0.634 → 0.591/0.550, FlashRank
-    0.669/0.623 → 0.611/0.563, BM25 0.605/0.509 → 0.520/0.514. No
+    text lost on five of the six reranker × embedding-model pairs and was flat
+    on the sixth. MRR@10 on this repository
+    (`scripts/eval_rerank_content.py`, 30 queries, top 10, bge-m3 / e5-small):
+    remote 0.686/0.634 → 0.579/0.550, FlashRank 0.669/0.623 → 0.611/0.564,
+    BM25 0.605/0.509 → 0.546/0.514 — the one non-loss, BM25 on e5-small, moves
+    less than a single query's rank change is worth on a set this size. No
     per-document cap between 300 and 2000 characters recovered it, and
     neither did keeping the preview alongside the body. A preview is not just
     a truncated chunk: for `code` and `outline` chunks it leads with the

--- a/plugins/vexor/skills/vexor-cli/SKILL.md
+++ b/plugins/vexor/skills/vexor-cli/SKILL.md
@@ -103,5 +103,5 @@ vexor search "where JWT claims are validated" --path . --mode code --content
   some snapshot scans. Watcher setup failures fall back to scanning. Separate
   CLI invocations still validate the filesystem. Use longer timeouts if needed.
 - Results return similarity ranking, exact file location, line numbers, and matching snippet preview.
-- Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
+- Add `--content` (or `--format json`) to get the matching source text in the same call, and skip reading those files separately. The text sits at `content_start_line`..`content_end_line`, which can begin later than the result's `start_line` when a long symbol was indexed as several chunks. If a result shows `stale_line_range`, the file changed since indexing — re-run `vexor index`. Content is capped per response, so lower-ranked results may report `budget_exhausted`.
 - Combine `--ext` with `--exclude-pattern` to focus on a subset (exclude rules apply on top).

--- a/scripts/_eval_common.py
+++ b/scripts/_eval_common.py
@@ -1,0 +1,55 @@
+"""Shared helpers for the retrieval evaluation scripts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_QUERIES = Path(__file__).with_name("eval_queries.jsonl")
+
+
+def load_queries(path: Path) -> list[dict[str, str]]:
+    queries: list[dict[str, str]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            item = json.loads(line)
+            if not isinstance(item.get("query"), str) or not isinstance(
+                item.get("expected"), str
+            ):
+                raise ValueError(f"Invalid query record on line {line_number}")
+            queries.append(item)
+    return queries
+
+
+def relative_result_paths(response, root: Path) -> list[str]:
+    paths: list[str] = []
+    for result in response.results:
+        try:
+            relative = result.path.resolve().relative_to(root)
+        except ValueError:
+            relative = result.path
+        paths.append(relative.as_posix())
+    return paths
+
+
+def metrics(details: Sequence[dict[str, object]]) -> dict[str, float]:
+    count = len(details)
+    if not count:
+        return {"mrr_at_10": 0.0, "hit_at_1": 0.0, "hit_at_5": 0.0}
+    reciprocal_sum = 0.0
+    hit_one = 0
+    hit_five = 0
+    for detail in details:
+        rank = detail["rank"]
+        if isinstance(rank, int) and rank <= 10:
+            reciprocal_sum += 1.0 / rank
+        hit_one += int(rank == 1)
+        hit_five += int(isinstance(rank, int) and rank <= 5)
+    return {
+        "mrr_at_10": reciprocal_sum / count,
+        "hit_at_1": hit_one / count,
+        "hit_at_5": hit_five / count,
+    }

--- a/scripts/eval_hybrid.py
+++ b/scripts/eval_hybrid.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Sequence
+
+from _eval_common import DEFAULT_QUERIES, load_queries, metrics, relative_result_paths
 
 from vexor import api
 from vexor.config import DEFAULT_LOCAL_MODEL, load_config
@@ -20,60 +21,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--top", type=int, default=10)
     parser.add_argument("--provider")
     parser.add_argument("--model")
-    parser.add_argument(
-        "--queries",
-        type=Path,
-        default=Path(__file__).with_name("eval_queries.jsonl"),
-    )
+    parser.add_argument("--queries", type=Path, default=DEFAULT_QUERIES)
     parser.add_argument("--json", action="store_true", dest="as_json")
     parser.add_argument("--verbose", action="store_true")
     return parser.parse_args()
-
-
-def _load_queries(path: Path) -> list[dict[str, str]]:
-    queries: list[dict[str, str]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for line_number, line in enumerate(handle, start=1):
-            if not line.strip():
-                continue
-            item = json.loads(line)
-            if not isinstance(item.get("query"), str) or not isinstance(
-                item.get("expected"), str
-            ):
-                raise ValueError(f"Invalid query record on line {line_number}")
-            queries.append(item)
-    return queries
-
-
-def _relative_result_paths(response, root: Path) -> list[str]:
-    paths: list[str] = []
-    for result in response.results:
-        try:
-            relative = result.path.resolve().relative_to(root)
-        except ValueError:
-            relative = result.path
-        paths.append(relative.as_posix())
-    return paths
-
-
-def _metrics(details: Sequence[dict[str, object]]) -> dict[str, float]:
-    count = len(details)
-    if not count:
-        return {"mrr_at_10": 0.0, "hit_at_1": 0.0, "hit_at_5": 0.0}
-    reciprocal_sum = 0.0
-    hit_one = 0
-    hit_five = 0
-    for detail in details:
-        rank = detail["rank"]
-        if isinstance(rank, int) and rank <= 10:
-            reciprocal_sum += 1.0 / rank
-        hit_one += int(rank == 1)
-        hit_five += int(isinstance(rank, int) and rank <= 5)
-    return {
-        "mrr_at_10": reciprocal_sum / count,
-        "hit_at_1": hit_one / count,
-        "hit_at_5": hit_five / count,
-    }
 
 
 def main() -> int:
@@ -93,7 +44,7 @@ def main() -> int:
     }
     api.index(**common)
 
-    queries = _load_queries(args.queries)
+    queries = load_queries(args.queries)
     by_arm: dict[str, list[dict[str, object]]] = {arm: [] for arm in ARMS}
     for item in queries:
         for arm in ARMS:
@@ -104,7 +55,7 @@ def main() -> int:
                 config={"rerank": arm},
                 **common,
             )
-            returned = _relative_result_paths(response, root)
+            returned = relative_result_paths(response, root)
             try:
                 rank: int | None = returned.index(item["expected"]) + 1
             except ValueError:
@@ -122,7 +73,7 @@ def main() -> int:
         "query_count": len(queries),
         "top": args.top,
         "arms": {
-            arm: {"metrics": _metrics(details), "queries": details}
+            arm: {"metrics": metrics(details), "queries": details}
             for arm, details in by_arm.items()
         },
     }
@@ -133,10 +84,10 @@ def main() -> int:
     print("| Rerank | MRR@10 | Hit@1 | Hit@5 |")
     print("|---|---:|---:|---:|")
     for arm in ARMS:
-        metrics = output["arms"][arm]["metrics"]
+        summary = output["arms"][arm]["metrics"]
         print(
-            f"| {arm} | {metrics['mrr_at_10']:.3f} | "
-            f"{metrics['hit_at_1']:.3f} | {metrics['hit_at_5']:.3f} |"
+            f"| {arm} | {summary['mrr_at_10']:.3f} | "
+            f"{summary['hit_at_1']:.3f} | {summary['hit_at_5']:.3f} |"
         )
     if args.verbose:
         for item in queries:

--- a/scripts/eval_rerank_content.py
+++ b/scripts/eval_rerank_content.py
@@ -1,0 +1,285 @@
+"""Measure whether the rerankers do better on chunk source text than on previews.
+
+Every reranker scores a document built from the filename, the path, and the stored
+160-character preview. Chunk text became readable at search time in 0.27.0, so the
+roadmap asked whether feeding that text to the rerankers instead lifts ranking
+quality; result ordering shifts either way, so the question needed a measurement.
+
+Each arm reruns the same query set with a different per-document character cap.
+``--chars 0`` is the shipped preview behavior; any other value patches the reranker's
+document builder to read the chunk back out of the file, the way ``search --content``
+does, and score that instead.
+
+Recorded result on this repository (30 queries, top 10, MRR@10):
+
+    | Rerank    | Doc chars | bge-m3 | e5-small |
+    |-----------|-----------|--------|----------|
+    | off       | -         | 0.628  | 0.611    |
+    | remote    | preview   | 0.686  | 0.634    |
+    | remote    | 1000      | 0.591  | 0.550    |
+    | flashrank | preview   | 0.669  | 0.623    |
+    | flashrank | 1000      | 0.611  | 0.563    |
+    | bm25      | preview   | 0.605  | 0.509    |
+    | bm25      | 1000      | 0.520  | 0.514    |
+
+No cap between 300 and 2000 characters beat the preview on any reranker, so
+the change was not shipped. See docs/roadmap.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Sequence
+
+from _eval_common import DEFAULT_QUERIES, load_queries, metrics, relative_result_paths
+
+from vexor import api
+from vexor.config import DEFAULT_LOCAL_MODEL, load_config
+from vexor.services import search_service
+from vexor.services.content_extract_service import read_chunk_content
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", type=Path, default=Path("."), help="Repository root")
+    parser.add_argument("--mode", default="auto")
+    parser.add_argument("--top", type=int, default=10)
+    parser.add_argument("--provider")
+    parser.add_argument("--model")
+    parser.add_argument(
+        "--rerank",
+        nargs="+",
+        default=["bm25"],
+        choices=["bm25", "flashrank", "remote"],
+        help="Rerankers to evaluate",
+    )
+    parser.add_argument(
+        "--chars",
+        nargs="+",
+        type=int,
+        default=[0, 1000],
+        help="Per-document chunk text caps to compare (0 = stored preview)",
+    )
+    parser.add_argument(
+        "--unverified",
+        action="store_true",
+        help="Skip the preview check on re-read text, so no candidate falls back",
+    )
+    parser.add_argument("--queries", type=Path, default=DEFAULT_QUERIES)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args()
+
+
+def _chunk_text(result, *, chars: int, verify: bool) -> str | None:
+    if result.start_line is None or result.end_line is None:
+        return None
+    try:
+        chunk = read_chunk_content(
+            result.path,
+            result.start_line,
+            result.end_line,
+            max_chars=chars,
+            anchor=search_service._chunk_window_anchor(result.preview),
+        )
+    except OSError:
+        return None
+    if chunk is None:
+        return None
+    if verify and not search_service._content_matches_preview(chunk.text, result.preview):
+        return None
+    return chunk.text
+
+
+def _content_document(result, content: str) -> str:
+    """The shipped document shape, with the chunk body in place of the preview.
+
+    The preview is a 160-character prefix of the same text, so only what it adds is
+    kept: ``code`` and ``outline`` previews carry a ``display :: snippet`` prefix
+    naming the symbol or heading, which the file text itself does not repeat.
+    """
+
+    label = ""
+    if result.preview:
+        head, separator, _ = result.preview.rpartition(" :: ")
+        label = head.strip() if separator else ""
+    identity = f"{result.path.name} {result.path.as_posix()} {label}".strip()
+    return f"{identity}\n{content}"
+
+
+class _Meter:
+    """Count the characters each arm hands to its reranker."""
+
+    def __init__(self) -> None:
+        self.documents = 0
+        self.characters = 0
+
+    def record(self, documents: Sequence[str]) -> Sequence[str]:
+        self.documents += len(documents)
+        self.characters += sum(len(document) for document in documents)
+        return documents
+
+    @property
+    def chars_per_document(self) -> float:
+        return self.characters / max(self.documents, 1)
+
+
+@contextmanager
+def _rerank_documents(*, chars: int, verify: bool) -> Iterator[_Meter]:
+    """Swap in chunk-text documents for the duration of one arm."""
+
+    meter = _Meter()
+    shipped = search_service._build_rerank_documents
+
+    def patched(results):
+        if chars <= 0:
+            return meter.record(shipped(results))
+        documents = []
+        for result in results:
+            content = _chunk_text(result, chars=chars, verify=verify)
+            documents.append(
+                _content_document(result, content)
+                if content
+                else search_service._build_rerank_document(result)
+            )
+        return meter.record(documents)
+
+    search_service._build_rerank_documents = patched
+    try:
+        yield meter
+    finally:
+        search_service._build_rerank_documents = shipped
+
+
+def _run_arm(
+    queries: Sequence[dict[str, str]],
+    *,
+    rerank: str,
+    chars: int,
+    verify: bool,
+    top: int,
+    common: dict[str, object],
+    root: Path,
+) -> dict[str, object]:
+    details: list[dict[str, object]] = []
+    started = time.perf_counter()
+    with _rerank_documents(chars=chars, verify=verify) as meter:
+        for item in queries:
+            response = api.search(
+                item["query"],
+                top=top,
+                auto_index=False,
+                config={"rerank": rerank},
+                **common,
+            )
+            returned = relative_result_paths(response, root)
+            try:
+                rank: int | None = returned.index(item["expected"]) + 1
+            except ValueError:
+                rank = None
+            details.append(
+                {
+                    "query": item["query"],
+                    "expected": item["expected"],
+                    "rank": rank,
+                    "results": returned,
+                }
+            )
+    elapsed = time.perf_counter() - started
+    return {
+        "rerank": rerank,
+        "chars": chars,
+        "metrics": metrics(details),
+        "seconds_per_query": elapsed / max(len(queries), 1),
+        "chars_per_document": meter.chars_per_document,
+        "queries": details,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    root = args.path.expanduser().resolve()
+    config = load_config()
+    provider = args.provider or config.provider
+    model = args.model or config.model
+    if provider == "local" and args.model is None:
+        model = DEFAULT_LOCAL_MODEL
+    common = {
+        "path": root,
+        "mode": args.mode,
+        "provider": provider,
+        "model": model,
+        "use_config": True,
+    }
+    api.index(**common)
+    queries = load_queries(args.queries)
+
+    arms = [
+        _run_arm(
+            queries,
+            rerank="off",
+            chars=0,
+            verify=True,
+            top=args.top,
+            common=common,
+            root=root,
+        )
+    ]
+    for rerank in args.rerank:
+        for chars in args.chars:
+            arms.append(
+                _run_arm(
+                    queries,
+                    rerank=rerank,
+                    chars=chars,
+                    verify=not args.unverified,
+                    top=args.top,
+                    common=common,
+                    root=root,
+                )
+            )
+
+    output = {
+        "query_count": len(queries),
+        "top": args.top,
+        "provider": provider,
+        "model": model,
+        "verified": not args.unverified,
+        "arms": arms,
+    }
+    if args.as_json:
+        print(json.dumps(output, indent=2))
+        return 0
+
+    print(f"provider={provider} model={model} queries={len(queries)} top={args.top}")
+    print("| Rerank | Doc chars | MRR@10 | Hit@1 | Hit@5 | Avg doc | s/query |")
+    print("|---|---:|---:|---:|---:|---:|---:|")
+    for arm in arms:
+        summary = arm["metrics"]
+        if arm["rerank"] == "off":
+            label, cap = "off (dense)", "-"
+        else:
+            label = arm["rerank"]
+            cap = "preview" if not arm["chars"] else str(arm["chars"])
+        print(
+            f"| {label} | {cap} | {summary['mrr_at_10']:.3f} | "
+            f"{summary['hit_at_1']:.3f} | {summary['hit_at_5']:.3f} | "
+            f"{arm['chars_per_document']:.0f} | {arm['seconds_per_query']:.2f} |"
+        )
+    if args.verbose:
+        for index, item in enumerate(queries):
+            ranks = []
+            for arm in arms:
+                cap = "preview" if not arm["chars"] else str(arm["chars"])
+                name = "off" if arm["rerank"] == "off" else f"{arm['rerank']}/{cap}"
+                ranks.append(f"{name}={arm['queries'][index]['rank'] or '-'}")
+            print(f"- {item['query']} -> {item['expected']} ({', '.join(ranks)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval_rerank_content.py
+++ b/scripts/eval_rerank_content.py
@@ -16,14 +16,16 @@ Recorded result on this repository (30 queries, top 10, MRR@10):
     |-----------|-----------|--------|----------|
     | off       | -         | 0.628  | 0.611    |
     | remote    | preview   | 0.686  | 0.634    |
-    | remote    | 1000      | 0.591  | 0.550    |
+    | remote    | 1000      | 0.579  | 0.550    |
     | flashrank | preview   | 0.669  | 0.623    |
-    | flashrank | 1000      | 0.611  | 0.563    |
+    | flashrank | 1000      | 0.611  | 0.564    |
     | bm25      | preview   | 0.605  | 0.509    |
-    | bm25      | 1000      | 0.520  | 0.514    |
+    | bm25      | 1000      | 0.546  | 0.514    |
 
 No cap between 300 and 2000 characters beat the preview on any reranker, so
-the change was not shipped. See docs/roadmap.md.
+the change was not shipped. See docs/roadmap.md. The corpus is this repository,
+so the absolute numbers move as it changes; the gap between the columns is what
+the arms are being compared on.
 """
 
 from __future__ import annotations
@@ -75,16 +77,18 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _chunk_text(result, *, chars: int, verify: bool) -> str | None:
+def _chunk_text(result, *, chars: int, verify: bool, mode: str) -> str | None:
     if result.start_line is None or result.end_line is None:
         return None
+    anchor, anchor_offset = search_service._chunk_window_anchor(result, mode) or ("", 0)
     try:
         chunk = read_chunk_content(
             result.path,
             result.start_line,
             result.end_line,
             max_chars=chars,
-            anchor=search_service._chunk_window_anchor(result.preview),
+            anchor=anchor,
+            anchor_offset=anchor_offset,
         )
     except OSError:
         return None
@@ -129,7 +133,7 @@ class _Meter:
 
 
 @contextmanager
-def _rerank_documents(*, chars: int, verify: bool) -> Iterator[_Meter]:
+def _rerank_documents(*, chars: int, verify: bool, mode: str) -> Iterator[_Meter]:
     """Swap in chunk-text documents for the duration of one arm."""
 
     meter = _Meter()
@@ -140,7 +144,7 @@ def _rerank_documents(*, chars: int, verify: bool) -> Iterator[_Meter]:
             return meter.record(shipped(results))
         documents = []
         for result in results:
-            content = _chunk_text(result, chars=chars, verify=verify)
+            content = _chunk_text(result, chars=chars, verify=verify, mode=mode)
             documents.append(
                 _content_document(result, content)
                 if content
@@ -167,7 +171,7 @@ def _run_arm(
 ) -> dict[str, object]:
     details: list[dict[str, object]] = []
     started = time.perf_counter()
-    with _rerank_documents(chars=chars, verify=verify) as meter:
+    with _rerank_documents(chars=chars, verify=verify, mode=str(common["mode"])) as meter:
         for item in queries:
             response = api.search(
                 item["query"],

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -50,6 +50,9 @@ def test_cli_small_helpers_and_version_callback(capsys):
 
 
 def test_cli_flashrank_prepare_success_and_errors(monkeypatch, tmp_path):
+    # See test_search_service_extra: assert the missing-extra path deterministically
+    # rather than relying on ``flashrank`` being absent from the environment.
+    monkeypatch.setitem(sys.modules, "flashrank", None)
     with pytest.raises(RuntimeError):
         cli._prepare_flashrank_model(None)
 

--- a/tests/unit/test_content_extract_service.py
+++ b/tests/unit/test_content_extract_service.py
@@ -33,6 +33,41 @@ def test_read_chunk_content_preserves_indentation(tmp_path):
     assert chunk.truncated is False
 
 
+def test_read_chunk_content_starts_at_the_anchor(tmp_path):
+    source = tmp_path / "mod.py"
+    source.write_text(
+        "def outer():\n\n    first = compute()\n    second = refine(first)\n",
+        encoding="utf-8",
+    )
+
+    chunk = read_chunk_content(source, 1, 4, max_chars=1000, anchor="second = refine")
+
+    assert chunk.text == "    second = refine(first)"
+    assert (chunk.start_line, chunk.end_line) == (4, 4)
+
+
+def test_read_chunk_content_ignores_an_anchor_it_cannot_find(tmp_path):
+    source = tmp_path / "mod.py"
+    source.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    chunk = read_chunk_content(source, 1, 2, max_chars=1000, anchor="gamma")
+
+    assert chunk.start_line == 1
+    assert chunk.text == "alpha\nbeta"
+
+
+def test_locate_anchor_line_matches_across_the_flattened_lines():
+    lines = ["def outer():", "", "    value = compute(", "        argument,", "    )"]
+
+    # Blank lines drop out and the rest join with single spaces, so an anchor can
+    # span what were two lines in the file.
+    assert ces.locate_anchor_line(lines, "compute( argument,") == 2
+    assert ces.locate_anchor_line(lines, "def outer():") == 0
+    assert ces.locate_anchor_line(lines, "missing") == 0
+    assert ces.locate_anchor_line(lines, "") == 0
+    assert ces.locate_anchor_line([], "anything") == 0
+
+
 def test_read_chunk_content_truncates_on_line_boundary(tmp_path):
     source = tmp_path / "long.txt"
     source.write_text("".join(f"line-{idx}\n" for idx in range(30)), encoding="utf-8")

--- a/tests/unit/test_modes_misc.py
+++ b/tests/unit/test_modes_misc.py
@@ -13,6 +13,26 @@ def test_get_strategy_rejects_invalid_mode():
         modes.get_strategy("nope")
 
 
+def test_code_chunk_extensions_match_the_parsers():
+    """The search path reads this set to know which previews carry chunk markers.
+
+    Teaching a new language to the AST chunkers without adding it here would leave
+    those files' split windows reading back as their symbol's first window.
+    """
+    from vexor.services.js_parser import JSTS_EXTENSIONS
+
+    assert modes.CODE_CHUNK_EXTENSIONS == JSTS_EXTENSIONS | {".py"}
+
+
+def test_uses_code_chunking_follows_the_strategy_that_ran():
+    assert modes.uses_code_chunking("auto", Path("a.py")) is True
+    assert modes.uses_code_chunking("code", Path("a.tsx")) is True
+    # `code` mode falls back to full chunking for anything the parsers refuse.
+    assert modes.uses_code_chunking("code", Path("notes.txt")) is False
+    assert modes.uses_code_chunking("full", Path("a.py")) is False
+    assert modes.uses_code_chunking(None, Path("a.py")) is False
+
+
 def test_available_modes_contains_auto_and_is_sorted():
     available = modes.available_modes()
     assert "auto" in available

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -1292,6 +1292,74 @@ def test_content_is_read_back_with_original_indentation(tmp_path: Path) -> None:
     assert budget.used == len(results[0].content)
 
 
+def _split_chunk_source(tmp_path: Path) -> Path:
+    source = tmp_path / "registry.py"
+    lines = ["class Registry:"]
+    lines += [
+        f'    SETTING_{index} = "value number {index} for the registry entry"'
+        for index in range(40)
+    ]
+    source.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return source
+
+
+def test_split_chunk_windows_read_back_their_own_lines(tmp_path: Path) -> None:
+    """Each window of a split chunk must return its own text, not the first window's.
+
+    A chunk too long to embed in one piece is split into overlapping windows that
+    all store their symbol's line range, so reading from the range's first line
+    returns window 1 for every one of them -- identical content on several results,
+    and a preview check that then reports the index as stale.
+    """
+    source = _split_chunk_source(tmp_path)
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": 'class Registry: [#1] :: class Registry: SETTING_0 = "value number 0 for the registry entry"',
+            "start_line": 1,
+            "end_line": 41,
+        },
+        {
+            "chunk_index": 1,
+            "preview": 'class Registry: [#2] :: SETTING_20 = "value number 20 for the registry entry" SETTING_21 =',
+            "start_line": 1,
+            "end_line": 41,
+        },
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source, source], chunks)
+
+    first, second = results[0], results[1]
+    assert [item.content_unavailable for item in results] == [None, None]
+    assert first.content_start_line == 1
+    assert first.content.startswith("class Registry:")
+    assert second.content_start_line == 22
+    assert second.content.startswith('    SETTING_20 = "value number 20')
+    assert first.content != second.content
+
+
+def test_content_is_not_anchored_for_chunks_with_real_line_ranges(tmp_path: Path) -> None:
+    """Only split windows are anchored; an outline chunk keeps its heading."""
+    source = tmp_path / "guide.md"
+    source.write_text(
+        "## Providers\n\nThe provider table lists every supported backend.\n",
+        encoding="utf-8",
+    )
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": "Providers :: The provider table lists every supported backend.",
+            "start_line": 1,
+            "end_line": 3,
+        }
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source], chunks)
+
+    assert results[0].content_start_line == 1
+    assert results[0].content.startswith("## Providers")
+
+
 def test_content_absent_when_not_requested(tmp_path: Path) -> None:
     source = tmp_path / "a.txt"
     source.write_text("alpha beta gamma\n", encoding="utf-8")

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -1327,7 +1327,9 @@ def test_split_chunk_windows_read_back_their_own_lines(tmp_path: Path) -> None:
         },
     ]
 
-    results, _, _ = _rank_with_content(_content_request(tmp_path), [source, source], chunks)
+    results, _, _ = _rank_with_content(
+        _content_request(tmp_path, mode="code"), [source, source], chunks
+    )
 
     first, second = results[0], results[1]
     assert [item.content_unavailable for item in results] == [None, None]
@@ -1336,6 +1338,44 @@ def test_split_chunk_windows_read_back_their_own_lines(tmp_path: Path) -> None:
     assert second.content_start_line == 22
     assert second.content.startswith('    SETTING_20 = "value number 20')
     assert first.content != second.content
+
+
+def test_split_window_anchor_prefers_the_occurrence_at_its_own_offset(
+    tmp_path: Path,
+) -> None:
+    """Repeated code must not pull a later window back to an earlier copy of itself."""
+    source = tmp_path / "handlers.py"
+    body = [
+        "        respect_gitignore=respect_gitignore,",
+        "        include_hidden=include_hidden,",
+    ]
+    lines = ["def dispatch():"]
+    for index in range(3):
+        lines.append(f"    branch_{index} = call(")
+        lines.extend(body)
+        lines.append("    )")
+        lines.extend(f"    filler_{index}_{step} = {step}" for step in range(30))
+    source.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    # The anchor also occurs in branch 0 at line 2; window 3 starts in branch 2.
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": (
+                "def dispatch(): [#3] :: respect_gitignore=respect_gitignore, "
+                "include_hidden=include_hidden,"
+            ),
+            "start_line": 1,
+            "end_line": len(lines),
+        }
+    ]
+
+    results, _, _ = _rank_with_content(
+        _content_request(tmp_path, mode="code"), [source], chunks
+    )
+
+    assert results[0].content_unavailable is None
+    assert results[0].content_start_line > 60
 
 
 def test_content_is_not_anchored_for_chunks_with_real_line_ranges(tmp_path: Path) -> None:
@@ -1358,6 +1398,38 @@ def test_content_is_not_anchored_for_chunks_with_real_line_ranges(tmp_path: Path
 
     assert results[0].content_start_line == 1
     assert results[0].content.startswith("## Providers")
+
+
+def test_file_text_that_looks_like_a_window_marker_is_not_anchored(
+    tmp_path: Path,
+) -> None:
+    """A `[#N] :: ` inside indexed text is file content, not a chunking marker.
+
+    `full` mode flattens raw file text into the preview, so a file that documents
+    the marker format would otherwise be anchored and lose its leading lines.
+    """
+    source = tmp_path / "notes.txt"
+    source.write_text(
+        "Chunk previews look like\nthis: 'class Registry: [#1] :: class Registry:'\n"
+        "and the marker is only meaningful in code mode.\n",
+        encoding="utf-8",
+    )
+    chunks = [
+        {
+            "chunk_index": 0,
+            "preview": (
+                "Chunk previews look like this: 'class Registry: [#1] :: class Registry:' "
+                "and the marker is only meaningful in code mode."
+            ),
+            "start_line": 1,
+            "end_line": 3,
+        }
+    ]
+
+    results, _, _ = _rank_with_content(_content_request(tmp_path), [source], chunks)
+
+    assert results[0].content_start_line == 1
+    assert results[0].content.startswith("Chunk previews look like")
 
 
 def test_content_absent_when_not_requested(tmp_path: Path) -> None:

--- a/tests/unit/test_search_service_extra.py
+++ b/tests/unit/test_search_service_extra.py
@@ -47,6 +47,30 @@ def test_rank_documents_bm25_is_independent_of_search_results():
     assert all(0.0 <= score <= 1.0 for _, score in ranking)
 
 
+def test_rank_documents_bm25_rejects_mismatched_score_count():
+    """Documents and scores are built separately, so a mismatch has to be loud.
+
+    Zipping them would silently rank only the shorter half and leave the rest
+    holding unfused retrieval scores.
+    """
+    with pytest.raises(ValueError, match="line up"):
+        search_service._rank_documents_bm25("alpha", ["one", "two"], [0.5])
+
+
+def test_rank_documents_answer_an_empty_document_list_locally(monkeypatch):
+    """Neither ranker should load a model or call a provider to rank nothing."""
+
+    def fail(**_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("no request should be sent")
+
+    monkeypatch.setattr(search_service, "_remote_rerank_request", fail)
+    monkeypatch.setitem(sys.modules, "flashrank", None)
+    search_service._get_flashranker.cache_clear()
+
+    assert search_service._rank_documents_remote("alpha", [], None) == []
+    assert search_service._rank_documents_flashrank("alpha", [], None) == []
+
+
 def test_apply_ranking_drops_bad_indices_and_keeps_the_tail():
     results = [_result("a.txt", 0.1), _result("b.txt", 0.2), _result("c.txt", 0.3)]
 
@@ -85,6 +109,7 @@ def test_flashrank_rerank_import_error_and_success(monkeypatch, tmp_path):
             assert request.query == "alpha"
             return [
                 {"id": None, "score": 0.0},
+                {"id": "not-an-index", "score": 0.0},
                 {"id": 99, "score": 0.0},
                 {"id": 1, "score": 0.95},
             ]

--- a/tests/unit/test_search_service_extra.py
+++ b/tests/unit/test_search_service_extra.py
@@ -62,6 +62,11 @@ def test_apply_ranking_drops_bad_indices_and_keeps_the_tail():
 
 
 def test_flashrank_rerank_import_error_and_success(monkeypatch, tmp_path):
+    # Simulate the extra being absent instead of depending on it being absent: a
+    # ``None`` entry in sys.modules makes the import raise whether or not the
+    # machine running the suite has ``flashrank`` installed.
+    monkeypatch.setitem(sys.modules, "flashrank", None)
+    search_service._get_flashranker.cache_clear()
     with pytest.raises(RuntimeError):
         search_service._apply_flashrank_rerank("q", [_result("a.txt", 0.1)], None)
 

--- a/tests/unit/test_search_service_extra.py
+++ b/tests/unit/test_search_service_extra.py
@@ -35,6 +35,32 @@ def test_bm25_helpers_fallbacks(monkeypatch):
     ]
 
 
+def test_rank_documents_bm25_is_independent_of_search_results():
+    documents = ["alpha alpha beta", "gamma delta", "beta gamma"]
+    base_scores = [0.1, 0.9, 0.2]
+
+    assert search_service._rank_documents_bm25("", documents, base_scores) is None
+
+    ranking = search_service._rank_documents_bm25("alpha", documents, base_scores)
+
+    assert [index for index, _ in ranking] == [1, 0, 2]
+    assert all(0.0 <= score <= 1.0 for _, score in ranking)
+
+
+def test_apply_ranking_drops_bad_indices_and_keeps_the_tail():
+    results = [_result("a.txt", 0.1), _result("b.txt", 0.2), _result("c.txt", 0.3)]
+
+    ordered = search_service._apply_ranking(
+        results,
+        [(2, 0.9), (99, 1.0), (-1, 1.0), (2, 0.5), (0, None)],
+    )
+
+    assert [item.path.name for item in ordered] == ["c.txt", "a.txt", "b.txt"]
+    assert ordered[0].score == 0.9
+    # A reranker that returns no score leaves the retrieval score in place.
+    assert ordered[1].score == 0.1
+
+
 def test_flashrank_rerank_import_error_and_success(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError):
         search_service._apply_flashrank_rerank("q", [_result("a.txt", 0.1)], None)

--- a/vexor/modes.py
+++ b/vexor/modes.py
@@ -24,6 +24,22 @@ from .services.keyword_service import (
 PREVIEW_CHAR_LIMIT = 160
 BRIEF_PREVIEW_LIMIT = 10
 
+# Extensions `CodeStrategy` can chunk by syntax; anything else falls back to
+# `FullStrategy` even under `--mode code`. The search path reads this to tell a
+# `display [#N] :: snippet` preview apart from file text that merely looks like one.
+# ``test_code_chunk_extensions_match_the_parsers`` pins it to the parsers.
+CODE_CHUNK_EXTENSIONS = frozenset(
+    {".py", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}
+)
+
+
+def uses_code_chunking(mode: str | None, file: Path) -> bool:
+    """Report whether *file* was chunked by :class:`CodeStrategy` under *mode*."""
+
+    if (mode or "").strip().lower() not in {"auto", "code"}:
+        return False
+    return file.suffix.lower() in CODE_CHUNK_EXTENSIONS
+
 
 @dataclass(slots=True)
 class ModePayload:
@@ -251,9 +267,7 @@ class AutoStrategy(IndexModeStrategy):
 
     def _payloads_for_file(self, file: Path) -> list[ModePayload]:
         suffix = file.suffix.lower()
-        if suffix == ".py":
-            return self.code.payloads_for_files([file])
-        if suffix in {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}:
+        if suffix in CODE_CHUNK_EXTENSIONS:
             return self.code.payloads_for_files([file])
         if suffix in {".md", ".markdown", ".mdx"}:
             return self.outline.payloads_for_files([file])

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import ast
 import codecs
-from bisect import bisect_left
+from bisect import bisect_left, bisect_right
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Protocol
+from typing import Dict, Protocol, Sequence
 
 HEAD_CHAR_LIMIT = 1000
 # Also bounds how far ``read_chunk_content`` will read back: no indexer chunks past
@@ -286,12 +286,46 @@ def _read_text_through_line(path: Path, last_line: int) -> str | None:
     return text or None
 
 
+def locate_anchor_line(lines: Sequence[str], anchor: str) -> int:
+    """Return the index within *lines* where *anchor* starts, or 0 when absent.
+
+    *anchor* is matched against the lines flattened the way previews are stored --
+    stripped, blank lines dropped, joined by single spaces -- because that is the
+    form the caller has to anchor with.
+    """
+
+    if not anchor:
+        return 0
+    starts: list[int] = []
+    line_indices: list[int] = []
+    parts: list[str] = []
+    position = 0
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if parts:
+            # The space the join puts between two lines.
+            position += 1
+        starts.append(position)
+        line_indices.append(index)
+        parts.append(stripped)
+        position += len(stripped)
+    if not parts:
+        return 0
+    found = " ".join(parts).find(anchor)
+    if found < 0:
+        return 0
+    return line_indices[max(bisect_right(starts, found) - 1, 0)]
+
+
 def read_chunk_content(
     path: Path,
     start_line: int,
     end_line: int,
     *,
     max_chars: int,
+    anchor: str | None = None,
 ) -> ChunkContent | None:
     """Read lines ``start_line``..``end_line`` (1-based, inclusive) back out of *path*.
 
@@ -299,6 +333,11 @@ def read_chunk_content(
     breaks: the text is meant to be read by a caller, not embedded. Returns ``None``
     when the file cannot be read or the range does not resolve to any line, so callers
     can fall back to the stored preview instead of surfacing an error.
+
+    *anchor* moves the starting line to where that text appears inside the range. A
+    chunk too long to embed in one piece is split into overlapping windows that all
+    carry their symbol's line range, so without an anchor every window of a symbol
+    reads back as the symbol's first window.
     """
 
     if start_line < 1 or end_line < start_line or max_chars <= 0:
@@ -314,6 +353,11 @@ def read_chunk_content(
     selected = lines[start_line - 1 : end_line]
     if not selected:
         return None
+    if anchor:
+        offset = locate_anchor_line(selected, anchor)
+        if offset:
+            selected = selected[offset:]
+            start_line += offset
 
     kept: list[str] = []
     used = 0

--- a/vexor/services/content_extract_service.py
+++ b/vexor/services/content_extract_service.py
@@ -286,12 +286,24 @@ def _read_text_through_line(path: Path, last_line: int) -> str | None:
     return text or None
 
 
-def locate_anchor_line(lines: Sequence[str], anchor: str) -> int:
+def locate_anchor_line(
+    lines: Sequence[str],
+    anchor: str,
+    *,
+    expected_offset: int = 0,
+) -> int:
     """Return the index within *lines* where *anchor* starts, or 0 when absent.
 
     *anchor* is matched against the lines flattened the way previews are stored --
     stripped, blank lines dropped, joined by single spaces -- because that is the
     form the caller has to anchor with.
+
+    *expected_offset* is roughly how far into the unflattened text the caller
+    expects the match. Code repeats itself, so a 40-character anchor taken from
+    late in a symbol often occurs early in it as well; with no hint the first
+    match wins and the caller gets an earlier region that still passes every
+    downstream check. The occurrence nearest the hint is picked instead, which at
+    the default of 0 is simply the first one.
     """
 
     if not anchor:
@@ -313,7 +325,17 @@ def locate_anchor_line(lines: Sequence[str], anchor: str) -> int:
         position += len(stripped)
     if not parts:
         return 0
-    found = " ".join(parts).find(anchor)
+    flattened = " ".join(parts)
+    # Flattening drops indentation and blank lines, so an offset into the original
+    # text has to be scaled down before it means anything in this one.
+    original_length = sum(len(line) + 1 for line in lines)
+    target = expected_offset * len(flattened) / original_length if original_length else 0
+    found = -1
+    position = flattened.find(anchor)
+    while position >= 0:
+        if found < 0 or abs(position - target) < abs(found - target):
+            found = position
+        position = flattened.find(anchor, position + 1)
     if found < 0:
         return 0
     return line_indices[max(bisect_right(starts, found) - 1, 0)]
@@ -326,6 +348,7 @@ def read_chunk_content(
     *,
     max_chars: int,
     anchor: str | None = None,
+    anchor_offset: int = 0,
 ) -> ChunkContent | None:
     """Read lines ``start_line``..``end_line`` (1-based, inclusive) back out of *path*.
 
@@ -334,10 +357,11 @@ def read_chunk_content(
     when the file cannot be read or the range does not resolve to any line, so callers
     can fall back to the stored preview instead of surfacing an error.
 
-    *anchor* moves the starting line to where that text appears inside the range. A
-    chunk too long to embed in one piece is split into overlapping windows that all
-    carry their symbol's line range, so without an anchor every window of a symbol
-    reads back as the symbol's first window.
+    *anchor* moves the starting line to where that text appears inside the range,
+    and *anchor_offset* says how far into the range to expect it. A chunk too long
+    to embed in one piece is split into overlapping windows that all carry their
+    symbol's line range, so without an anchor every window of a symbol reads back
+    as the symbol's first window.
     """
 
     if start_line < 1 or end_line < start_line or max_chars <= 0:
@@ -354,7 +378,7 @@ def read_chunk_content(
     if not selected:
         return None
     if anchor:
-        offset = locate_anchor_line(selected, anchor)
+        offset = locate_anchor_line(selected, anchor, expected_offset=anchor_offset)
         if offset:
             selected = selected[offset:]
             start_line += offset

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -279,8 +279,7 @@ def _attach_chunk_content(
 
 def _build_rerank_document(result: SearchResult) -> str:
     preview = result.preview or ""
-    document = f"{result.path.name} {result.path.as_posix()} {preview}".strip()
-    return document or result.path.as_posix()
+    return f"{result.path.name} {result.path.as_posix()} {preview}".strip()
 
 
 def _build_rerank_documents(results: Sequence[SearchResult]) -> list[str]:
@@ -363,6 +362,11 @@ def _rank_documents_bm25(
     caller's original order untouched.
     """
 
+    if len(documents) != len(base_scores):
+        raise ValueError(
+            "rerank documents and base scores must line up: "
+            f"got {len(documents)} documents and {len(base_scores)} scores"
+        )
     query_tokens = _bm25_tokenize(query)
     if not query_tokens:
         return None
@@ -411,6 +415,9 @@ def _rank_documents_flashrank(
     documents: Sequence[str],
     model_name: str | None,
 ) -> list[tuple[int, float | None]]:
+    if not documents:
+        # Nothing to rank, and loading a ranker model to say so would be waste.
+        return []
     try:
         from flashrank import RerankRequest
     except ImportError as exc:
@@ -559,6 +566,10 @@ def _rank_documents_remote(
     documents: Sequence[str],
     config: RemoteRerankConfig | None,
 ) -> list[tuple[int, float | None]]:
+    if not documents:
+        # Rerank endpoints reject an empty document array, so answer locally
+        # rather than turning "nothing to rank" into a provider error.
+        return []
     resolved = _resolve_remote_rerank_config(config)
     payload = _remote_rerank_request(
         config=resolved,
@@ -580,8 +591,6 @@ def _apply_remote_rerank(
         _build_rerank_documents(results),
         config,
     )
-    if not ranking:
-        return list(results)
     return _apply_ranking(results, ranking)
 
 

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -279,7 +279,40 @@ def _attach_chunk_content(
 
 def _build_rerank_document(result: SearchResult) -> str:
     preview = result.preview or ""
-    return f"{result.path.name} {result.path.as_posix()} {preview}".strip()
+    document = f"{result.path.name} {result.path.as_posix()} {preview}".strip()
+    return document or result.path.as_posix()
+
+
+def _build_rerank_documents(results: Sequence[SearchResult]) -> list[str]:
+    return [_build_rerank_document(result) for result in results]
+
+
+def _apply_ranking(
+    results: Sequence[SearchResult],
+    ranking: Sequence[tuple[int, float | None]],
+) -> list[SearchResult]:
+    """Reorder *results* by a reranker's ``(index, score)`` pairs.
+
+    Unknown, duplicate, and out-of-range indices are dropped, and anything the
+    reranker left out keeps its original relative order at the tail, so a partial
+    response degrades to "reranked head, dense tail" instead of losing results.
+    """
+
+    ordered: list[SearchResult] = []
+    seen: set[int] = set()
+    for index, score in ranking:
+        if index < 0 or index >= len(results) or index in seen:
+            continue
+        result = results[index]
+        if score is not None:
+            result.score = float(score)
+        ordered.append(result)
+        seen.add(index)
+    if len(ordered) < len(results):
+        for index, result in enumerate(results):
+            if index not in seen:
+                ordered.append(result)
+    return ordered
 
 
 def _normalize_by_max(scores: Sequence[float]) -> list[float]:
@@ -319,26 +352,46 @@ def _bm25_scores(
     return [float(score) for score in scores]
 
 
+def _rank_documents_bm25(
+    query: str,
+    documents: Sequence[str],
+    base_scores: Sequence[float],
+) -> list[tuple[int, float]] | None:
+    """Fuse lexical scores over *documents* with the retrieval scores behind them.
+
+    Returns ``None`` when the query carries no usable tokens, which leaves the
+    caller's original order untouched.
+    """
+
+    query_tokens = _bm25_tokenize(query)
+    if not query_tokens:
+        return None
+    tokenized = [_bm25_tokenize(document) for document in documents]
+    lexical_norm = _normalize_by_max(_bm25_scores(query_tokens, tokenized))
+    base_norm = _normalize_by_max([max(score, 0.0) for score in base_scores])
+    fused = [
+        (
+            index,
+            _FUSION_SEMANTIC_WEIGHT * base
+            + (1.0 - _FUSION_SEMANTIC_WEIGHT) * lexical,
+        )
+        for index, (base, lexical) in enumerate(zip(base_norm, lexical_norm))
+    ]
+    fused.sort(key=lambda item: item[1], reverse=True)
+    return fused
+
+
 def _apply_bm25_rerank(query: str, results: Sequence[SearchResult]) -> list[SearchResult]:
     if not results:
         return []
-    query_tokens = _bm25_tokenize(query)
-    if not query_tokens:
+    ranking = _rank_documents_bm25(
+        query,
+        _build_rerank_documents(results),
+        [result.score for result in results],
+    )
+    if ranking is None:
         return list(results)
-    documents = [_bm25_tokenize(_build_rerank_document(result)) for result in results]
-    bm25_scores = _bm25_scores(query_tokens, documents)
-    semantic_scores = [max(result.score, 0.0) for result in results]
-    semantic_norm = _normalize_by_max(semantic_scores)
-    bm25_norm = _normalize_by_max(bm25_scores)
-    fused: list[SearchResult] = []
-    for result, sem_score, bm25_score in zip(results, semantic_norm, bm25_norm):
-        fused_score = _FUSION_SEMANTIC_WEIGHT * sem_score + (
-            (1.0 - _FUSION_SEMANTIC_WEIGHT) * bm25_score
-        )
-        result.score = float(fused_score)
-        fused.append(result)
-    fused.sort(key=lambda item: item.score, reverse=True)
-    return fused
+    return _apply_ranking(results, ranking)
 
 
 @lru_cache(maxsize=4)
@@ -353,13 +406,11 @@ def _get_flashranker(model_name: str | None, max_length: int):
     return Ranker(**kwargs)
 
 
-def _apply_flashrank_rerank(
+def _rank_documents_flashrank(
     query: str,
-    results: Sequence[SearchResult],
+    documents: Sequence[str],
     model_name: str | None,
-) -> list[SearchResult]:
-    if not results:
-        return []
+) -> list[tuple[int, float | None]]:
     try:
         from flashrank import RerankRequest
     except ImportError as exc:
@@ -373,32 +424,37 @@ def _apply_flashrank_rerank(
         from ..text import Messages
 
         raise RuntimeError(Messages.ERROR_FLASHRANK_MISSING) from exc
-    passages = []
-    for idx, result in enumerate(results):
-        text = _build_rerank_document(result) or result.path.as_posix()
-        passages.append({"id": idx, "text": text})
-    rerank_request = RerankRequest(query=query, passages=passages)
-    reranked = ranker.rerank(rerank_request)
-    id_to_result = {idx: result for idx, result in enumerate(results)}
-    ordered: list[SearchResult] = []
-    seen: set[int] = set()
+    passages = [
+        {"id": index, "text": document} for index, document in enumerate(documents)
+    ]
+    reranked = ranker.rerank(RerankRequest(query=query, passages=passages))
+    ranking: list[tuple[int, float | None]] = []
     for item in reranked:
-        idx = item.get("id")
-        if idx is None:
+        index = item.get("id")
+        if index is None:
             continue
-        result = id_to_result.get(idx)
-        if result is None:
+        try:
+            position = int(index)
+        except (TypeError, ValueError):
             continue
         score = item.get("score")
-        if score is not None:
-            result.score = float(score)
-        ordered.append(result)
-        seen.add(idx)
-    if len(ordered) < len(results):
-        for idx, result in enumerate(results):
-            if idx not in seen:
-                ordered.append(result)
-    return ordered
+        ranking.append((position, float(score) if score is not None else None))
+    return ranking
+
+
+def _apply_flashrank_rerank(
+    query: str,
+    results: Sequence[SearchResult],
+    model_name: str | None,
+) -> list[SearchResult]:
+    if not results:
+        return []
+    ranking = _rank_documents_flashrank(
+        query,
+        _build_rerank_documents(results),
+        model_name,
+    )
+    return _apply_ranking(results, ranking)
 
 
 def _resolve_remote_rerank_config(
@@ -498,6 +554,20 @@ def _extract_remote_rerank_items(payload: object) -> list[tuple[int, float | Non
     return parsed
 
 
+def _rank_documents_remote(
+    query: str,
+    documents: Sequence[str],
+    config: RemoteRerankConfig | None,
+) -> list[tuple[int, float | None]]:
+    resolved = _resolve_remote_rerank_config(config)
+    payload = _remote_rerank_request(
+        config=resolved,
+        query=query,
+        documents=documents,
+    )
+    return _extract_remote_rerank_items(payload)
+
+
 def _apply_remote_rerank(
     query: str,
     results: Sequence[SearchResult],
@@ -505,32 +575,14 @@ def _apply_remote_rerank(
 ) -> list[SearchResult]:
     if not results:
         return []
-    resolved = _resolve_remote_rerank_config(config)
-    documents = [
-        _build_rerank_document(result) or result.path.as_posix() for result in results
-    ]
-    payload = _remote_rerank_request(
-        config=resolved,
-        query=query,
-        documents=documents,
+    ranking = _rank_documents_remote(
+        query,
+        _build_rerank_documents(results),
+        config,
     )
-    items = _extract_remote_rerank_items(payload)
-    if not items:
+    if not ranking:
         return list(results)
-    ordered: list[SearchResult] = []
-    seen: set[int] = set()
-    for idx, score in items:
-        if idx < 0 or idx >= len(results) or idx in seen:
-            continue
-        result = results[idx]
-        if score is not None:
-            result.score = score
-        ordered.append(result)
-        seen.add(idx)
-    for idx, result in enumerate(results):
-        if idx not in seen:
-            ordered.append(result)
-    return ordered
+    return _apply_ranking(results, ranking)
 
 
 def _empty_response(directory: Path, *, is_stale: bool) -> SearchResponse:

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 import json
+import re
+
 import numpy as np
 from typing import Callable, Sequence, TYPE_CHECKING
 from urllib import error as urlerror
@@ -41,6 +43,10 @@ DEFAULT_CONTENT_CHARS_TOTAL = 8000
 # anything — and too small to survive the preview check, which would then misreport the
 # result as stale rather than as out of budget.
 MIN_USEFUL_CONTENT_CHARS = 200
+
+# Marks one window of a chunk that was split to fit the embedding window; see
+# CodeStrategy in modes.py, which tags them ``display [#N] :: snippet``.
+_CHUNK_WINDOW_RE = re.compile(r"\[#\d+\]")
 
 # How much of a stored preview is compared against re-read text, and the shortest
 # probe worth comparing at all. Both are heuristics: the check exists to catch text
@@ -215,6 +221,29 @@ def _preview_probe(preview: str | None) -> str:
     return preview.rsplit(" :: ", 1)[-1].rstrip("…").strip()
 
 
+def _chunk_window_anchor(preview: str | None) -> str | None:
+    """Return the text that locates a split chunk's window inside its symbol.
+
+    A ``code`` chunk too long to embed in one piece is split into overlapping
+    windows tagged ``[#N]``, and every window carries its whole symbol's line
+    range, so reading from the first line hands back window 1 whatever matched.
+    The preview snippet says where the window actually starts.
+
+    Only these windows are anchored. The other modes chunk with per-chunk ranges
+    that are already right, and anchoring them would move content that is correct
+    where it is: an ``outline`` chunk's snippet starts one line below its own
+    ``start_line``, so the heading would drop out of the content.
+    """
+
+    label, separator, _ = (preview or "").rpartition(" :: ")
+    if not separator or not _CHUNK_WINDOW_RE.search(label):
+        return None
+    probe = _preview_probe(preview)
+    if len(probe) < PREVIEW_PROBE_MIN_CHARS:
+        return None
+    return probe[:PREVIEW_PROBE_CHARS]
+
+
 def _content_matches_preview(content: str, preview: str | None) -> bool:
     """Check that re-read text still looks like what was indexed at that line range.
 
@@ -260,6 +289,7 @@ def _attach_chunk_content(
                 result.start_line,
                 result.end_line,
                 max_chars=min(per_result, remaining),
+                anchor=_chunk_window_anchor(result.preview),
             )
         except OSError:
             chunk = None

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -238,6 +238,12 @@ def _chunk_window_anchor(
     anchoring them would move content that is correct where it is: an ``outline``
     chunk's snippet starts one line below its own ``start_line``, so the heading
     would drop out of the content.
+
+    ``class`` chunks are the one code case this cannot help. Their text is
+    assembled rather than sliced -- class line, dedented docstring, class-level
+    statements, then a synthetic ``Methods: ...`` line -- so a window opening
+    inside the assembled seams has no counterpart in the file, the anchor is not
+    found, and the read falls back to the symbol's first lines as before.
     """
 
     from ..modes import uses_code_chunking  # local import
@@ -272,6 +278,12 @@ def _content_matches_preview(content: str, preview: str | None) -> bool:
     before the full-mode line offset fix, and files edited since they were indexed.
     Deliberately lenient — a false negative only costs the caller a preview fallback,
     while a false positive hands an agent code from the wrong part of the file.
+
+    An anchored read seeks to this same text, so for those chunks the check passes
+    whenever the anchor was found at all. What it still guarantees there is the part
+    that matters: the returned text is what was indexed. A file edited since then
+    either still holds that text somewhere in the range, and the read finds it, or
+    does not, and the read falls back to the range's first lines and is caught here.
     """
 
     probe = _preview_probe(preview)

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -46,7 +46,7 @@ MIN_USEFUL_CONTENT_CHARS = 200
 
 # Marks one window of a chunk that was split to fit the embedding window; see
 # CodeStrategy in modes.py, which tags them ``display [#N] :: snippet``.
-_CHUNK_WINDOW_RE = re.compile(r"\[#\d+\]")
+_CHUNK_WINDOW_RE = re.compile(r"\[#(\d+)\]")
 
 # How much of a stored preview is compared against re-read text, and the shortest
 # probe worth comparing at all. Both are heuristics: the check exists to catch text
@@ -221,27 +221,48 @@ def _preview_probe(preview: str | None) -> str:
     return preview.rsplit(" :: ", 1)[-1].rstrip("…").strip()
 
 
-def _chunk_window_anchor(preview: str | None) -> str | None:
-    """Return the text that locates a split chunk's window inside its symbol.
+def _chunk_window_anchor(
+    result: SearchResult,
+    mode: str | None,
+) -> tuple[str, int] | None:
+    """Return where a split chunk's window starts, as ``(anchor text, offset hint)``.
 
     A ``code`` chunk too long to embed in one piece is split into overlapping
     windows tagged ``[#N]``, and every window carries its whole symbol's line
     range, so reading from the first line hands back window 1 whatever matched.
-    The preview snippet says where the window actually starts.
+    The preview says which window this is and how it opens.
 
-    Only these windows are anchored. The other modes chunk with per-chunk ranges
-    that are already right, and anchoring them would move content that is correct
-    where it is: an ``outline`` chunk's snippet starts one line below its own
-    ``start_line``, so the heading would drop out of the content.
+    Only files that ``CodeStrategy`` actually chunks are considered, because a
+    ``[#N] :: `` in any other preview is file text that merely looks like a marker.
+    The other modes chunk with per-chunk ranges that are already right, and
+    anchoring them would move content that is correct where it is: an ``outline``
+    chunk's snippet starts one line below its own ``start_line``, so the heading
+    would drop out of the content.
     """
 
-    label, separator, _ = (preview or "").rpartition(" :: ")
-    if not separator or not _CHUNK_WINDOW_RE.search(label):
+    from ..modes import uses_code_chunking  # local import
+
+    if not uses_code_chunking(mode, result.path):
         return None
-    probe = _preview_probe(preview)
+    # The marker sits at the end of the display, immediately before the first
+    # separator; a later one belongs to the snippet, i.e. to the file's own text.
+    label, separator, snippet = (result.preview or "").partition(" :: ")
+    if not separator:
+        return None
+    marker = _CHUNK_WINDOW_RE.search(label)
+    if marker is None or marker.end() != len(label):
+        return None
+    probe = snippet.rstrip("…").strip()
     if len(probe) < PREVIEW_PROBE_MIN_CHARS:
         return None
-    return probe[:PREVIEW_PROBE_CHARS]
+    # Windows advance by one stride each, so window N opens about that far into
+    # the chunk. Only a hint: it disambiguates repeated code, and the strategy may
+    # have been built with a different stride.
+    from .content_extract_service import DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE
+
+    stride = max(DEFAULT_CHUNK_SIZE - DEFAULT_CHUNK_OVERLAP, 1)
+    offset = (int(marker.group(1)) - 1) * stride
+    return probe[:PREVIEW_PROBE_CHARS], offset
 
 
 def _content_matches_preview(content: str, preview: str | None) -> bool:
@@ -283,13 +304,15 @@ def _attach_chunk_content(
         if remaining < min(MIN_USEFUL_CONTENT_CHARS, per_result):
             result.content_unavailable = CONTENT_BUDGET_EXHAUSTED
             continue
+        anchor, anchor_offset = _chunk_window_anchor(result, request.mode) or ("", 0)
         try:
             chunk = read_chunk_content(
                 result.path,
                 result.start_line,
                 result.end_line,
                 max_chars=min(per_result, remaining),
-                anchor=_chunk_window_anchor(result.preview),
+                anchor=anchor,
+                anchor_offset=anchor_offset,
             )
         except OSError:
             chunk = None


### PR DESCRIPTION
Stacked on #51 (the seam the harness patches) and #52 (without the anchored read, the content arms score the wrong lines). Merge those first; this diff shrinks to `scripts/` + `docs/` once they land.

## Motivation

`docs/roadmap.md` listed "feed chunk content to the rerankers" as a P0 follow-up to 0.27.0, on the premise that scoring filename + path + a 160-character preview caps rerank quality, and required its own benchmark because either answer shifts result ordering for anyone using `--rerank`.

## Result: the premise does not hold

MRR@10 on this repository, 30 queries, top 10, `--chars 0` (preview) vs `--chars 1000` (chunk source text):

| Rerank | Doc chars | bge-m3 | e5-small |
|---|---|---:|---:|
| off (dense) | - | 0.628 | 0.611 |
| remote | preview | **0.686** | **0.634** |
| remote | 1000 | 0.579 | 0.550 |
| flashrank | preview | **0.669** | **0.623** |
| flashrank | 1000 | 0.611 | 0.564 |
| bm25 | preview | **0.605** | 0.509 |
| bm25 | 1000 | 0.546 | 0.514 |

Five clear losses out of six reranker × model pairs; the sixth (BM25 on e5-small) moves less than one query's rank change is worth on a set this size. Also ruled out, each on the remote reranker:

- **Cap size.** 300 → 0.649, 500 → 0.616, 1000 → 0.591, 2000 → 0.651, against 0.686 for the preview. There is no sweet spot, so this is not "we fed it too much".
- **Losing the preview's breadcrumb.** Keeping the preview *and* appending the body scored 0.553 — worse than either alone.
- **Candidates falling back.** Skipping the preview check so every candidate carries text scored 0.575, still below the preview arm.

The reading: a preview is not a truncated chunk. For `code` and `outline` chunks it leads with the symbol signature or heading breadcrumb — the most discriminative text available — and the body dilutes it while the reranker truncates anyway (FlashRank at 256 tokens). So no behavior change ships; `_build_rerank_document` keeps scoring the preview.

The corpus is this repository, so absolute numbers move as it changes; the gap between the arms is what they are compared on, and it has held across every run.

## What lands

- `scripts/eval_rerank_content.py` — the harness, self-contained: it patches `_build_rerank_documents` for the content arms, so no product code carries an unused knob. The recorded numbers are in its docstring and the roadmap.
- `scripts/_eval_common.py` — query loading and MRR/Hit metrics, previously private to `eval_hybrid.py` and now shared.
- `docs/roadmap.md` — the item moves from "needs a benchmark" to the measured result, with the caveat that the query set is small and code-heavy, so a prose corpus deserves a re-run. Also marks the reranker seam done and updates the collection API's delivery order.
- `docs/development.md` — how to run both retrieval harnesses.

## Verification

- `python -m pytest --cov=vexor --cov-report=term-missing` — 662 passed, 91% total, `search_service.py` at 91%.
- Every table above is a real run against the configured provider (`BAAI/bge-m3` on an OpenAI-compatible endpoint, `BAAI/bge-reranker-v2-m3` for remote rerank) and the local `intfloat/multilingual-e5-small` path; both columns come from one tree, and the preview-vs-1000 pair has been reproduced on four separate trees, including once after the script was rewritten to touch no product code.