### PR TITLE
fix(api): resolve the default path when the call runs

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -73,7 +73,8 @@ commands.
 Core parameters:
 
 - `query`: text to search for (required)
-- `path`: root directory to search
+- `path`: root directory to search, resolved when the call runs; defaults to
+  the process's current working directory
 - `mode`: indexing strategy (`auto`, `name`, `head`, `brief`, `code`, `outline`, `full`)
 - `top`: number of results
 - `include_hidden`, `respect_gitignore`, `recursive`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,14 +109,6 @@ ignore = [
     "RUF001",
 ]
 
-[tool.ruff.lint.per-file-ignores]
-# Both modules default `path` to `Path.cwd()`, which binds the working directory
-# at import time instead of at call time. That is a real defect in the Python API
-# and is tracked separately; fixing it changes public signatures, so it does not
-# ride along with the linter rollout.
-"vexor/api.py" = ["B008"]
-"vexor/cli.py" = ["B008"]
-
 [tool.ruff.lint.flake8-bugbear]
 # Typer carries CLI metadata in call-expression defaults, so B008 there reports
 # the framework's documented signature style rather than a shared-state bug.

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2404,3 +2404,49 @@ def test_project_local_cache_index_search_show_and_clear(tmp_path, monkeypatch):
     assert "Removed 1 cached index entry" in clear_result.stdout
     assert show_after_clear.exit_code == 0
     assert "No cached index found" in show_after_clear.stdout
+
+
+def test_search_without_path_uses_cwd_at_invocation(tmp_path, monkeypatch):
+    """`--path` defaults to the directory the command runs in, not the import-time one."""
+    runner = CliRunner()
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    captured = {}
+
+    def fake_perform_search(request):
+        captured["directory"] = request.directory
+        return SearchResponse(
+            base_path=request.directory,
+            backend="fake-backend",
+            results=[],
+            is_stale=False,
+            index_empty=True,
+        )
+
+    monkeypatch.setattr("vexor.cli.perform_search", fake_perform_search)
+    monkeypatch.chdir(workdir)
+
+    result = runner.invoke(app, ["search", "alpha"])
+
+    assert result.exit_code == 0
+    assert captured["directory"] == workdir.resolve()
+
+
+def test_index_without_path_uses_cwd_at_invocation(tmp_path, monkeypatch):
+    """Indexing with no --path must target the directory the command runs in."""
+    runner = CliRunner()
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    captured = {}
+
+    def fake_build_index(directory, **_kwargs):
+        captured["directory"] = directory
+        return IndexResult(status=IndexStatus.EMPTY)
+
+    monkeypatch.setattr("vexor.cli.build_index", fake_build_index)
+    monkeypatch.chdir(workdir)
+
+    result = runner.invoke(app, ["index"])
+
+    assert result.exit_code == 0
+    assert captured["directory"] == workdir.resolve()

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from typer.testing import CliRunner
@@ -324,3 +325,25 @@ def test_update_pre_release_check_does_not_touch_notice_cache(monkeypatch):
     result = runner.invoke(app, ["update", "--pre"])
     assert result.exit_code == 0
     assert written == []
+
+
+def test_mcp_command_without_path_uses_cwd_at_invocation(monkeypatch, tmp_path):
+    """The MCP server's default root follows the directory the command runs in."""
+    runner = CliRunner()
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    captured = {}
+
+    import vexor.services.mcp_service as mcp_service
+
+    def fake_serve_stdio(default_path=None):
+        # Mirror what VexorMcpServer.__init__ does with the value it is handed.
+        captured["resolved"] = Path(default_path or Path.cwd()).resolve()
+
+    monkeypatch.setattr(mcp_service, "serve_stdio", fake_serve_stdio)
+    monkeypatch.chdir(workdir)
+
+    result = runner.invoke(app, ["mcp"])
+
+    assert result.exit_code == 0
+    assert captured["resolved"] == workdir.resolve()

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -766,3 +766,105 @@ def test_index_local_creates_project_cache_and_uses_it(tmp_path, monkeypatch) ->
     assert (tmp_path / ".vexor" / ".gitignore").is_file()
     expected_cache_path = tmp_path / ".vexor" / cache_module.DB_FILENAME
     assert result.cache_path == expected_cache_path.resolve()
+
+
+def _capture_directory(monkeypatch, attribute, result):
+    """Stub one service entry point and record the directory the API resolved."""
+
+    captured: dict[str, object] = {}
+
+    def fake(directory, *_args, **_kwargs):
+        captured["directory"] = directory
+        return result(directory) if callable(result) else result
+
+    monkeypatch.setattr(api_module, attribute, fake)
+    return captured
+
+
+def _capture_search_directory(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_perform_search(request):
+        captured["directory"] = request.directory
+        return SearchResponse(
+            base_path=request.directory,
+            backend=None,
+            results=[],
+            is_stale=False,
+            index_empty=True,
+        )
+
+    monkeypatch.setattr(api_module, "perform_search", fake_perform_search)
+    return captured
+
+
+@pytest.fixture
+def elsewhere(tmp_path, monkeypatch):
+    """Change into a directory that is not the one the module was imported from."""
+
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    return workdir.resolve()
+
+
+def test_search_default_path_tracks_cwd_at_call_time(elsewhere, monkeypatch) -> None:
+    captured = _capture_search_directory(monkeypatch)
+
+    api_module.search("hello", mode="name", use_config=False)
+
+    assert captured["directory"] == elsewhere
+
+
+def test_index_default_path_tracks_cwd_at_call_time(elsewhere, monkeypatch) -> None:
+    captured = _capture_directory(
+        monkeypatch, "build_index", IndexResult(status=IndexStatus.EMPTY)
+    )
+
+    api_module.index(mode="name", use_config=False)
+
+    assert captured["directory"] == elsewhere
+
+
+def test_index_in_memory_default_path_tracks_cwd_at_call_time(
+    elsewhere, monkeypatch
+) -> None:
+    captured = _capture_directory(
+        monkeypatch,
+        "build_index_in_memory",
+        lambda directory: (np.zeros((0, 3), dtype=np.float32), [], []),
+    )
+
+    api_module.index_in_memory(mode="name", use_config=False)
+
+    assert captured["directory"] == elsewhere
+
+
+def test_clear_index_default_path_tracks_cwd_at_call_time(elsewhere, monkeypatch) -> None:
+    captured = _capture_directory(monkeypatch, "clear_index_entries", 0)
+
+    api_module.clear_index(mode="name")
+
+    assert captured["directory"] == elsewhere
+
+
+def test_client_search_default_path_tracks_cwd_at_call_time(
+    elsewhere, monkeypatch
+) -> None:
+    captured = _capture_search_directory(monkeypatch)
+
+    with api_module.VexorClient(use_config=False) as client:
+        client.search("hello", mode="name")
+
+    assert captured["directory"] == elsewhere
+
+
+def test_client_index_default_path_tracks_cwd_at_call_time(elsewhere, monkeypatch) -> None:
+    captured = _capture_directory(
+        monkeypatch, "build_index", IndexResult(status=IndexStatus.EMPTY)
+    )
+
+    with api_module.VexorClient(use_config=False) as client:
+        client.index(mode="name")
+
+    assert captured["directory"] == elsewhere

--- a/vexor/api.py
+++ b/vexor/api.py
@@ -332,7 +332,7 @@ class VexorClient:
         self,
         query: str,
         *,
-        path: Path | str = Path.cwd(),
+        path: Path | str = ".",
         top: int = 5,
         include_hidden: bool = False,
         respect_gitignore: bool = True,
@@ -406,7 +406,7 @@ class VexorClient:
 
     def index(
         self,
-        path: Path | str = Path.cwd(),
+        path: Path | str = ".",
         *,
         include_hidden: bool = False,
         respect_gitignore: bool = True,
@@ -467,7 +467,7 @@ class VexorClient:
 
     def index_in_memory(
         self,
-        path: Path | str = Path.cwd(),
+        path: Path | str = ".",
         *,
         include_hidden: bool = False,
         respect_gitignore: bool = True,
@@ -527,7 +527,7 @@ class VexorClient:
 
     def clear_index(
         self,
-        path: Path | str = Path.cwd(),
+        path: Path | str = ".",
         *,
         include_hidden: bool = False,
         respect_gitignore: bool = True,
@@ -587,7 +587,7 @@ def config_context(
 def search(
     query: str,
     *,
-    path: Path | str = Path.cwd(),
+    path: Path | str = ".",
     top: int = 5,
     include_hidden: bool = False,
     respect_gitignore: bool = True,
@@ -654,7 +654,7 @@ def search(
 
 
 def index(
-    path: Path | str = Path.cwd(),
+    path: Path | str = ".",
     *,
     include_hidden: bool = False,
     respect_gitignore: bool = True,
@@ -709,7 +709,7 @@ def index(
 
 
 def index_in_memory(
-    path: Path | str = Path.cwd(),
+    path: Path | str = ".",
     *,
     include_hidden: bool = False,
     respect_gitignore: bool = True,
@@ -764,7 +764,7 @@ def index_in_memory(
 
 
 def clear_index(
-    path: Path | str = Path.cwd(),
+    path: Path | str = ".",
     *,
     include_hidden: bool = False,
     respect_gitignore: bool = True,

--- a/vexor/cli.py
+++ b/vexor/cli.py
@@ -382,7 +382,7 @@ def main(
 def search(
     query: str = typer.Argument(..., help=Messages.HELP_QUERY),
     path: Path = typer.Option(
-        Path.cwd(),
+        Path("."),
         "--path",
         "-p",
         help=Messages.HELP_SEARCH_PATH,
@@ -581,7 +581,7 @@ def search(
 @app.command()
 def index(
     path: Path = typer.Option(
-        Path.cwd(),
+        Path("."),
         "--path",
         "-p",
         help=Messages.HELP_INDEX_PATH,
@@ -1659,7 +1659,7 @@ def install(
 @app.command(help=Messages.HELP_MCP)
 def mcp(
     path: Path = typer.Option(
-        Path.cwd(),
+        Path("."),
         "--path",
         "-p",
         help=Messages.HELP_MCP_PATH,


### PR DESCRIPTION
Follows #56, which introduced the `B008` per-file-ignores this PR removes.
Rebased onto `main` now that #56 has landed.

## The defect

`vexor/api.py` and `vexor/cli.py` defaulted `path` to `Path.cwd()`. A default
expression is evaluated **once, when the module is imported**, so the value was
the working directory at import time rather than at call time.

For the Python API this is a real bug — the working directory is free to move
during a long-lived process:

```python
import vexor, os
os.chdir("/some/project")
vexor.api.search("query")     # searched wherever the interpreter started
```

The CLI was exposed through the same defaults: any invocation whose working
directory differed from the one in effect when `vexor.cli` was imported targeted
the wrong tree. `vexor mcp` additionally overrode the correct `None` handling in
`VexorMcpServer.__init__`, which already resolved lazily.

Ruff's `B008` is what surfaced this during the lint rollout (#56).

## The fix

Both layers now default to the relative `"."` instead of an absolute snapshot.

This works because the value has exactly one consumer on every path.
`_search_with_settings`, `_index_with_settings`, `_index_in_memory_with_settings`
and `_clear_index_with_settings` each reference `path` exactly once, always as
`resolve_directory(path)` — verified by walking the AST rather than by reading.
`resolve_directory` calls `Path(path).expanduser().resolve()`, and `.resolve()`
interprets a relative path against the **live** working directory. The MCP server
does its own `Path(default_path or Path.cwd()).resolve()`.

So the default is now resolved by the same code that already resolved every
explicit argument, at the moment the call runs.

11 sites: 8 in `vexor/api.py` (4 `VexorClient` methods + 4 module-level
functions), 3 in `vexor/cli.py` (`search`, `index`, `mcp`).

## Compatibility

| | |
| --- | --- |
| Callers passing `path` explicitly | Unaffected. |
| Callers omitting `path` **without** changing directory | Unaffected — same resolved directory. |
| Callers omitting `path` **after** changing directory | Behavior changes: they now get the directory they are in, which is what the parameter always meant. |
| Signature default in generated docs / `inspect.signature` | `Path.cwd()` snapshot -> `"."`. |

The docs already used `path="."` in every example, so the new default matches
documented usage rather than introducing a new convention.

**CLI output change** — `--help` no longer prints an absolute machine-specific
path:

```
| --path   -p   PATH   Root directory to scan for indexing.  |
|                      [default: .]                          |
```

## Lint

With the defect gone, the two `B008` per-file-ignores added in #56 are removed.
`B008` is now enforced across the whole codebase with no suppressions.

## Verification

```
python -m ruff check .        -> All checks passed! (exit 0)
python -m pytest -q           -> 670 passed  (662 + 8 new)
python -m pytest --cov=vexor  -> TOTAL 8044 stmts, 730 miss, 91%
```

**The 8 new tests were confirmed to catch the defect**, not merely to pass:
reverting the fix in `api.py` fails all 6 API tests, and reverting it in `cli.py`
fails both CLI tests. Each changes directory with `monkeypatch.chdir` and asserts
the directory that actually reached the service layer.

Covered: `search`, `index`, `index_in_memory`, `clear_index`, plus
`VexorClient.search` / `.index`, plus the `search` and `index` CLI commands.

**End-to-end**, real run against the configured provider (`custom` /
SiliconFlow, `BAAI/bge-m3`), executed *from inside* the target directory with no
`--path` — the exact path this PR fixes:

```
$ cd .../scratchpad/e2e2
$ vexor index --mode full
Indexing files under ...\scratchpad\e2e2...
Index saved to ~/.vexor/index.db.

$ vexor search "how do stale cache rows get removed" --mode full --top 3
| # | Similarity | File path    | Lines |
|---+------------+--------------+-------|
| 1 |      0.642 | ./cache.py   |  L1-3 |
| 2 |      0.343 | ./auth.py    |  L1-3 |
| 3 |      0.289 | ./invoice.md |  L1-2 |

$ vexor mcp        # initialize handshake, no --path
Vexor MCP server ready (stdio). Default path: ...\scratchpad\e2e2
```

All three targeted the working directory rather than the repository root. The
test index was cleared afterwards.

## Docs

`docs/api/python.md` now states that `path` is resolved when the call runs and
defaults to the process's current working directory. The bundled skill is
untouched — no command, flag, or output contract changed beyond the `--help`
default shown above.

