### PR TITLE
chore(release): bump version to 0.27.2

### DIFF
--- a/docs/release-notes/0.27.2.md
+++ b/docs/release-notes/0.27.2.md
@@ -1,0 +1,25 @@
+## Default path now resolves at call time
+
+`search()`, `index()`, `index_in_memory()`, and `clear_index()` — along with the
+matching `VexorClient` methods and the `search`, `index`, and `mcp` CLI commands
+— defaulted `path` to `Path.cwd()`. A default expression is evaluated once, when
+the module is imported, so the value was the working directory at import time
+rather than at call time.
+
+For the Python API this returned wrong results silently. A process that changed
+directory after importing vexor kept searching and indexing wherever the
+interpreter had started:
+
+```python
+import vexor, os
+os.chdir("/some/project")
+vexor.api.search("query")     # searched the import-time directory, no error
+```
+
+The default is now the relative `"."`, which resolves against the live working
+directory. Callers that pass `path` explicitly are unaffected, and so are
+callers that omit it without changing directory. Only the case that was already
+returning the wrong tree changes, and it now returns the right one.
+
+`vexor <command> --help` shows `[default: .]` instead of an absolute,
+machine-specific path.

--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/scarletkc/vexor",
     "source": "github"
   },
-  "version": "0.27.1",
+  "version": "0.27.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vexor",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.27.1"
+__version__ = "0.27.2"
 
 _API_EXPORTS = frozenset(
     {


### PR DESCRIPTION
Patch release carrying the call-time default path fix from #57.

## Why release now

Only three PRs landed since v0.27.1, and two of them (#55, #56) are CI and lint
work with no user-visible effect. The release exists for one thing: #57 fixed a
public API defect that returned wrong results **silently** — a process that
changed directory after importing vexor kept searching the import-time tree,
with no error to signal it. That is not a bug worth sitting on.

Because the generated changelog for this range reads as two CI commits and one
fix, `docs/release-notes/0.27.2.md` carries the explanation so the release page
says what actually changed.

## Semver note

`0.27.2` is a patch. Strictly speaking the behavior change breaks anyone who
depended on the old snapshot semantics, but the old semantics were the defect;
callers passing `path` explicitly, and callers omitting it without changing
directory, are unaffected.

## Verification

```
python scripts/bump_version.py 0.27.2 --note ...
python -m vexor --version   -> Vexor v0.27.2
python -m ruff check .      -> All checks passed! (exit 0)
python -m pytest -q         -> 671 passed
```

Version is consistent across `vexor/__init__.py`, `server.json` (both the
top-level and package entries), and `plugins/vexor/.claude-plugin/plugin.json`.

The release note was checked against the publish job's own validation: it opens
with a `## <title>` heading and has a non-empty body, so the publish step will
not fail on a malformed note.

Merging this publishes to PyPI, GitHub Releases, and the MCP registry.