### PR TITLE
chore(release): bump version to 0.27.1

### DIFF
--- a/docs/release-notes/0.27.1.md
+++ b/docs/release-notes/0.27.1.md
@@ -1,0 +1,11 @@
+## Search content fixes
+
+Split code chunks now return source text from the matched window instead of
+repeatedly reading from the start of the enclosing symbol. This removes false
+`stale_line_range` reports, avoids duplicated content spending the shared
+budget, and makes `content_start_line` point to where the returned text
+actually begins.
+
+FlashRank reranking now ignores duplicate result IDs instead of returning the
+same search result more than once. The reranker configuration and public API
+remain unchanged.

--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/scarletkc/vexor",
     "source": "github"
   },
-  "version": "0.27.0",
+  "version": "0.27.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vexor",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.27.0"
+__version__ = "0.27.1"
 
 _API_EXPORTS = frozenset(
     {


### PR DESCRIPTION
## What changed

- Bump the Python package, bundled plugin, and MCP server manifests to 0.27.1.
- Add a hand-written release note for the split-chunk content and duplicate FlashRank result fixes.

## Why

The fixes merged after v0.27.0 are ready for a patch release. Merging this version bump to `main` triggers the repository's release workflow.

There are no config, index-format, or public API migrations in this release.

## Verification

- `python -m pytest --cov=vexor --cov-report=term-missing`: 662 passed, 91% total coverage.
- `python -m build --no-isolation`: built the 0.27.1 sdist and wheel locally. The standard isolated command hit a Windows Store Python nested-venv failure before invoking the project build backend.
- `python -m twine check dist\\vexor-0.27.1*`: both artifacts passed with Twine 7.0.0.
- `python -m vexor --version`: `Vexor v0.27.1`.
