### PR TITLE
ci: upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Setup Python
         if: steps.detect.outputs.changed == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -98,7 +98,7 @@ jobs:
       # CODECOV_TOKEN is configured in repository secrets
       - name: Upload coverage to Codecov
         if: steps.detect.outputs.changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -213,10 +213,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -246,7 +246,7 @@ jobs:
           cp "${{ matrix.built-binary }}" "release/vexor-${VERSION}-${{ matrix.artifact-suffix }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vexor-${{ matrix.artifact-suffix }}
           path: release/
@@ -265,12 +265,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release
           merge-multiple: true
@@ -327,7 +327,7 @@ jobs:
           } > release_notes.md
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.prepare_release.outputs.version }}
           name: Vexor v${{ needs.prepare_release.outputs.version }}
@@ -353,7 +353,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Sync server.json version
         shell: bash
@@ -424,10 +424,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           cache: 'pip'


### PR DESCRIPTION
## Why

GitHub annotated every 0.27.1 release job because several actions still targeted the deprecated Node 20 runtime. GitHub-hosted runners are already forcing those actions onto Node 24, so this moves the workflow to the current Node 24 majors before compatibility mode disappears.

## What changed

- Upgrade `actions/checkout` and `actions/setup-python` to v7.
- Upgrade `actions/upload-artifact` to v7 and `actions/download-artifact` to v8.
- Upgrade `softprops/action-gh-release` to v3 and `codecov/codecov-action` to v7.
- Keep `pypa/gh-action-pypi-publish@v1.14.2`, which is already current.

The workflow conditions, permissions, version detection, artifact paths, and release inputs are unchanged. `download-artifact@v8` now fails on an artifact digest mismatch instead of warning, which is the safer release behavior.

## Verification

- Parsed `.github/workflows/publish.yml` locally and confirmed all six jobs remain present.
- Checked every input used by the workflow against the new majors' published `action.yml` definitions.
- `python -m pytest --cov=vexor --cov-report=term-missing`: 662 passed, 91% total coverage.
- The PR run completed with `actions/checkout@v7` and no Node 20 annotation.

The existing doc-only detector treats this YAML-only diff as skippable, so the PR run did not execute `setup-python`, pytest, Codecov, or the release-only jobs. Setup and test coverage come from the local run; artifact upload/download and GitHub Release remain version-bump-only. This PR does not change the package version or publish a release.
