### PR TITLE
feat(collection): add filesystem-independent record collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Everyday usage fits in `vexor "query"`, `vexor search`, and `vexor index` (see Q
 - [CLI reference](https://github.com/scarletkc/vexor/blob/main/docs/cli.md) — commands, flags, index modes, cache behavior
 - [MCP server](https://github.com/scarletkc/vexor/blob/main/docs/mcp.md) — client setup, environment variables, tool schemas
 - [Python API](https://github.com/scarletkc/vexor/blob/main/docs/api/python.md) — programmatic usage
+- [Collections API](https://github.com/scarletkc/vexor/blob/main/docs/api/collections.md) — database-backed text records and filtered search
 
 ## Contributing
 

--- a/docs/api/collections.md
+++ b/docs/api/collections.md
@@ -16,13 +16,15 @@ the handle does not touch the database; the named collection is created by its
 first successful non-empty write.
 
 The handle uses the client's resolved embedding configuration unless you pass
-overrides to `collection(...)`. The provider, model, and vector dimension are
-pinned when the first write creates the collection. Any later write **or search**
-configured with a different provider, model, or dimension raises an error that
-tells you to recreate the collection instead of mixing incompatible vectors.
-Reads are checked too: two models can share a vector width while embedding into
-unrelated spaces, so a dimension match alone would let a query score vectors it
-has nothing to do with and return a ranking that means nothing.
+overrides to `collection(...)`.
+
+The provider, model, and vector dimension are fixed when the collection is
+created. Later writes **and searches** configured differently are rejected, with
+an error telling you to recreate the collection.
+
+Matching dimensions are not enough on their own: two models can produce
+incompatible vector spaces at the same width. That is why searches are checked
+against the pinned contract too, not just against the vector size.
 
 ## Write records
 
@@ -40,12 +42,15 @@ One asymmetry to know about: a `datetime` is stored as both an ISO 8601 string
 and epoch seconds, so range filters on it work as expected, but reading a record
 back returns the ISO **string**, not a `datetime` object. Parse it yourself if
 you need the type: `datetime.fromisoformat(record.metadata["sent_at"])`.
-Stored `datetime` values are returned as ISO 8601 strings when records are read.
 
 An upsert replaces the record's metadata wholesale. When its text has not
 changed, Vexor keeps the existing embedding and BM25 postings instead of
 embedding it again, but still rewrites the metadata. The returned
 `UpsertReport` reports `written`, `embedded`, and `skipped` counts.
+
+One record is one vector. V1 does not chunk long text, and text that exceeds the
+embedding provider's limit surfaces the provider error rather than being
+silently truncated. Split long documents yourself before upserting them.
 
 ## Filter records
 
@@ -82,10 +87,6 @@ collections do not have an approximate nearest-neighbor index. Search cost
 therefore tracks the size of one filtered slice. Without a filter, that slice
 is the entire collection, so use selective metadata such as a chat, tenant, or
 time boundary when the application naturally has one.
-
-V1 stores one vector per record and does not chunk long text. Text that exceeds
-the embedding provider's limit surfaces the provider error; Vexor does not
-silently truncate it.
 
 ## Worked example: database-backed chat history
 

--- a/docs/api/collections.md
+++ b/docs/api/collections.md
@@ -1,0 +1,142 @@
+# Collections Python API
+
+A collection is a named, persistent set of caller-owned text records. Use one
+when the source of truth is a database, message store, or another system that
+already has stable record IDs and can send inserts and updates to Vexor. Use
+`vexor index` when the source is a filesystem tree and Vexor should discover and
+refresh files itself.
+
+Collections are currently available through the Python API. They store records
+in `collections.db`, separately from file indexes.
+
+## Get a handle
+
+Call `VexorClient(...).collection("name")` to get a `CollectionHandle`. Getting
+the handle does not touch the database; the named collection is created by its
+first successful non-empty write.
+
+The handle uses the client's resolved embedding configuration unless you pass
+overrides to `collection(...)`. The provider, model, and vector dimension are
+pinned when the first write creates the collection. Any later write **or search**
+configured with a different provider, model, or dimension raises an error that
+tells you to recreate the collection instead of mixing incompatible vectors.
+Reads are checked too: two models can share a vector width while embedding into
+unrelated spaces, so a dimension match alone would let a query score vectors it
+has nothing to do with and return a ranking that means nothing.
+
+## Write records
+
+`upsert_many(records)` accepts a sequence of mappings. Each record has:
+
+- `id`: a non-empty caller-owned identifier. Vexor stores its string form.
+- `text`: non-empty text to embed and search.
+- `metadata`: an optional flat mapping used for filtering.
+
+Metadata values may be `str`, `int`, `float`, `bool`, `datetime`, or `None`.
+Keys must be non-empty strings. Lists, dictionaries, and other nested values are
+rejected at write time rather than stored in a form no filter could ever match.
+
+One asymmetry to know about: a `datetime` is stored as both an ISO 8601 string
+and epoch seconds, so range filters on it work as expected, but reading a record
+back returns the ISO **string**, not a `datetime` object. Parse it yourself if
+you need the type: `datetime.fromisoformat(record.metadata["sent_at"])`.
+Stored `datetime` values are returned as ISO 8601 strings when records are read.
+
+An upsert replaces the record's metadata wholesale. When its text has not
+changed, Vexor keeps the existing embedding and BM25 postings instead of
+embedding it again, but still rewrites the metadata. The returned
+`UpsertReport` reports `written`, `embedded`, and `skipped` counts.
+
+## Filter records
+
+Pass `filters` to `search()`. A bare value is equality shorthand; an operator
+mapping provides the other comparisons.
+
+| Operator | Meaning |
+| --- | --- |
+| `eq` | Equal to the value |
+| `ne` | Not equal to the value, including records where the key is absent |
+| `in` | Equal to any value in a non-empty list, tuple, set, or frozenset |
+| `nin` | Equal to none of the values, including records where the key is absent |
+| `gt`, `gte`, `lt`, `lte` | Number, boolean, or datetime range comparison |
+| `exists` | Require the key to be present (`True`) or absent (`False`) |
+
+All filter keys and all operators within them are ANDed. V1 has no OR. Because
+`ne` and `nin` include records without the key, combine a negative condition
+with `exists: True` when the key itself is required.
+
+Filters resolve to record IDs before query scoring. An unknown key therefore
+produces no matches for a positive condition, and a record excluded by a filter
+cannot re-enter through dense or hybrid ranking.
+
+## Search and scale
+
+`search(query, *, top_k=10, filters=None, rerank="off")` returns
+`RecordResult` objects with `id`, `text`, `metadata`, and `score`. Collection
+search accepts only `rerank="off"` for dense similarity or `rerank="hybrid"`
+to fuse dense and BM25 scores. Filters resolve before either mode scores
+candidates.
+
+Dense scoring is a brute-force matrix product over the filtered candidate set;
+collections do not have an approximate nearest-neighbor index. Search cost
+therefore tracks the size of one filtered slice. Without a filter, that slice
+is the entire collection, so use selective metadata such as a chat, tenant, or
+time boundary when the application naturally has one.
+
+V1 stores one vector per record and does not chunk long text. Text that exceeds
+the embedding provider's limit surfaces the provider error; Vexor does not
+silently truncate it.
+
+## Worked example: database-backed chat history
+
+The application keeps the messages in its database and uses the message or turn
+ID as the collection record ID. `chat_id` and `sent_at` form a selective slice
+before relevance scoring:
+
+```python
+from datetime import datetime, timezone
+
+from vexor import VexorClient
+
+with VexorClient() as client:
+    messages = client.collection("chat-history")
+    report = messages.upsert_many(
+        [
+            {
+                "id": "message-1042",
+                "text": "The deployment failed because the token had expired.",
+                "metadata": {
+                    "chat_id": "chat-7",
+                    "sent_at": datetime(2026, 8, 20, 9, 30, tzinfo=timezone.utc),
+                },
+            },
+            {
+                "id": "message-1043",
+                "text": "Rotating the token fixed the deployment.",
+                "metadata": {
+                    "chat_id": "chat-7",
+                    "sent_at": datetime(2026, 8, 20, 9, 35, tzinfo=timezone.utc),
+                },
+            },
+        ]
+    )
+
+    results = messages.search(
+        "Why did the deployment fail?",
+        top_k=5,
+        filters={
+            "chat_id": "chat-7",
+            "sent_at": {"gte": datetime(2026, 8, 20, tzinfo=timezone.utc)},
+        },
+        rerank="hybrid",
+    )
+
+    print(report.embedded, report.skipped)
+    for result in results:
+        print(result.id, result.score, result.text)
+```
+
+`get()` / `get_many()` read records by ID, `delete()` / `delete_many()` remove
+them, `count()` reports the collection size, and `info()` returns the pinned
+embedding contract. `drop()` deletes the named collection and all of its
+records.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,106 +39,41 @@ never leaving the machine.
     path-only results, agent+Vexor could not show much saving over grep
     because the follow-up reads dominated.
 
-- Add a filesystem-independent, general-purpose text collection API for
-  callers to submit records from databases directly, with operations such
-  as `upsert(id, text, metadata)`, `delete(id)`, and
-  `search(query, filters, top_k)`. Metadata should support fields such as
-  `user_id`, `chat_id`, timestamp, record type, and source, with strict
-  field-based filtering at search time. Reuse the existing embedding,
-  cache, BM25, hybrid ranking, and reranker layers without requiring text
-  to originate from files. Results should return the record ID, original
-  text, metadata, and relevance score instead of file paths and line
-  numbers. This lets integrations such as Telegram bots keep MySQL as the
-  source of truth and incrementally write chat excerpts to Vexor without
-  exporting temporary files or maintaining a parallel file tree.
-  - Reuse, unchanged: `bm25.py` already holds only pure functions over
-    ids and rows (`score_postings` returns `{id: score}`, `rrf_fuse`
-    fuses by row index); the `embedding_cache` table is keyed by
-    `(model, text_hash)` and its helpers open `cache_db_path()` on their
-    own connection, so a separate store still shares one embedding cache;
-    and `VexorSearcher.embed_texts` accepts arbitrary text and already
-    L2-normalizes, so a dot product is cosine similarity.
-  - Filesystem coupling to break: `index_metadata` keys on a path hash
-    and `indexed_file` requires `rel_path`, `abs_path`, `size_bytes`, and
-    `mtime`; `SearchResult.path` is a required `Path`; and all three
-    rerankers build their documents through `_build_rerank_document`,
-    which reads `result.path`.
-  - Storage location: give collections their own `collections.db` beside
-    `index.db` rather than new tables inside it. `clear_all_cache()`
-    unlinks the database file and `vexor config --clear-index-all` calls
-    it; a file index is rebuildable from disk, but collection records are
-    only rebuildable by making the caller re-upsert everything and pay
-    for embeddings a second time. Do not bump `CACHE_VERSION` for this
-    work — the new tables are additive under
-    `CREATE TABLE IF NOT EXISTS`, and a bump would invalidate every
-    existing user's file index. Extract the shared `_connect` and
-    `_chunk_values` helpers out of `cache.py` so both stores get the same
-    WAL and `busy_timeout` behavior under concurrent writers.
-  - Schema: `collection` (name, provider, model, dimension, schema
-    version) pins the embedding contract, and changing model or dimension
-    afterwards must raise and tell the caller to recreate the collection
-    instead of mixing vector widths. `collection_record` holds the
-    caller's `record_key` (unique per collection), the original text, a
-    `text_hash` computed with `embedding_cache_key` so an unchanged
-    upsert skips re-embedding, and the metadata JSON.
-    `collection_embedding` stores one normalized vector per record: v1
-    does not chunk, one record is one vector, and text that exceeds a
-    provider limit surfaces the provider error rather than being silently
-    truncated. `collection_bm25_doc` and `collection_bm25_posting`
-    deliberately mirror the shape of the existing `bm25_doc` and
-    `bm25_posting` tables so `bm25.score_postings` consumes their rows
-    unchanged.
-  - Metadata and filtering: keep metadata a flat mapping of scalars
-    (`str`, `int`, `float`, `bool`, `None`) and reject nested values
-    rather than accepting values that can never be filtered on, which
-    would surface later as a phantom recall bug. Index it in a
-    `collection_meta` EAV table carrying both `value_text` and
-    `value_num` so strings compare by equality while numbers,
-    timestamps, and booleans also support ranges; a `datetime` writes
-    ISO text and epoch seconds together. Support `eq`, `ne`, `in`,
-    `nin`, `gt`, `gte`, `lt`, `lte`, and `exists` with keys ANDed
-    together, and leave OR out of v1. Filtering must be strict: the
-    filter compiles to SQL and resolves to a candidate id set *before*
-    scoring, with only those vectors loaded into memory. Post-filtering
-    a global top-k returns nothing for a single chat whose records never
-    reach the global head, which is exactly the Telegram case. An
-    unknown metadata key is an empty result; a malformed operator or a
-    non-scalar value is an error.
-  - Ranking: once the filter resolves ids, dense scoring is a matrix
-    product against the query vector, and `hybrid` tokenizes with
-    `bm25.tokenize`, loads postings restricted to those ids, then fuses
-    through `score_postings` and `rrf_fuse` unchanged. Compute the BM25
-    `doc_count` and `avg_doc_len` over the filtered subset rather than
-    the whole collection so idf and scoring agree on what the corpus is.
-    Resolve the query embedding through the shared `embedding_cache`; the
-    per-index `query_cache` layer is index-scoped and not worth
-    duplicating here.
-  - Reranker seam (done): `_rank_documents_bm25`,
-    `_rank_documents_flashrank`, and `_rank_documents_remote` take
-    `(query, documents)` and return ranked `(index, score)` pairs, and
-    `_apply_ranking` maps those back onto results. The file path stays
-    inside `_build_rerank_document`; collections build documents from
-    record text and reuse the three rankers unchanged.
-  - Surface: `vexor/collection_store.py` for the SQLite layer beside
-    `cache.py`, `vexor/services/collection_service.py` for orchestration,
-    and a `VexorClient.collection(name)` handle exposing `upsert_many`,
-    `delete_many`, `get`, `search`, `count`, and `drop`. `upsert_many` is
-    the primary write path — one batched embedding call that skips
-    records whose `text_hash` is unchanged, the same trick
-    `_split_payloads_by_label` already uses for files — and single-record
-    `upsert` delegates to it. Provider and model resolution goes through
-    the existing `_resolve_settings` so config precedence matches every
-    other entry point. Results are a
-    `RecordResult(id, text, metadata, score)`.
-  - Delivery: the reranker refactor has landed, so next are the store,
-    service, and Python API with tests, then
-    `vexor collection list|info|search|delete|drop` plus an
-    `upsert --json -` NDJSON stdin path for bulk import from a database
-    dump. Tests must cover strict pre-filtering (a record ranked first
-    globally must not appear once filtered out), upsert idempotency,
-    cascade deletes, and model or dimension mismatch errors. Hold MCP
-    exposure: the server is path-scoped today, and deciding which
-    collection an agent may reach is a separate design question.
+- Filesystem-independent text collections (shipped): the Python API now
+  accepts caller-owned records directly, persists their text, metadata,
+  embeddings, and BM25 postings in `collections.db`, and returns
+  `RecordResult(id, text, metadata, score)` instead of file locations.
+  `VexorClient.collection(name)` exposes `upsert` / `upsert_many`, `get` /
+  `get_many`, `delete` / `delete_many`, `search`, `count`, `info`, and `drop`.
+  This lets a database remain the source of truth while Vexor incrementally
+  indexes records without a temporary file export. Provider, model, and vector
+  dimension are pinned on first write; later writes with a different contract
+  raise and tell the caller to recreate the collection. Metadata remains a
+  flat scalar mapping, filters resolve before scoring, and v1 has no OR.
+  Deliberate boundaries and follow-ups:
+  - `vexor config --clear-index-all` does not delete `collections.db`. File
+    indexes can be rebuilt from disk, while collection records can only be
+    recovered by re-upserting everything and paying for embeddings again.
+    `clear_all_collections()` is the separate destructive exit.
+  - The CLI `vexor collection ...` surface and its NDJSON bulk-import path are
+    deferred. This release adds no collection command.
+  - MCP exposure is deferred. The server is path-scoped today, and deciding
+    which collection an agent may reach is a separate authorization design
+    question.
+  - Collection search supports `rerank="off"` and `rerank="hybrid"` only;
+    FlashRank and remote reranking are deferred. `hybrid` already fuses dense
+    and BM25 scores over persisted postings whose idf is computed on the
+    filtered subset. That is better information than the legacy `bm25`
+    reranker's second pass over a truncated candidate list: the reranker
+    compensates for file search predating the inverted index, while a
+    collection has one from its first write.
+  - Caller-supplied vectors and a custom embedding function are deferred.
+    Their design must revisit the `text_hash` skip, which currently assumes
+    that identical text always produces an identical vector; externally
+    supplied vectors break that assumption.
+  - Chunking is deferred. V1 stores one vector per record, and over-long text
+    surfaces the embedding provider's error instead of being silently
+    truncated.
 - Flip the default ranking to hybrid retrieval (shipped opt-in behind
   `--rerank hybrid` in 0.25.0) once the benchmark confirms it beats
   dense-only across embedding models. Current `scripts/eval_hybrid.py`

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1155,3 +1155,58 @@ def test_compare_snapshot_current_for_nested_paths(tmp_path, monkeypatch):
         meta["files"],
         recursive=True,
     ) is True
+
+
+def test_schema_reset_ignores_a_half_built_schema(tmp_path):
+    """A schema another connection is still creating must not look stale.
+
+    ``executescript`` builds ``index_metadata`` and ``indexed_file`` before
+    ``indexed_chunk``. A second connection arriving in that window used to
+    conclude the layout was the pre-chunk one and drop the tables the first was
+    still building, surfacing as ``no such table: main.indexed_file`` under
+    concurrent writers.
+    """
+
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_path / "half.db")
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE index_metadata (id INTEGER PRIMARY KEY);
+            CREATE TABLE indexed_file (id INTEGER PRIMARY KEY);
+            """
+        )
+        conn.commit()
+        assert cache._schema_needs_reset(conn) is False
+    finally:
+        conn.close()
+
+
+def test_schema_reset_still_detects_the_pre_chunk_layout(tmp_path):
+    """``file_embedding`` only ever existed before chunked indexing."""
+
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_path / "legacy.db")
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE index_metadata (id INTEGER PRIMARY KEY);
+            CREATE TABLE file_embedding (id INTEGER PRIMARY KEY);
+            """
+        )
+        conn.commit()
+        assert cache._schema_needs_reset(conn) is True
+    finally:
+        conn.close()
+
+
+def test_schema_reset_leaves_an_empty_database_alone(tmp_path):
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_path / "empty.db")
+    try:
+        assert cache._schema_needs_reset(conn) is False
+    finally:
+        conn.close()

--- a/tests/unit/test_collection_contract.py
+++ b/tests/unit/test_collection_contract.py
@@ -689,3 +689,99 @@ def test_a_failed_first_write_leaves_no_pinned_collection(isolated_cache):
     # The name is free again, including under a different contract.
     _upsert("fresh", [{"id": "a", "text": "alpha"}], backend, model="other-model")
     assert store.get_collection("fresh").model == "other-model"
+
+
+# ---------------------------------------------------------------------------
+# 10. Second review pass: the fixes themselves
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_never_deletes_a_concurrent_callers_records(isolated_cache):
+    """Failed-creation cleanup must not take someone else's collection with it.
+
+    Checking "is it empty" and deleting it are one transaction, conditional on
+    the row still being the same collection. Done as separate statements, a
+    caller cleaning up its own failed creation could delete records another
+    caller wrote in between.
+    """
+
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0], "beta": [0.0, 1.0, 0.0]})
+    real_upsert = store.upsert_records
+
+    def fail_after_letting_b_win(collection_id, rows):
+        store.upsert_records = real_upsert
+        # Writer B succeeds against the collection A just created.
+        _upsert("shared", [{"id": "b-record", "text": "beta"}], backend)
+        raise RuntimeError("A's write failed")
+
+    store.upsert_records = fail_after_letting_b_win
+    try:
+        with pytest.raises(RuntimeError):
+            _upsert("shared", [{"id": "a-record", "text": "alpha"}], backend)
+    finally:
+        store.upsert_records = real_upsert
+
+    assert store.get_collection("shared") is not None
+    assert collection_service.count_records(name="shared") == 1
+    assert collection_service.get_records(name="shared", record_keys=["b-record"])
+
+
+def test_cleanup_failure_does_not_replace_the_original_error(isolated_cache):
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0]})
+    real_upsert = store.upsert_records
+    real_drop = store.drop_collection_if_empty
+
+    def explode(collection_id, rows):
+        raise RuntimeError("ORIGINAL")
+
+    def cleanup_explodes(name, collection_id):
+        raise OSError("cleanup blew up")
+
+    store.upsert_records = explode
+    store.drop_collection_if_empty = cleanup_explodes
+    try:
+        with pytest.raises(RuntimeError, match="ORIGINAL"):
+            _upsert("fresh", [{"id": "a", "text": "alpha"}], backend)
+    finally:
+        store.upsert_records = real_upsert
+        store.drop_collection_if_empty = real_drop
+
+
+def test_ensure_wal_reports_the_mode_actually_in_force(tmp_path):
+    """An unsuccessful journal_mode switch does not raise, it reports the old mode.
+
+    So the result has to be inspected rather than assumed, or a database left on
+    the rollback journal would be treated as if it were in WAL.
+    """
+
+    from vexor import sqlite_util
+
+    conn = sqlite_util.connect(tmp_path / "fresh.db")
+    try:
+        assert str(conn.execute("PRAGMA journal_mode;").fetchone()[0]).lower() == "wal"
+        assert sqlite_util._ensure_wal(conn) is True
+    finally:
+        conn.close()
+
+
+def test_ensure_wal_propagates_errors_that_are_not_contention(tmp_path):
+    """Lock contention is tolerated; a disk or corruption error is not.
+
+    Swallowing everything would defer a real failure to some later, unrelated
+    query where it is far harder to attribute.
+    """
+
+    from vexor import sqlite_util
+
+    class Failing:
+        def execute(self, sql, *args):
+            raise sqlite3.OperationalError("disk I/O error")
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O"):
+        sqlite_util._ensure_wal(Failing())
+
+    class Contended:
+        def execute(self, sql, *args):
+            raise sqlite3.OperationalError("database is locked")
+
+    assert sqlite_util._ensure_wal(Contended()) is False

--- a/tests/unit/test_collection_contract.py
+++ b/tests/unit/test_collection_contract.py
@@ -436,3 +436,70 @@ def test_searching_with_a_different_model_raises_even_at_the_same_dimension(
 
     # The matching contract still works.
     assert [hit.id for hit in _search("c", "query", backend)] == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# 8. Concurrent writers must queue, not fail
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_first_writes_do_not_deadlock(isolated_cache):
+    """Racing writers must serialize instead of raising "database is locked".
+
+    A DEFERRED transaction takes a read lock on its first SELECT and only tries
+    to upgrade on the first write. Two writers holding read locks can never both
+    upgrade, so SQLite returns BUSY immediately and busy_timeout does not help --
+    waiting cannot resolve a deadlock. Writes therefore open with BEGIN
+    IMMEDIATE, which busy_timeout does cover.
+    """
+
+    import threading
+
+    errors: list[str] = []
+    created: list[int] = []
+    barrier = threading.Barrier(8)
+
+    def worker() -> None:
+        try:
+            barrier.wait()
+            info = store.ensure_collection(
+                "race", provider="local", model="m", dimension=3
+            )
+            created.append(info.id)
+        # Broad on purpose: the failure mode under test is any raise at all.
+        except Exception as exc:
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(set(created)) == 1, "all writers must converge on one collection"
+
+
+def test_concurrent_upserts_all_land(isolated_cache):
+    import threading
+
+    backend = CountingBackend({})
+    errors: list[str] = []
+    barrier = threading.Barrier(8)
+
+    def worker(index: int) -> None:
+        try:
+            barrier.wait()
+            _upsert("race", [{"id": f"r{index}", "text": f"text {index}"}], backend)
+        # Broad on purpose: the failure mode under test is any raise at all.
+        except Exception as exc:
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert collection_service.count_records(name="race") == 8

--- a/tests/unit/test_collection_contract.py
+++ b/tests/unit/test_collection_contract.py
@@ -1,0 +1,373 @@
+"""Contract tests for the collection API.
+
+These lock the four guarantees the design rests on: filtering happens before
+scoring, unchanged text is never re-embedded, deleting a record takes its
+derived rows with it, and the pinned embedding contract cannot drift. A fifth
+covers the negative-filter recall rule, which is the failure mode the metadata
+contract exists to prevent.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import vexor.cache as cache
+import vexor.collection_store as store
+from vexor.collection_store import CollectionError
+from vexor.search import VexorSearcher
+from vexor.services import collection_service
+
+DIM = 3
+
+
+class CountingBackend:
+    """Deterministic embedding stub that records every call."""
+
+    def __init__(self, vectors: dict[str, list[float]], dim: int = DIM) -> None:
+        self._vectors = vectors
+        self._dim = dim
+        self.calls = 0
+        self.embedded: list[str] = []
+
+    def embed(self, texts):
+        self.calls += 1
+        self.embedded.extend(texts)
+        rows = []
+        for text in texts:
+            vector = self._vectors.get(text)
+            if vector is None:
+                vector = [1.0] + [0.0] * (self._dim - 1)
+            rows.append(vector)
+        return np.array(rows, dtype=np.float32)
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / "cache")
+    cache._clear_embedding_memory_cache()
+    yield tmp_path
+    cache._clear_embedding_memory_cache()
+
+
+def _searcher(backend: CountingBackend) -> VexorSearcher:
+    return VexorSearcher(model_name="stub-model", backend=backend, provider="local")
+
+
+def _upsert(name, records, backend, *, model="stub-model", provider="local"):
+    return collection_service.upsert_records(
+        name=name,
+        records=records,
+        searcher=_searcher(backend),
+        model_name=model,
+        provider=provider,
+    )
+
+
+def _search(name, query, backend, **kwargs):
+    return collection_service.search_records(
+        name=name,
+        query=query,
+        searcher=_searcher(backend),
+        model_name="stub-model",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Strict pre-filtering
+# ---------------------------------------------------------------------------
+
+
+def test_filter_excludes_the_globally_top_ranked_record(isolated_cache):
+    """A filtered-out record must not appear even when it wins globally.
+
+    This is the whole reason filtering resolves to a candidate id set before
+    scoring. Post-filtering a global top-k would return nothing for a chat whose
+    records never reach the global head.
+    """
+
+    backend = CountingBackend(
+        {
+            "deploy broke again": [1.0, 0.0, 0.0],
+            "lunch plans": [0.0, 1.0, 0.0],
+            "dinner plans": [0.0, 0.9, 0.1],
+            "deploy": [1.0, 0.0, 0.0],
+        }
+    )
+    _upsert(
+        "chat",
+        [
+            {"id": "a", "text": "deploy broke again", "metadata": {"chat_id": 1}},
+            {"id": "b", "text": "lunch plans", "metadata": {"chat_id": 2}},
+            {"id": "c", "text": "dinner plans", "metadata": {"chat_id": 2}},
+        ],
+        backend,
+    )
+
+    unfiltered = _search("chat", "deploy", backend, top_k=3)
+    assert unfiltered[0].id == "a", "record a should win without a filter"
+
+    filtered = _search("chat", "deploy", backend, top_k=3, filters={"chat_id": 2})
+    assert [result.id for result in filtered] == ["b", "c"] or [
+        result.id for result in filtered
+    ] == ["c", "b"]
+    assert "a" not in {result.id for result in filtered}
+
+
+def test_filter_on_unknown_key_returns_nothing(isolated_cache):
+    backend = CountingBackend({"hello": [1.0, 0.0, 0.0]})
+    _upsert("chat", [{"id": "a", "text": "hello", "metadata": {"chat_id": 1}}], backend)
+    assert _search("chat", "hello", backend, filters={"nope": 1}) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Upsert idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_unchanged_text_is_not_re_embedded(isolated_cache):
+    backend = CountingBackend({"first": [1.0, 0.0, 0.0], "second": [0.0, 1.0, 0.0]})
+    records = [
+        {"id": "a", "text": "first", "metadata": {"n": 1}},
+        {"id": "b", "text": "second", "metadata": {"n": 2}},
+    ]
+    first = _upsert("c", records, backend)
+    assert first.embedded == 2
+    assert first.skipped == 0
+    embedded_after_first = list(backend.embedded)
+
+    second = _upsert("c", records, backend)
+    assert second.embedded == 0
+    assert second.skipped == 2
+    assert backend.embedded == embedded_after_first, "no text should be embedded twice"
+
+
+def test_metadata_only_edit_skips_embedding_but_updates_the_filter(isolated_cache):
+    """Changing metadata alone must not cost an embedding, and must take effect.
+
+    The stored vector and postings belong to the text, not the metadata, so a
+    pure metadata edit keeps them; dropping them would silently remove the
+    record from lexical search.
+    """
+
+    backend = CountingBackend({"stable text": [1.0, 0.0, 0.0], "stable": [1.0, 0.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "stable text", "metadata": {"tag": "old"}}], backend)
+    calls_after_first = backend.calls
+
+    report = _upsert(
+        "c", [{"id": "a", "text": "stable text", "metadata": {"tag": "new"}}], backend
+    )
+    assert report.embedded == 0
+    assert backend.calls == calls_after_first
+
+    assert _search("c", "stable", backend, filters={"tag": "old"}) == []
+    refreshed = _search("c", "stable", backend, filters={"tag": "new"})
+    assert [result.id for result in refreshed] == ["a"]
+
+    # The vector survived the metadata-only rewrite, so hybrid still ranks it.
+    hybrid = _search("c", "stable text", backend, rerank="hybrid")
+    assert [result.id for result in hybrid] == ["a"]
+
+
+def test_changed_text_re_embeds_only_that_record(isolated_cache):
+    backend = CountingBackend(
+        {
+            "first": [1.0, 0.0, 0.0],
+            "second": [0.0, 1.0, 0.0],
+            "second edited": [0.0, 0.0, 1.0],
+        }
+    )
+    _upsert(
+        "c",
+        [{"id": "a", "text": "first"}, {"id": "b", "text": "second"}],
+        backend,
+    )
+    backend.embedded.clear()
+
+    report = _upsert(
+        "c",
+        [{"id": "a", "text": "first"}, {"id": "b", "text": "second edited"}],
+        backend,
+    )
+    assert report.embedded == 1
+    assert report.skipped == 1
+    assert backend.embedded == ["second edited"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Cascade delete
+# ---------------------------------------------------------------------------
+
+
+def _row_counts(db_path) -> dict[str, int]:
+    from vexor.sqlite_util import connect
+
+    conn = connect(db_path, readonly=True)
+    try:
+        return {
+            table: conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()["n"]
+            for table in (
+                "collection_record",
+                "collection_embedding",
+                "collection_bm25_doc",
+                "collection_bm25_posting",
+                "collection_meta",
+            )
+        }
+    finally:
+        conn.close()
+
+
+def test_deleting_a_record_removes_its_derived_rows(isolated_cache):
+    backend = CountingBackend({"alpha beta": [1.0, 0.0, 0.0], "gamma": [0.0, 1.0, 0.0]})
+    _upsert(
+        "c",
+        [
+            {"id": "a", "text": "alpha beta", "metadata": {"k": "v"}},
+            {"id": "b", "text": "gamma", "metadata": {"k": "w"}},
+        ],
+        backend,
+    )
+    db_path = store.collections_db_path()
+    before = _row_counts(db_path)
+    assert before["collection_record"] == 2
+    assert before["collection_embedding"] == 2
+    assert before["collection_meta"] == 2
+    assert before["collection_bm25_posting"] > 0
+
+    assert collection_service.delete_records(name="c", record_keys=["a"]) == 1
+    after = _row_counts(db_path)
+    assert after["collection_record"] == 1
+    assert after["collection_embedding"] == 1
+    assert after["collection_bm25_doc"] == 1
+    assert after["collection_meta"] == 1
+    assert 0 < after["collection_bm25_posting"] < before["collection_bm25_posting"]
+
+
+def test_dropping_a_collection_removes_every_record(isolated_cache):
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "alpha", "metadata": {"k": "v"}}], backend)
+    assert collection_service.drop_collection(name="c") is True
+    counts = _row_counts(store.collections_db_path())
+    assert all(value == 0 for value in counts.values())
+
+
+# ---------------------------------------------------------------------------
+# 4. The pinned embedding contract cannot drift
+# ---------------------------------------------------------------------------
+
+
+def test_dimension_change_raises_instead_of_mixing_vector_widths(isolated_cache):
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "alpha"}], backend)
+
+    wider = CountingBackend({"beta": [1.0, 0.0, 0.0, 0.0]}, dim=4)
+    with pytest.raises(CollectionError) as excinfo:
+        _upsert("c", [{"id": "b", "text": "beta"}], wider)
+    assert "recreate" in str(excinfo.value).lower()
+
+
+def test_model_change_raises(isolated_cache):
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0], "beta": [0.0, 1.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "alpha"}], backend)
+    with pytest.raises(CollectionError):
+        _upsert("c", [{"id": "b", "text": "beta"}], backend, model="other-model")
+
+
+def test_provider_change_raises(isolated_cache):
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0], "beta": [0.0, 1.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "alpha"}], backend)
+    with pytest.raises(CollectionError):
+        _upsert("c", [{"id": "b", "text": "beta"}], backend, provider="openai")
+
+
+# ---------------------------------------------------------------------------
+# 5. Negative filters must not silently drop unlabeled records
+# ---------------------------------------------------------------------------
+
+
+def test_ne_matches_records_that_lack_the_key(isolated_cache):
+    """``ne`` must include records without the key at all.
+
+    Requiring the key to exist would quietly drop every unlabeled record from a
+    negative filter — the caller believes they excluded closed tickets and
+    actually lost all untagged ones too.
+    """
+
+    backend = CountingBackend(
+        {
+            "closed ticket": [1.0, 0.0, 0.0],
+            "open ticket": [0.9, 0.1, 0.0],
+            "untagged note": [0.8, 0.2, 0.0],
+            "ticket": [1.0, 0.0, 0.0],
+        }
+    )
+    _upsert(
+        "c",
+        [
+            {"id": "closed", "text": "closed ticket", "metadata": {"status": "closed"}},
+            {"id": "open", "text": "open ticket", "metadata": {"status": "open"}},
+            {"id": "untagged", "text": "untagged note", "metadata": {"other": 1}},
+        ],
+        backend,
+    )
+
+    found = {
+        result.id
+        for result in _search(
+            "c", "ticket", backend, top_k=10, filters={"status": {"ne": "closed"}}
+        )
+    }
+    assert found == {"open", "untagged"}
+
+
+def test_nin_matches_records_that_lack_the_key(isolated_cache):
+    backend = CountingBackend(
+        {
+            "a text": [1.0, 0.0, 0.0],
+            "b text": [0.9, 0.1, 0.0],
+            "c text": [0.8, 0.2, 0.0],
+            "text": [1.0, 0.0, 0.0],
+        }
+    )
+    _upsert(
+        "c",
+        [
+            {"id": "a", "text": "a text", "metadata": {"kind": "spam"}},
+            {"id": "b", "text": "b text", "metadata": {"kind": "ham"}},
+            {"id": "c", "text": "c text", "metadata": {}},
+        ],
+        backend,
+    )
+    found = {
+        result.id
+        for result in _search(
+            "c", "text", backend, top_k=10, filters={"kind": {"nin": ["spam"]}}
+        )
+    }
+    assert found == {"b", "c"}
+
+
+def test_exists_is_the_way_to_require_a_key(isolated_cache):
+    backend = CountingBackend(
+        {"tagged": [1.0, 0.0, 0.0], "plain": [0.9, 0.1, 0.0], "q": [1.0, 0.0, 0.0]}
+    )
+    _upsert(
+        "c",
+        [
+            {"id": "tagged", "text": "tagged", "metadata": {"status": "open"}},
+            {"id": "plain", "text": "plain", "metadata": {}},
+        ],
+        backend,
+    )
+    present = {
+        result.id
+        for result in _search("c", "q", backend, filters={"status": {"exists": True}})
+    }
+    assert present == {"tagged"}
+    absent = {
+        result.id
+        for result in _search("c", "q", backend, filters={"status": {"exists": False}})
+    }
+    assert absent == {"plain"}

--- a/tests/unit/test_collection_contract.py
+++ b/tests/unit/test_collection_contract.py
@@ -9,6 +9,8 @@ contract exists to prevent.
 
 from __future__ import annotations
 
+import sqlite3
+
 import numpy as np
 import pytest
 
@@ -503,3 +505,187 @@ def test_concurrent_upserts_all_land(isolated_cache):
 
     assert errors == []
     assert collection_service.count_records(name="race") == 8
+
+
+# ---------------------------------------------------------------------------
+# 9. Findings from the review pass, each locked against regression
+# ---------------------------------------------------------------------------
+
+
+def test_a_falsey_non_mapping_filter_is_an_error_not_no_filter(isolated_cache):
+    """`filters=[]` must not silently widen the search to the whole collection.
+
+    Only ``None`` means "no filter". A caller who decoded a tenant filter into
+    the wrong shape has to hear about it, not receive every tenant's records.
+    """
+
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0], "q": [1.0, 0.0, 0.0]})
+    _upsert(
+        "c",
+        [
+            {"id": "a", "text": "alpha", "metadata": {"tenant": "A"}},
+            {"id": "b", "text": "beta", "metadata": {"tenant": "B"}},
+        ],
+        backend,
+    )
+    for malformed in ([], False, 0, ""):
+        with pytest.raises(CollectionError):
+            _search("c", "q", backend, filters=malformed)
+    # None still means "search everything".
+    assert len(_search("c", "q", backend, filters=None, top_k=10)) == 2
+
+
+def test_text_losing_all_tokens_clears_its_bm25_statistics(isolated_cache):
+    """Stale token counts would skew the corpus average for every hybrid query."""
+
+    backend = CountingBackend({"alpha beta": [1.0, 0.0, 0.0], "!!!": [0.0, 0.0, 1.0]})
+    _upsert("c", [{"id": "a", "text": "alpha beta"}], backend)
+
+    def doc_rows() -> list[tuple[int, int]]:
+        conn = store._open_readonly()
+        try:
+            return [
+                (int(row["record_id"]), int(row["token_count"]))
+                for row in conn.execute(
+                    "SELECT record_id, token_count FROM collection_bm25_doc"
+                )
+            ]
+        finally:
+            conn.close()
+
+    assert doc_rows() == [(1, 2)]
+    _upsert("c", [{"id": "a", "text": "!!!"}], backend)
+    assert doc_rows() == [], "a text with no tokens must leave no length statistic"
+
+
+def test_metadata_only_upsert_loses_to_a_concurrent_text_change(isolated_cache):
+    """The record's text and its vector must never disagree.
+
+    "Unchanged" is decided before the write lock is taken. If another writer
+    changes the text in between, the metadata-only update is writing about a
+    version that no longer exists, so it is skipped rather than committing a row
+    whose text and embedding describe different strings.
+    """
+
+    backend = CountingBackend(
+        {"old text": [1.0, 0.0, 0.0], "new text": [0.0, 1.0, 0.0]}
+    )
+    _upsert("c", [{"id": "r", "text": "old text"}], backend)
+
+    real_upsert = store.upsert_records
+    fired = False
+
+    def interleave(collection_id, rows):
+        nonlocal fired
+        if not fired and rows and rows[0].refresh_embedding is False:
+            fired = True
+            store.upsert_records = real_upsert
+            _upsert("c", [{"id": "r", "text": "new text"}], backend)
+            store.upsert_records = interleave
+        return real_upsert(collection_id, rows)
+
+    store.upsert_records = interleave
+    try:
+        _upsert("c", [{"id": "r", "text": "old text", "metadata": {"w": "late"}}], backend)
+    finally:
+        store.upsert_records = real_upsert
+
+    info = store.get_collection("c")
+    ids = store.resolve_filter_ids(info.id, None)
+    record = store.fetch_by_ids(info.id, ids)[ids[0]]
+    _, matrix = store.load_vectors(info.id, ids, info.dimension)
+    expected = {"old text": [1.0, 0.0, 0.0], "new text": [0.0, 1.0, 0.0]}[record.text]
+    assert np.allclose(matrix[0], expected), "text and vector disagree"
+
+
+def test_search_holds_one_snapshot_so_a_filter_cannot_leak(isolated_cache):
+    """A record moved out of the filtered set mid-search must not be returned.
+
+    Filtering, vector loading, and the final fetch are separate statements. On
+    an idle connection WAL lets the snapshot advance between them, so without an
+    explicit read transaction a writer could hand tenant B's record to a caller
+    who filtered for tenant A.
+    """
+
+    backend = CountingBackend(
+        {"alpha": [1.0, 0.0, 0.0], "beta": [0.0, 1.0, 0.0], "q": [1.0, 0.0, 0.0]}
+    )
+    _upsert(
+        "c",
+        [
+            {"id": "a", "text": "alpha", "metadata": {"tenant": "A"}},
+            {"id": "b", "text": "beta", "metadata": {"tenant": "B"}},
+        ],
+        backend,
+    )
+
+    real_load = store.load_vectors
+    fired = False
+
+    def racing_load(collection_id, record_ids, dimension, conn=None):
+        nonlocal fired
+        if not fired:
+            fired = True
+            # The filter already picked 'a' for tenant A; move it to B.
+            _upsert(
+                "c",
+                [{"id": "a", "text": "alpha", "metadata": {"tenant": "B"}}],
+                backend,
+            )
+        return real_load(collection_id, record_ids, dimension, conn)
+
+    store.load_vectors = racing_load
+    try:
+        results = _search("c", "q", backend, filters={"tenant": "A"}, top_k=10)
+    finally:
+        store.load_vectors = real_load
+
+    assert [r for r in results if r.metadata.get("tenant") != "A"] == []
+
+
+def test_a_damaged_database_raises_instead_of_returning_nothing(isolated_cache):
+    """Collection records cannot be rebuilt, so silence is not an acceptable answer.
+
+    The file index degrades to empty on a read error because it can always be
+    rebuilt from disk. These records can only come back if the caller re-upserts
+    everything and pays for embeddings again, so damage has to surface.
+    """
+
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0], "q": [1.0, 0.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "alpha"}], backend)
+
+    conn = store._open()
+    try:
+        conn.execute("DROP TABLE collection_embedding")
+    finally:
+        conn.close()
+
+    with pytest.raises(sqlite3.OperationalError):
+        _search("c", "q", backend)
+
+
+def test_a_failed_first_write_leaves_no_pinned_collection(isolated_cache):
+    """Creation and the first write are separate transactions.
+
+    If the write fails, a collection created by that same call must not survive
+    holding a contract the caller never successfully used, since that would also
+    block retrying the name under a different provider or model.
+    """
+
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0]})
+    real_upsert = store.upsert_records
+
+    def explode(collection_id, rows):
+        raise RuntimeError("write failed")
+
+    store.upsert_records = explode
+    try:
+        with pytest.raises(RuntimeError):
+            _upsert("fresh", [{"id": "a", "text": "alpha"}], backend)
+    finally:
+        store.upsert_records = real_upsert
+
+    assert store.get_collection("fresh") is None
+    # The name is free again, including under a different contract.
+    _upsert("fresh", [{"id": "a", "text": "alpha"}], backend, model="other-model")
+    assert store.get_collection("fresh").model == "other-model"

--- a/tests/unit/test_collection_contract.py
+++ b/tests/unit/test_collection_contract.py
@@ -69,7 +69,8 @@ def _search(name, query, backend, **kwargs):
         name=name,
         query=query,
         searcher=_searcher(backend),
-        model_name="stub-model",
+        model_name=kwargs.pop("model_name", "stub-model"),
+        provider=kwargs.pop("provider", "local"),
         **kwargs,
     )
 
@@ -371,3 +372,67 @@ def test_exists_is_the_way_to_require_a_key(isolated_cache):
         for result in _search("c", "q", backend, filters={"status": {"exists": False}})
     }
     assert absent == {"plain"}
+
+
+# ---------------------------------------------------------------------------
+# 6. Teardown must not create state, and must not fail on a held file handle
+# ---------------------------------------------------------------------------
+
+
+def test_dropping_a_missing_collection_does_not_create_the_database(isolated_cache):
+    assert collection_service.drop_collection(name="never-existed") is False
+    assert not store.collections_db_path().exists()
+
+
+def test_clear_all_collections_succeeds_while_a_connection_is_open(isolated_cache):
+    """Clearing must work even when a reader still holds the file.
+
+    On Windows an open handle makes ``unlink`` raise, so emptying the tables has
+    to happen first: the caller asked for the records to be gone, and a lock
+    somewhere else in the process must not turn that into an error.
+    """
+
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "alpha"}], backend)
+    held = store._open_readonly()
+    try:
+        store.clear_all_collections()
+        assert store.list_collections() == []
+    finally:
+        if held is not None:
+            held.close()
+
+    # The store stays usable after a clear, whether or not the file survived.
+    _upsert("c2", [{"id": "a", "text": "alpha"}], backend)
+    assert [info.name for info in store.list_collections()] == ["c2"]
+
+
+# ---------------------------------------------------------------------------
+# 7. The pinned contract guards reads, not just writes
+# ---------------------------------------------------------------------------
+
+
+def test_searching_with_a_different_model_raises_even_at_the_same_dimension(
+    isolated_cache,
+):
+    """A same-width model must not be allowed to query someone else's vectors.
+
+    Two models can share a vector width while embedding into unrelated spaces.
+    A dimension check alone lets the dot product succeed and return a ranking
+    that means nothing, which is worse than an error because nothing surfaces.
+    """
+
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0], "query": [1.0, 0.0, 0.0]})
+    _upsert("c", [{"id": "a", "text": "alpha"}], backend)
+
+    # Same dimension, different model: must raise rather than score.
+    with pytest.raises(CollectionError) as excinfo:
+        _search("c", "query", backend, model_name="other-model")
+    assert "recreate" in str(excinfo.value).lower()
+
+    # Same dimension, different provider: same rule.
+    with pytest.raises(CollectionError):
+        _search("c", "query", backend, provider="openai")
+
+    # The matching contract still works.
+    assert [hit.id for hit in _search("c", "query", backend)] == ["a"]

--- a/tests/unit/test_collection_service.py
+++ b/tests/unit/test_collection_service.py
@@ -1,0 +1,225 @@
+"""Unit coverage for collection orchestration and the public handle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from test_collection_contract import CountingBackend
+
+import vexor
+import vexor.api as api_module
+import vexor.cache as cache
+from vexor.collection_store import CollectionError
+from vexor.search import VexorSearcher
+from vexor.services import collection_service
+
+
+@pytest.fixture
+def isolated_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / "cache")
+    cache._clear_embedding_memory_cache()
+    yield tmp_path
+    cache._clear_embedding_memory_cache()
+
+
+def _searcher(backend: CountingBackend) -> VexorSearcher:
+    return VexorSearcher(model_name="stub-model", backend=backend, provider="local")
+
+
+def _upsert(
+    name: str,
+    records,
+    backend: CountingBackend,
+):
+    return collection_service.upsert_records(
+        name=name,
+        records=records,
+        searcher=_searcher(backend),
+        model_name="stub-model",
+        provider="local",
+    )
+
+
+def _search(
+    name: str,
+    query: str,
+    backend: CountingBackend,
+    **kwargs,
+):
+    return collection_service.search_records(
+        name=name,
+        query=query,
+        searcher=_searcher(backend),
+        model_name=kwargs.pop("model_name", "stub-model"),
+        provider=kwargs.pop("provider", "local"),
+        **kwargs,
+    )
+
+
+def test_record_that_is_not_a_mapping_raises_collection_error(isolated_cache):
+    backend = CountingBackend({})
+    with pytest.raises(CollectionError):
+        _upsert("records", [object()], backend)
+
+
+@pytest.mark.parametrize("record", [{"text": "body"}, {"id": "", "text": "body"}])
+def test_empty_or_missing_record_id_raises_collection_error(isolated_cache, record):
+    backend = CountingBackend({})
+    with pytest.raises(CollectionError):
+        _upsert("records", [record], backend)
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        {"id": "one"},
+        {"id": "one", "text": "   \t"},
+    ],
+)
+def test_empty_or_whitespace_text_raises_collection_error(isolated_cache, record):
+    backend = CountingBackend({})
+    with pytest.raises(CollectionError):
+        _upsert("records", [record], backend)
+
+
+def test_duplicate_ids_in_one_call_raise_collection_error(isolated_cache):
+    backend = CountingBackend({})
+    with pytest.raises(CollectionError):
+        _upsert(
+            "records",
+            [
+                {"id": "same", "text": "first"},
+                {"id": " same ", "text": "second"},
+            ],
+            backend,
+        )
+
+
+def test_empty_search_query_raises_collection_error(isolated_cache):
+    backend = CountingBackend({})
+    with pytest.raises(CollectionError):
+        _search("missing", " \t ", backend)
+
+
+def test_unsupported_rerank_value_raises_collection_error(isolated_cache):
+    backend = CountingBackend({})
+    with pytest.raises(CollectionError):
+        _search("missing", "query", backend, rerank="flashrank")
+
+
+def test_non_positive_top_k_returns_empty_without_embedding(isolated_cache):
+    backend = CountingBackend({})
+
+    assert _search("missing", "query", backend, top_k=0) == []
+    assert _search("missing", "query", backend, top_k=-1) == []
+    assert backend.calls == 0
+
+
+def test_searching_missing_collection_raises_collection_error(isolated_cache):
+    backend = CountingBackend({})
+    with pytest.raises(CollectionError):
+        _search("missing", "query", backend)
+
+
+def test_missing_collection_read_and_delete_operations_are_empty(isolated_cache):
+    assert collection_service.get_records(name="missing", record_keys=["one"]) == []
+    assert collection_service.count_records(name="missing") == 0
+    assert collection_service.delete_records(name="missing", record_keys=["one"]) == 0
+
+
+def test_list_collections_and_collection_info(isolated_cache):
+    backend = CountingBackend({"alpha": [1.0, 0.0, 0.0], "beta": [0.0, 1.0, 0.0]})
+    _upsert("zeta", [{"id": "z", "text": "alpha"}], backend)
+    _upsert("alpha", [{"id": "a", "text": "beta"}], backend)
+
+    assert [info.name for info in collection_service.list_collections()] == ["alpha", "zeta"]
+    info = collection_service.collection_info(name="zeta")
+    assert info is not None
+    assert (info.provider, info.model, info.dimension) == ("local", "stub-model", 3)
+    assert collection_service.collection_info(name="missing") is None
+
+
+def _inject_backend(monkeypatch: pytest.MonkeyPatch, backend: CountingBackend) -> None:
+    searcher_type = VexorSearcher
+
+    def make_searcher(**_kwargs) -> VexorSearcher:
+        return searcher_type(model_name="stub-model", backend=backend, provider="local")
+
+    monkeypatch.setattr(api_module, "VexorSearcher", make_searcher)
+
+
+def test_collection_handle_exercises_full_lifecycle(tmp_path: Path, monkeypatch):
+    backend = CountingBackend(
+        {
+            "alpha": [1.0, 0.0, 0.0],
+            "beta": [0.0, 1.0, 0.0],
+            "gamma": [0.0, 0.0, 1.0],
+            "find alpha": [1.0, 0.0, 0.0],
+        }
+    )
+    _inject_backend(monkeypatch, backend)
+    cache_dir = tmp_path / "api-cache"
+
+    with api_module.VexorClient(cache_dir=cache_dir, use_config=False) as client:
+        handle = client.collection(
+            "api-records",
+            provider="local",
+            model="stub-model",
+            no_cache=True,
+        )
+        first = handle.upsert("a", "alpha", {"kind": "first"})
+        rest = handle.upsert_many(
+            [
+                {"id": "b", "text": "beta", "metadata": {"kind": "second"}},
+                {"id": "c", "text": "gamma", "metadata": {"kind": "third"}},
+            ]
+        )
+        assert (first.written, first.embedded, first.skipped) == (1, 1, 0)
+        assert (rest.written, rest.embedded, rest.skipped) == (2, 2, 0)
+
+        results = handle.search("find alpha", top_k=3)
+        assert [result.id for result in results] == ["a", "b", "c"]
+        assert handle.get("a") is not None
+        assert handle.get("missing") is None
+        assert [record.id for record in handle.get_many(["c", "missing", "a"])] == [
+            "c",
+            "a",
+        ]
+        assert handle.count() == 3
+        info = handle.info()
+        assert info is not None
+        assert (info.name, info.provider, info.model, info.dimension) == (
+            "api-records",
+            "local",
+            "stub-model",
+            3,
+        )
+
+        assert handle.delete("b") == 1
+        assert handle.delete_many(["a", "missing"]) == 1
+        assert handle.count() == 1
+        assert handle.drop() is True
+        assert handle.info() is None
+
+    assert (cache_dir / "collections.db").is_file()
+
+
+def test_collection_handle_translates_contract_errors_to_vexor_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    backend = CountingBackend({})
+    _inject_backend(monkeypatch, backend)
+
+    with api_module.VexorClient(cache_dir=tmp_path / "api-cache", use_config=False) as client:
+        handle = client.collection(
+            "api-records",
+            provider="local",
+            model="stub-model",
+            no_cache=True,
+        )
+        with pytest.raises(vexor.VexorError) as excinfo:
+            handle.upsert("", "body")
+
+    assert not isinstance(excinfo.value, CollectionError)

--- a/tests/unit/test_collection_store.py
+++ b/tests/unit/test_collection_store.py
@@ -1,0 +1,268 @@
+"""Unit coverage for the SQLite collection store."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import vexor.cache as cache
+import vexor.collection_store as store
+from vexor.collection_store import CollectionError, PreparedRecord
+from vexor.sqlite_util import connect
+
+
+@pytest.fixture
+def isolated_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / "cache")
+    cache._clear_embedding_memory_cache()
+    yield tmp_path
+    cache._clear_embedding_memory_cache()
+
+
+def _create_collection(name: str = "records") -> store.CollectionInfo:
+    return store.ensure_collection(
+        name,
+        provider="local",
+        model="stub-model",
+        dimension=3,
+    )
+
+
+def _write_records(
+    info: store.CollectionInfo,
+    records: list[tuple[str, dict[str, store.ScalarValue]]],
+) -> None:
+    prepared = [
+        PreparedRecord(
+            record_key=record_id,
+            text=f"text for {record_id}",
+            text_hash=f"hash-{record_id}",
+            metadata=metadata,
+            vector=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+            bm25_terms={"text": 1, record_id: 1},
+            token_count=2,
+        )
+        for record_id, metadata in records
+    ]
+    assert store.upsert_records(info.id, prepared) == len(records)
+
+
+def _filtered_keys(
+    info: store.CollectionInfo,
+    filters: dict[str, object],
+) -> list[str]:
+    internal_ids = store.resolve_filter_ids(info.id, filters)
+    found = store.fetch_by_ids(info.id, internal_ids)
+    return [found[record_id].id for record_id in internal_ids]
+
+
+def test_metadata_scalars_round_trip_filter_and_use_expected_columns(isolated_cache):
+    timestamp = datetime(2026, 8, 20, 12, 30, 45, tzinfo=timezone.utc)
+    metadata: dict[str, store.ScalarValue] = {
+        "string": "alpha",
+        "integer": 7,
+        "float": 2.5,
+        "boolean": True,
+        "timestamp": timestamp,
+        "nullable": None,
+    }
+    info = _create_collection()
+    _write_records(info, [("one", metadata)])
+
+    [record] = store.fetch_records(info.id, ["one"])
+    assert record.metadata == {
+        "string": "alpha",
+        "integer": 7,
+        "float": 2.5,
+        "boolean": True,
+        "timestamp": timestamp.isoformat(),
+        "nullable": None,
+    }
+
+    for key, value in metadata.items():
+        assert _filtered_keys(info, {key: value}) == ["one"]
+
+    conn = connect(store.collections_db_path(), readonly=True)
+    try:
+        rows = conn.execute("SELECT key, value_text, value_num FROM collection_meta").fetchall()
+    finally:
+        conn.close()
+    encoded = {str(row["key"]): (row["value_text"], row["value_num"]) for row in rows}
+    assert encoded == {
+        "string": ("alpha", None),
+        "integer": (None, 7.0),
+        "float": (None, 2.5),
+        "boolean": (None, 1.0),
+        "timestamp": (timestamp.isoformat(), timestamp.timestamp()),
+        "nullable": (None, None),
+    }
+
+
+def test_eq_explicit_and_bare_shorthand(isolated_cache):
+    info = _create_collection()
+    _write_records(
+        info,
+        [
+            ("a", {"group": "x"}),
+            ("b", {"group": "x"}),
+            ("c", {"group": "y"}),
+        ],
+    )
+
+    assert _filtered_keys(info, {"group": {"eq": "x"}}) == ["a", "b"]
+    assert _filtered_keys(info, {"group": "x"}) == ["a", "b"]
+
+
+def test_in_filter_accepts_multiple_scalar_types(isolated_cache):
+    info = _create_collection()
+    _write_records(
+        info,
+        [
+            ("a", {"value": "one"}),
+            ("b", {"value": 2}),
+            ("c", {"value": "three"}),
+        ],
+    )
+
+    assert _filtered_keys(info, {"value": {"in": ["one", 2]}}) == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    ("operator", "threshold", "expected"),
+    [
+        ("gt", 1, ["b", "c"]),
+        ("gte", 2, ["b", "c"]),
+        ("lt", 3, ["a", "b"]),
+        ("lte", 2, ["a", "b"]),
+    ],
+)
+def test_range_filters(
+    isolated_cache,
+    operator: str,
+    threshold: int,
+    expected: list[str],
+):
+    info = _create_collection()
+    _write_records(
+        info,
+        [
+            ("a", {"score": 1}),
+            ("b", {"score": 2}),
+            ("c", {"score": 3}),
+        ],
+    )
+
+    assert _filtered_keys(info, {"score": {operator: threshold}}) == expected
+
+
+def test_multiple_filter_keys_are_anded(isolated_cache):
+    info = _create_collection()
+    _write_records(
+        info,
+        [
+            ("a", {"group": "x", "score": 1}),
+            ("b", {"group": "x", "score": 2}),
+            ("c", {"group": "y", "score": 3}),
+        ],
+    )
+
+    assert _filtered_keys(
+        info,
+        {"group": "x", "score": {"gte": 2}},
+    ) == ["b"]
+
+
+def test_nested_metadata_value_raises_collection_error():
+    with pytest.raises(CollectionError):
+        store.normalize_metadata({"nested": {"child": "value"}})
+
+
+def test_metadata_that_is_not_a_mapping_raises_collection_error():
+    with pytest.raises(CollectionError):
+        store.normalize_metadata([("key", "value")])  # type: ignore[arg-type]
+
+
+def test_unknown_filter_operator_raises_collection_error():
+    with pytest.raises(CollectionError):
+        store.resolve_filter_ids(1, {"key": {"contains": "value"}})
+
+
+def test_exists_with_non_bool_raises_collection_error():
+    with pytest.raises(CollectionError):
+        store.resolve_filter_ids(1, {"key": {"exists": 1}})
+
+
+@pytest.mark.parametrize("operator", ["in", "nin"])
+def test_set_operator_with_non_sequence_raises_collection_error(operator: str):
+    with pytest.raises(CollectionError):
+        store.resolve_filter_ids(1, {"key": {operator: 1}})
+
+
+@pytest.mark.parametrize("operator", ["in", "nin"])
+def test_set_operator_with_empty_sequence_raises_collection_error(operator: str):
+    with pytest.raises(CollectionError):
+        store.resolve_filter_ids(1, {"key": {operator: []}})
+
+
+@pytest.mark.parametrize("operator", ["gt", "gte", "lt", "lte"])
+def test_range_operator_with_string_raises_collection_error(operator: str):
+    with pytest.raises(CollectionError):
+        store.resolve_filter_ids(1, {"key": {operator: "value"}})
+
+
+def test_empty_filter_condition_mapping_raises_collection_error():
+    with pytest.raises(CollectionError):
+        store.resolve_filter_ids(1, {"key": {}})
+
+
+def test_fetch_records_preserves_order_and_skips_absent_ids(isolated_cache):
+    info = _create_collection()
+    _write_records(
+        info,
+        [
+            ("a", {"position": 1}),
+            ("b", {"position": 2}),
+            ("c", {"position": 3}),
+        ],
+    )
+
+    records = store.fetch_records(info.id, ["c", "missing", "a"])
+    assert [record.id for record in records] == ["c", "a"]
+
+
+def test_empty_and_missing_store_operations_are_noops(isolated_cache):
+    assert store.count_records(1) == 0
+    assert store.load_record_hashes(1, ["missing"]) == {}
+    assert store.fetch_records(1, ["missing"]) == []
+    assert store.resolve_filter_ids(1, None) == []
+    assert store.load_bm25_stats(1, [1]) == (0, 0.0)
+    assert store.load_bm25_postings(1, [1], ["term"]) == {}
+    assert store.fetch_by_ids(1, [1]) == {}
+    vector_ids, vectors = store.load_vectors(1, [1], 3)
+    assert vector_ids == []
+    assert vectors.shape == (0, 3)
+
+    assert store.load_record_hashes(1, []) == {}
+    assert store.upsert_records(1, []) == 0
+    assert store.delete_records(1, []) == 0
+    assert store.fetch_records(1, []) == []
+    assert store.load_bm25_stats(1, []) == (0, 0.0)
+    assert store.load_bm25_postings(1, [], ["term"]) == {}
+    assert store.fetch_by_ids(1, []) == {}
+    vector_ids, vectors = store.load_vectors(1, [], 3)
+    assert vector_ids == []
+    assert vectors.shape == (0, 3)
+
+
+def test_clear_all_collections_removes_database_file(isolated_cache):
+    _create_collection()
+    db_path = store.collections_db_path()
+    assert db_path.is_file()
+
+    store.clear_all_collections()
+
+    assert not db_path.exists()
+    assert store.list_collections() == []

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -5,10 +5,26 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from .api import InMemoryIndex, VexorClient, VexorError
+    from .api import (
+        CollectionError,
+        CollectionHandle,
+        CollectionInfo,
+        InMemoryIndex,
+        RecordResult,
+        StoredRecord,
+        UpsertReport,
+        VexorClient,
+        VexorError,
+    )
 
 __all__ = [
+    "CollectionError",
+    "CollectionHandle",
+    "CollectionInfo",
     "InMemoryIndex",
+    "RecordResult",
+    "StoredRecord",
+    "UpsertReport",
     "VexorClient",
     "VexorError",
     "__version__",
@@ -26,7 +42,13 @@ __version__ = "0.27.2"
 
 _API_EXPORTS = frozenset(
     {
+        "CollectionError",
+        "CollectionHandle",
+        "CollectionInfo",
         "InMemoryIndex",
+        "RecordResult",
+        "StoredRecord",
+        "UpsertReport",
         "VexorClient",
         "VexorError",
         "clear_index",

--- a/vexor/api.py
+++ b/vexor/api.py
@@ -1463,6 +1463,7 @@ class CollectionHandle:
                 query=query,
                 searcher=self._searcher(settings),
                 model_name=settings.model_name,
+                provider=settings.provider,
                 top_k=top_k,
                 filters=filters,
                 rerank=rerank,

--- a/vexor/api.py
+++ b/vexor/api.py
@@ -16,8 +16,10 @@ from .cache import (
     project_cache_context,
     set_cache_dir,
 )
+from .collection_store import CollectionError, CollectionInfo, StoredRecord
 from .config import (
     DEFAULT_BATCH_SIZE,
+    DEFAULT_EMBED_CONCURRENCY,
     DEFAULT_EXTRACT_BACKEND,
     DEFAULT_EXTRACT_CONCURRENCY,
     DEFAULT_RERANK,
@@ -35,6 +37,13 @@ from .providers.capabilities import (
     DEFAULT_PROVIDER,
     resolve_default_model,
     validate_embedding_dimensions_for_model,
+)
+from .search import VexorSearcher
+from .services import collection_service
+from .services.collection_service import (
+    DEFAULT_COLLECTION_RERANK,
+    RecordResult,
+    UpsertReport,
 )
 from .services.freshness_service import FreshnessTracker
 from .services.index_service import (
@@ -553,6 +562,54 @@ class VexorClient:
             recursive=recursive,
             extensions=extensions,
             exclude_patterns=exclude_patterns,
+            data_dir=resolved_data_dir,
+            config_dir=resolved_config_dir,
+            cache_dir=resolved_cache_dir,
+        )
+
+    def collection(
+        self,
+        name: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        batch_size: int | None = None,
+        embed_concurrency: int | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        local_cuda: bool | None = None,
+        embedding_dimensions: int | None = None,
+        use_config: bool | None = None,
+        config: Config | Mapping[str, object] | str | None = None,
+        no_cache: bool = False,
+        data_dir: Path | str | None = None,
+        config_dir: Path | str | None = None,
+        cache_dir: Path | str | None = None,
+    ) -> CollectionHandle:
+        """Return a handle to the named record collection.
+
+        The collection is created on first write, not here, so asking for a
+        handle never touches the database.
+        """
+
+        resolved_use_config = self.use_config if use_config is None else use_config
+        resolved_data_dir, resolved_config_dir, resolved_cache_dir = (
+            self._resolve_dir_overrides(data_dir, config_dir, cache_dir)
+        )
+        return CollectionHandle(
+            name,
+            provider=provider,
+            model=model,
+            batch_size=batch_size,
+            embed_concurrency=embed_concurrency,
+            base_url=base_url,
+            api_key=api_key,
+            local_cuda=local_cuda,
+            embedding_dimensions=embedding_dimensions,
+            use_config=resolved_use_config,
+            config=config,
+            runtime_config=self._runtime_config,
+            no_cache=no_cache,
             data_dir=resolved_data_dir,
             config_dir=resolved_config_dir,
             cache_dir=resolved_cache_dir,
@@ -1245,3 +1302,215 @@ def _coerce_embedding_dimensions(value: int | None) -> int | None:
     if value < 0:
         raise VexorError(Messages.ERROR_EMBEDDING_DIMENSIONS_INVALID)
     return value
+
+
+@contextmanager
+def _collection_errors():
+    """Translate store/service contract errors into the public error type."""
+
+    try:
+        yield
+    except CollectionError as exc:
+        raise VexorError(str(exc)) from exc
+
+
+class CollectionHandle:
+    """Session handle for one named collection.
+
+    A collection holds caller-supplied records instead of files, so nothing here
+    takes a path. The embedding provider, model, and vector width are pinned on
+    first write and verified on every later one; changing any of them raises
+    rather than mixing incompatible vectors into one corpus.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        batch_size: int | None = None,
+        embed_concurrency: int | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        local_cuda: bool | None = None,
+        embedding_dimensions: int | None = None,
+        use_config: bool = True,
+        config: Config | Mapping[str, object] | str | None = None,
+        runtime_config: _RuntimeConfigOverride | None = None,
+        no_cache: bool = False,
+        data_dir: Path | str | None = None,
+        config_dir: Path | str | None = None,
+        cache_dir: Path | str | None = None,
+    ) -> None:
+        self.name = name
+        self._provider = provider
+        self._model = model
+        self._batch_size = batch_size
+        self._embed_concurrency = embed_concurrency
+        self._base_url = base_url
+        self._api_key = api_key
+        self._local_cuda = local_cuda
+        self._embedding_dimensions = embedding_dimensions
+        self._use_config = use_config
+        self._config = config
+        self._runtime_config = runtime_config
+        self._no_cache = no_cache
+        self._data_dir = data_dir
+        self._config_dir = config_dir
+        self._cache_dir = cache_dir
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"CollectionHandle(name={self.name!r})"
+
+    def _settings(self) -> RuntimeSettings:
+        # ``directory=None`` on purpose: collections live in the shared cache
+        # directory, so picking up a project-local config from the working
+        # directory would make the pinned provider depend on where Python
+        # happened to be started.
+        return _resolve_settings(
+            directory=None,
+            provider=self._provider,
+            model=self._model,
+            batch_size=self._batch_size,
+            embed_concurrency=self._embed_concurrency,
+            extract_concurrency=None,
+            extract_backend=None,
+            base_url=self._base_url,
+            api_key=self._api_key,
+            local_cuda=self._local_cuda,
+            embedding_dimensions=self._embedding_dimensions,
+            auto_index=None,
+            use_config=self._use_config,
+            runtime_config=self._runtime_config,
+            config_override=self._config,
+        )
+
+    def _dir_context(self):
+        return _data_dir_context(
+            self._data_dir,
+            config_dir=self._config_dir,
+            cache_dir=self._cache_dir,
+        )
+
+    def _searcher(self, settings: RuntimeSettings) -> VexorSearcher:
+        return VexorSearcher(
+            model_name=settings.model_name,
+            batch_size=settings.batch_size,
+            embed_concurrency=settings.embed_concurrency or DEFAULT_EMBED_CONCURRENCY,
+            provider=settings.provider,
+            base_url=settings.base_url,
+            api_key=settings.api_key,
+            local_cuda=settings.local_cuda,
+            embedding_dimensions=settings.embedding_dimensions,
+        )
+
+    def upsert_many(
+        self,
+        records: Sequence[Mapping[str, object]],
+    ) -> UpsertReport:
+        """Insert or replace records, embedding only the texts that changed.
+
+        Each record is a mapping with ``id`` and ``text``, plus an optional flat
+        ``metadata`` mapping of scalars. A record whose text is unchanged since
+        the last upsert keeps its stored vector and postings; its metadata is
+        still replaced, so a pure metadata edit costs nothing to embed.
+        """
+
+        with self._dir_context(), _collection_errors():
+            settings = self._settings()
+            return collection_service.upsert_records(
+                name=self.name,
+                records=records,
+                searcher=self._searcher(settings),
+                model_name=settings.model_name,
+                provider=settings.provider,
+                embedding_dimension=settings.embedding_dimensions,
+                no_cache=self._no_cache,
+            )
+
+    def upsert(
+        self,
+        record_id: str,
+        text: str,
+        metadata: Mapping[str, object] | None = None,
+    ) -> UpsertReport:
+        """Insert or replace a single record."""
+
+        return self.upsert_many(
+            [{"id": record_id, "text": text, "metadata": metadata}]
+        )
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 10,
+        filters: Mapping[str, object] | None = None,
+        rerank: str = DEFAULT_COLLECTION_RERANK,
+    ) -> list[RecordResult]:
+        """Search this collection, applying *filters* before anything is scored.
+
+        Filtering is strict and resolves to a candidate id set first, so a
+        record that never reaches the global head is still findable inside its
+        own filtered subset.
+        """
+
+        with self._dir_context(), _collection_errors():
+            settings = self._settings()
+            return collection_service.search_records(
+                name=self.name,
+                query=query,
+                searcher=self._searcher(settings),
+                model_name=settings.model_name,
+                top_k=top_k,
+                filters=filters,
+                rerank=rerank,
+                embedding_dimension=settings.embedding_dimensions,
+                no_cache=self._no_cache,
+            )
+
+    def delete_many(self, record_ids: Sequence[str]) -> int:
+        """Delete records by id, returning how many existed."""
+
+        with self._dir_context(), _collection_errors():
+            return collection_service.delete_records(
+                name=self.name, record_keys=record_ids
+            )
+
+    def delete(self, record_id: str) -> int:
+        """Delete a single record by id."""
+
+        return self.delete_many([record_id])
+
+    def get_many(self, record_ids: Sequence[str]) -> list[StoredRecord]:
+        """Return stored records by id, skipping ids that are absent."""
+
+        with self._dir_context(), _collection_errors():
+            return collection_service.get_records(
+                name=self.name, record_keys=record_ids
+            )
+
+    def get(self, record_id: str) -> StoredRecord | None:
+        """Return one stored record, or ``None`` when it is absent."""
+
+        found = self.get_many([record_id])
+        return found[0] if found else None
+
+    def count(self) -> int:
+        """Return how many records this collection holds."""
+
+        with self._dir_context(), _collection_errors():
+            return collection_service.count_records(name=self.name)
+
+    def info(self) -> CollectionInfo | None:
+        """Return the pinned provider/model/dimension contract, or ``None``."""
+
+        with self._dir_context(), _collection_errors():
+            return collection_service.collection_info(name=self.name)
+
+    def drop(self) -> bool:
+        """Delete this collection and every record in it."""
+
+        with self._dir_context(), _collection_errors():
+            return collection_service.drop_collection(name=self.name)

--- a/vexor/cache.py
+++ b/vexor/cache.py
@@ -7,7 +7,7 @@ import os
 import sqlite3
 import uuid
 from collections import OrderedDict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -17,6 +17,7 @@ from threading import Lock
 
 import numpy as np
 
+from .sqlite_util import chunk_values, connect
 from .utils import collect_files
 
 DEFAULT_CACHE_DIR = Path(os.path.expanduser("~")) / ".vexor"
@@ -250,9 +251,8 @@ def _deserialize_exclude_patterns(value: str | None) -> tuple[str, ...]:
     return tuple(parts)
 
 
-def _chunk_values(values: Sequence[object], size: int) -> Iterable[Sequence[object]]:
-    for idx in range(0, len(values), size):
-        yield values[idx : idx + size]
+# Shared with the collection store so both databases batch identically.
+_chunk_values = chunk_values
 
 
 def _resolve_cache_dir() -> Path:
@@ -371,30 +371,8 @@ def cache_file(  # pragma: no cover - kept for API parity
     return cache_db_path()
 
 
-def _connect(
-    db_path: Path,
-    *,
-    readonly: bool = False,
-    query_only: bool = False,
-) -> sqlite3.Connection:
-    if readonly:
-        db_uri = f"file:{db_path.as_posix()}?mode=ro"
-        conn = sqlite3.connect(db_uri, uri=True)
-    else:
-        conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    try:
-        conn.execute("PRAGMA journal_mode = WAL;")
-    except sqlite3.OperationalError as exc:
-        if "readonly" not in str(exc).lower():
-            raise
-    conn.execute("PRAGMA synchronous = NORMAL;")
-    conn.execute("PRAGMA temp_store = MEMORY;")
-    conn.execute("PRAGMA busy_timeout = 5000;")
-    conn.execute("PRAGMA foreign_keys = ON;")
-    if readonly or query_only:
-        conn.execute("PRAGMA query_only = ON;")
-    return conn
+# Shared with the collection store so both databases open under the same pragmas.
+_connect = connect
 
 
 def _ensure_schema_readonly(

--- a/vexor/cache.py
+++ b/vexor/cache.py
@@ -403,12 +403,21 @@ def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
 
 
 def _schema_needs_reset(conn: sqlite3.Connection) -> bool:
-    if _table_exists(conn, "indexed_chunk"):
-        return False
-    return any(
-        _table_exists(conn, table)
-        for table in ("index_metadata", "indexed_file", "file_embedding", "query_cache")
-    )
+    """True when the database still holds the pre-chunk layout.
+
+    Keyed on ``file_embedding``, which only ever existed before chunked indexing
+    and is never created again, so its presence is unambiguous.
+
+    The previous test — ``indexed_chunk`` missing while some other index table is
+    present — also fired against a schema that another connection was partway
+    through creating: ``executescript`` builds ``index_metadata`` and
+    ``indexed_file`` before ``indexed_chunk``, so a second connection arriving in
+    that window concluded the layout was stale and dropped the tables the first
+    one was still building. That surfaced as ``no such table: main.indexed_file``
+    under concurrent writers.
+    """
+
+    return _table_exists(conn, "file_embedding")
 
 
 def _reset_index_schema(conn: sqlite3.Connection) -> None:

--- a/vexor/collection_store.py
+++ b/vexor/collection_store.py
@@ -202,15 +202,47 @@ def _write_transaction(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]
 
 
 def _open_readonly() -> sqlite3.Connection | None:
-    """Open the database read-only, or return ``None`` when it does not exist."""
+    """Open the database read-only, or return ``None`` when it does not exist.
+
+    A missing file is the one expected "nothing here" case — asking about a
+    collection before anything was ever written. Every other failure is real
+    damage and propagates, because these records cannot be rebuilt from disk the
+    way a file index can.
+    """
 
     db_path = collections_db_path()
     if not db_path.exists():
         return None
+    conn = connect(db_path, readonly=True)
+    # Explicit transaction control so read_snapshot can pin one snapshot.
+    conn.isolation_level = None
+    return conn
+
+
+@contextmanager
+def read_snapshot() -> Iterator[sqlite3.Connection | None]:
+    """Hold one read transaction so every query inside sees the same data.
+
+    WAL gives readers a consistent snapshot only for the duration of a read
+    transaction; between statements on an idle connection the snapshot advances.
+    A search that resolves its filter, loads vectors, then reads records across
+    three separate statements can therefore observe a record that a concurrent
+    writer moved out of the filtered set in between — and return it to the wrong
+    tenant. Yields ``None`` when the database does not exist yet.
+    """
+
+    conn = _open_readonly()
+    if conn is None:
+        yield None
+        return
     try:
-        return connect(db_path, readonly=True)
-    except sqlite3.OperationalError:
-        return None
+        conn.execute("BEGIN")
+        yield conn
+    finally:
+        try:
+            conn.rollback()
+        finally:
+            conn.close()
 
 
 # --------------------------------------------------------------------------
@@ -366,39 +398,40 @@ def ensure_collection(
         conn.close()
 
 
-def get_collection(name: str) -> CollectionInfo | None:
+def get_collection(
+    name: str,
+    conn: sqlite3.Connection | None = None,
+) -> CollectionInfo | None:
     """Return the stored contract for *name*, or ``None`` when it does not exist."""
 
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return None
     try:
-        try:
-            row = conn.execute(
-                "SELECT * FROM collection WHERE name = ?", ((name or "").strip(),)
-            ).fetchone()
-        except sqlite3.OperationalError:
-            return None
+        row = connection.execute(
+            "SELECT * FROM collection WHERE name = ?", ((name or "").strip(),)
+        ).fetchone()
         return _row_to_info(row) if row is not None else None
     finally:
-        conn.close()
+        if owns_connection:
+            connection.close()
 
-
-def list_collections() -> list[CollectionInfo]:
+def list_collections(
+    conn: sqlite3.Connection | None = None,
+) -> list[CollectionInfo]:
     """Return every stored collection, ordered by name."""
 
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return []
     try:
-        try:
-            rows = conn.execute("SELECT * FROM collection ORDER BY name").fetchall()
-        except sqlite3.OperationalError:
-            return []
+        rows = connection.execute("SELECT * FROM collection ORDER BY name").fetchall()
         return [_row_to_info(row) for row in rows]
     finally:
-        conn.close()
-
+        if owns_connection:
+            connection.close()
 
 def drop_collection(name: str) -> bool:
     """Delete *name* and everything under it. Returns ``False`` when absent."""
@@ -417,24 +450,25 @@ def drop_collection(name: str) -> bool:
         conn.close()
 
 
-def count_records(collection_id: int) -> int:
+def count_records(
+    collection_id: int,
+    conn: sqlite3.Connection | None = None,
+) -> int:
     """Return how many records *collection_id* holds."""
 
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return 0
     try:
-        try:
-            row = conn.execute(
-                "SELECT COUNT(*) AS total FROM collection_record WHERE collection_id = ?",
-                (int(collection_id),),
-            ).fetchone()
-        except sqlite3.OperationalError:
-            return 0
+        row = connection.execute(
+            "SELECT COUNT(*) AS total FROM collection_record WHERE collection_id = ?",
+            (int(collection_id),),
+        ).fetchone()
         return int(row["total"]) if row is not None else 0
     finally:
-        conn.close()
-
+        if owns_connection:
+            connection.close()
 
 def clear_all_collections() -> None:
     """Remove the collection database entirely.
@@ -475,68 +509,97 @@ def clear_all_collections() -> None:
 def load_record_hashes(
     collection_id: int,
     record_keys: Sequence[str],
+    conn: sqlite3.Connection | None = None,
 ) -> dict[str, str]:
     """Return ``{record_key: text_hash}`` for the keys already stored."""
 
     keys = [key for key in dict.fromkeys(record_keys) if key]
     if not keys:
         return {}
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return {}
     try:
         results: dict[str, str] = {}
         for batch in chunk_values(keys):
             placeholders = ", ".join("?" for _ in batch)
-            try:
-                rows = conn.execute(
-                    f"""
-                    SELECT record_key, text_hash
-                    FROM collection_record
-                    WHERE collection_id = ? AND record_key IN ({placeholders})
-                    """,
-                    (int(collection_id), *batch),
-                ).fetchall()
-            except sqlite3.OperationalError:
-                return {}
+            rows = connection.execute(
+                f"""
+                SELECT record_key, text_hash
+                FROM collection_record
+                WHERE collection_id = ? AND record_key IN ({placeholders})
+                """,
+                (int(collection_id), *batch),
+            ).fetchall()
             for row in rows:
                 results[str(row["record_key"])] = str(row["text_hash"])
         return results
     finally:
-        conn.close()
-
+        if owns_connection:
+            connection.close()
 
 def upsert_records(collection_id: int, records: Sequence[PreparedRecord]) -> int:
-    """Insert or replace *records*, returning how many rows were written."""
+    """Insert or replace *records*, returning how many rows were written.
+
+    A record whose text is unchanged takes a narrower path: its metadata is
+    rewritten under a ``text_hash`` guard, so a concurrent writer that changed
+    the text between the service layer's read and this transaction wins and the
+    stale update is skipped. Without the guard the row would end up claiming the
+    old text while the embedding and postings describe the new one.
+    """
 
     if not records:
         return 0
     conn = _open()
     try:
         updated_at = datetime.now(timezone.utc).isoformat()
+        written = 0
         with _write_transaction(conn):
             for record in records:
-                conn.execute(
-                    """
-                    INSERT INTO collection_record (
-                        collection_id, record_key, text, text_hash,
-                        metadata_json, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(collection_id, record_key) DO UPDATE SET
-                        text = excluded.text,
-                        text_hash = excluded.text_hash,
-                        metadata_json = excluded.metadata_json,
-                        updated_at = excluded.updated_at
-                    """,
-                    (
-                        int(collection_id),
-                        record.record_key,
-                        record.text,
-                        record.text_hash,
-                        json.dumps(_metadata_to_json(record.metadata)),
-                        updated_at,
-                    ),
-                )
+                metadata_json = json.dumps(_metadata_to_json(record.metadata))
+                if record.refresh_embedding:
+                    conn.execute(
+                        """
+                        INSERT INTO collection_record (
+                            collection_id, record_key, text, text_hash,
+                            metadata_json, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(collection_id, record_key) DO UPDATE SET
+                            text = excluded.text,
+                            text_hash = excluded.text_hash,
+                            metadata_json = excluded.metadata_json,
+                            updated_at = excluded.updated_at
+                        """,
+                        (
+                            int(collection_id),
+                            record.record_key,
+                            record.text,
+                            record.text_hash,
+                            metadata_json,
+                            updated_at,
+                        ),
+                    )
+                else:
+                    cursor = conn.execute(
+                        """
+                        UPDATE collection_record
+                        SET metadata_json = ?, updated_at = ?
+                        WHERE collection_id = ? AND record_key = ? AND text_hash = ?
+                        """,
+                        (
+                            metadata_json,
+                            updated_at,
+                            int(collection_id),
+                            record.record_key,
+                            record.text_hash,
+                        ),
+                    )
+                    if cursor.rowcount == 0:
+                        # The text changed under us, so this metadata belongs to
+                        # a version that no longer exists. Leave the winner be.
+                        continue
+
                 row = conn.execute(
                     """
                     SELECT id FROM collection_record
@@ -545,21 +608,16 @@ def upsert_records(collection_id: int, records: Sequence[PreparedRecord]) -> int
                     (int(collection_id), record.record_key),
                 ).fetchone()
                 record_id = int(row["id"])
+                written += 1
+
                 # Metadata replaces wholesale on every upsert.
                 conn.execute(
                     "DELETE FROM collection_meta WHERE record_id = ?", (record_id,)
                 )
-                if record.refresh_embedding:
-                    # New text means the old postings score a string that no
-                    # longer exists, so they go before the new ones land.
-                    conn.execute(
-                        "DELETE FROM collection_bm25_posting WHERE record_id = ?",
-                        (record_id,),
-                    )
-                meta_rows = []
-                for key, value in record.metadata.items():
-                    value_text, value_num = _encode_value(value)
-                    meta_rows.append((record_id, key, value_text, value_num))
+                meta_rows = [
+                    (record_id, key, *_encode_value(value))
+                    for key, value in record.metadata.items()
+                ]
                 if meta_rows:
                     conn.executemany(
                         """
@@ -568,6 +626,22 @@ def upsert_records(collection_id: int, records: Sequence[PreparedRecord]) -> int
                         """,
                         meta_rows,
                     )
+
+                if not record.refresh_embedding:
+                    continue
+
+                # New text means the old postings and length statistics describe
+                # a string that no longer exists. Both go unconditionally: a text
+                # that tokenizes to nothing must not leave the previous
+                # token_count behind for the corpus average to pick up.
+                conn.execute(
+                    "DELETE FROM collection_bm25_posting WHERE record_id = ?",
+                    (record_id,),
+                )
+                conn.execute(
+                    "DELETE FROM collection_bm25_doc WHERE record_id = ?",
+                    (record_id,),
+                )
                 if record.vector is not None:
                     conn.execute(
                         """
@@ -582,7 +656,7 @@ def upsert_records(collection_id: int, records: Sequence[PreparedRecord]) -> int
                 if record.bm25_terms:
                     conn.execute(
                         """
-                        INSERT OR REPLACE INTO collection_bm25_doc (record_id, token_count)
+                        INSERT INTO collection_bm25_doc (record_id, token_count)
                         VALUES (?, ?)
                         """,
                         (record_id, int(record.token_count)),
@@ -598,7 +672,7 @@ def upsert_records(collection_id: int, records: Sequence[PreparedRecord]) -> int
                             for term, tf in record.bm25_terms.items()
                         ],
                     )
-        return len(records)
+        return written
     finally:
         conn.close()
 
@@ -648,30 +722,32 @@ def _decode_metadata(payload: str) -> dict[str, ScalarValue]:
     return loaded if isinstance(loaded, dict) else {}
 
 
-def fetch_records(collection_id: int, record_keys: Sequence[str]) -> list[StoredRecord]:
+def fetch_records(
+    collection_id: int,
+    record_keys: Sequence[str],
+    conn: sqlite3.Connection | None = None,
+) -> list[StoredRecord]:
     """Return stored records for *record_keys*, skipping keys that are absent."""
 
     keys = [key for key in dict.fromkeys(record_keys) if key]
     if not keys:
         return []
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return []
     try:
         found: dict[str, StoredRecord] = {}
         for batch in chunk_values(keys):
             placeholders = ", ".join("?" for _ in batch)
-            try:
-                rows = conn.execute(
-                    f"""
-                    SELECT record_key, text, metadata_json
-                    FROM collection_record
-                    WHERE collection_id = ? AND record_key IN ({placeholders})
-                    """,
-                    (int(collection_id), *batch),
-                ).fetchall()
-            except sqlite3.OperationalError:
-                return []
+            rows = connection.execute(
+                f"""
+                SELECT record_key, text, metadata_json
+                FROM collection_record
+                WHERE collection_id = ? AND record_key IN ({placeholders})
+                """,
+                (int(collection_id), *batch),
+            ).fetchall()
             for row in rows:
                 found[str(row["record_key"])] = StoredRecord(
                     id=str(row["record_key"]),
@@ -680,14 +756,25 @@ def fetch_records(collection_id: int, record_keys: Sequence[str]) -> list[Stored
                 )
         return [found[key] for key in keys if key in found]
     finally:
-        conn.close()
-
+        if owns_connection:
+            connection.close()
 
 def _compile_filter(
     filters: Mapping[str, object] | None,
 ) -> tuple[list[str], list[object]]:
     """Compile *filters* into SQL fragments ANDed against ``collection_record``."""
 
+    if filters is None:
+        return [], []
+    if not isinstance(filters, Mapping):
+        # Only None means "no filter". A falsey non-mapping — an empty list, 0,
+        # False — is a malformed filter, and treating it as "no filter" would
+        # silently widen a tenant-scoped search to the entire collection.
+        raise CollectionError(
+            Messages.ERROR_COLLECTION_FILTER_NOT_MAPPING.format(
+                type=type(filters).__name__
+            )
+        )
     if not filters:
         return [], []
     clauses: list[str] = []
@@ -801,6 +888,7 @@ def _compile_operation(
 def resolve_filter_ids(
     collection_id: int,
     filters: Mapping[str, object] | None,
+    conn: sqlite3.Connection | None = None,
 ) -> list[int]:
     """Return the record ids matching *filters*, resolved before any scoring.
 
@@ -809,52 +897,50 @@ def resolve_filter_ids(
     """
 
     clauses, params = _compile_filter(filters)
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return []
     try:
         sql = "SELECT r.id FROM collection_record AS r WHERE r.collection_id = ?"
         if clauses:
             sql += " AND " + " AND ".join(clauses)
         sql += " ORDER BY r.id"
-        try:
-            rows = conn.execute(sql, (int(collection_id), *params)).fetchall()
-        except sqlite3.OperationalError:
-            return []
+        rows = connection.execute(sql, (int(collection_id), *params)).fetchall()
         return [int(row["id"]) for row in rows]
     finally:
-        conn.close()
-
+        if owns_connection:
+            connection.close()
 
 def load_vectors(
     collection_id: int,
     record_ids: Sequence[int],
     dimension: int,
+    conn: sqlite3.Connection | None = None,
 ) -> tuple[list[int], np.ndarray]:
     """Load embeddings for *record_ids*, dropping rows with no stored vector."""
 
     ids = [int(value) for value in record_ids]
+    empty = np.empty((0, dimension), dtype=np.float32)
     if not ids:
-        return [], np.empty((0, dimension), dtype=np.float32)
-    conn = _open_readonly()
-    if conn is None:
-        return [], np.empty((0, dimension), dtype=np.float32)
+        return [], empty
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
+        return [], empty
     try:
         vectors: dict[int, np.ndarray] = {}
         for batch in chunk_values(ids):
             placeholders = ", ".join("?" for _ in batch)
-            try:
-                rows = conn.execute(
-                    f"""
-                    SELECT e.record_id, e.vector_blob
-                    FROM collection_embedding AS e
-                    JOIN collection_record AS r ON r.id = e.record_id
-                    WHERE r.collection_id = ? AND e.record_id IN ({placeholders})
-                    """,
-                    (int(collection_id), *batch),
-                ).fetchall()
-            except sqlite3.OperationalError:
-                return [], np.empty((0, dimension), dtype=np.float32)
+            rows = connection.execute(
+                f"""
+                SELECT e.record_id, e.vector_blob
+                FROM collection_embedding AS e
+                JOIN collection_record AS r ON r.id = e.record_id
+                WHERE r.collection_id = ? AND e.record_id IN ({placeholders})
+                """,
+                (int(collection_id), *batch),
+            ).fetchall()
             for row in rows:
                 blob = row["vector_blob"]
                 if not blob:
@@ -865,16 +951,17 @@ def load_vectors(
                 vectors[int(row["record_id"])] = vector
         ordered_ids = [value for value in ids if value in vectors]
         if not ordered_ids:
-            return [], np.empty((0, dimension), dtype=np.float32)
+            return [], empty
         matrix = np.vstack([vectors[value] for value in ordered_ids])
         return ordered_ids, matrix
     finally:
-        conn.close()
-
+        if owns_connection:
+            connection.close()
 
 def load_bm25_stats(
     collection_id: int,
     record_ids: Sequence[int],
+    conn: sqlite3.Connection | None = None,
 ) -> tuple[int, float]:
     """Return BM25 corpus statistics over *record_ids* only.
 
@@ -885,25 +972,23 @@ def load_bm25_stats(
     ids = [int(value) for value in record_ids]
     if not ids:
         return 0, 0.0
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return 0, 0.0
     try:
         total = 0
         length_sum = 0
         for batch in chunk_values(ids):
             placeholders = ", ".join("?" for _ in batch)
-            try:
-                row = conn.execute(
-                    f"""
-                    SELECT COUNT(*) AS doc_count, SUM(token_count) AS length_sum
-                    FROM collection_bm25_doc
-                    WHERE record_id IN ({placeholders})
-                    """,
-                    tuple(batch),
-                ).fetchone()
-            except sqlite3.OperationalError:
-                return 0, 0.0
+            row = connection.execute(
+                f"""
+                SELECT COUNT(*) AS doc_count, SUM(token_count) AS length_sum
+                FROM collection_bm25_doc
+                WHERE record_id IN ({placeholders})
+                """,
+                tuple(batch),
+            ).fetchone()
             if row is None:
                 continue
             total += int(row["doc_count"] or 0)
@@ -912,13 +997,14 @@ def load_bm25_stats(
             return 0, 0.0
         return total, length_sum / total
     finally:
-        conn.close()
-
+        if owns_connection:
+            connection.close()
 
 def load_bm25_postings(
     collection_id: int,
     record_ids: Sequence[int],
     terms: Sequence[str],
+    conn: sqlite3.Connection | None = None,
 ) -> dict[str, list[tuple[int, int, int]]]:
     """Load posting lists restricted to *record_ids*, shaped for ``bm25``."""
 
@@ -926,25 +1012,23 @@ def load_bm25_postings(
     unique_terms = [term for term in dict.fromkeys(terms) if term]
     if not ids or not unique_terms:
         return {}
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return {}
     try:
         results: dict[str, list[tuple[int, int, int]]] = {}
         for batch in chunk_values(unique_terms):
             placeholders = ", ".join("?" for _ in batch)
-            try:
-                rows = conn.execute(
-                    f"""
-                    SELECT p.term, p.record_id, p.tf, d.token_count
-                    FROM collection_bm25_posting AS p
-                    JOIN collection_bm25_doc AS d ON d.record_id = p.record_id
-                    WHERE p.collection_id = ? AND p.term IN ({placeholders})
-                    """,
-                    (int(collection_id), *batch),
-                ).fetchall()
-            except sqlite3.OperationalError:
-                return {}
+            rows = connection.execute(
+                f"""
+                SELECT p.term, p.record_id, p.tf, d.token_count
+                FROM collection_bm25_posting AS p
+                JOIN collection_bm25_doc AS d ON d.record_id = p.record_id
+                WHERE p.collection_id = ? AND p.term IN ({placeholders})
+                """,
+                (int(collection_id), *batch),
+            ).fetchall()
             for row in rows:
                 record_id = int(row["record_id"])
                 if record_id not in ids:
@@ -954,33 +1038,35 @@ def load_bm25_postings(
                 )
         return results
     finally:
-        conn.close()
+        if owns_connection:
+            connection.close()
 
-
-def fetch_by_ids(collection_id: int, record_ids: Sequence[int]) -> dict[int, StoredRecord]:
+def fetch_by_ids(
+    collection_id: int,
+    record_ids: Sequence[int],
+    conn: sqlite3.Connection | None = None,
+) -> dict[int, StoredRecord]:
     """Return ``{record_id: StoredRecord}`` for the given internal ids."""
 
     ids = [int(value) for value in dict.fromkeys(record_ids)]
     if not ids:
         return {}
-    conn = _open_readonly()
-    if conn is None:
+    owns_connection = conn is None
+    connection = conn if conn is not None else _open_readonly()
+    if connection is None:
         return {}
     try:
         results: dict[int, StoredRecord] = {}
         for batch in chunk_values(ids):
             placeholders = ", ".join("?" for _ in batch)
-            try:
-                rows = conn.execute(
-                    f"""
-                    SELECT id, record_key, text, metadata_json
-                    FROM collection_record
-                    WHERE collection_id = ? AND id IN ({placeholders})
-                    """,
-                    (int(collection_id), *batch),
-                ).fetchall()
-            except sqlite3.OperationalError:
-                return {}
+            rows = connection.execute(
+                f"""
+                SELECT id, record_key, text, metadata_json
+                FROM collection_record
+                WHERE collection_id = ? AND id IN ({placeholders})
+                """,
+                (int(collection_id), *batch),
+            ).fetchall()
             for row in rows:
                 results[int(row["id"])] = StoredRecord(
                     id=str(row["record_key"]),
@@ -989,4 +1075,6 @@ def fetch_by_ids(collection_id: int, record_ids: Sequence[int]) -> dict[int, Sto
                 )
         return results
     finally:
-        conn.close()
+        if owns_connection:
+            connection.close()
+

--- a/vexor/collection_store.py
+++ b/vexor/collection_store.py
@@ -450,6 +450,37 @@ def drop_collection(name: str) -> bool:
         conn.close()
 
 
+def drop_collection_if_empty(name: str, collection_id: int) -> bool:
+    """Drop *name* only if it is still *collection_id* and still holds nothing.
+
+    Both checks happen inside one write transaction. Doing them as separate
+    statements would let a caller cleaning up its own failed creation delete a
+    different caller's collection: the row can gain records, or be dropped and
+    recreated under the same name, between a separate check and the delete.
+    """
+
+    if not collections_db_path().exists():
+        return False
+    conn = _open()
+    try:
+        with _write_transaction(conn):
+            row = conn.execute(
+                "SELECT id FROM collection WHERE name = ?", ((name or "").strip(),)
+            ).fetchone()
+            if row is None or int(row["id"]) != int(collection_id):
+                return False
+            populated = conn.execute(
+                "SELECT 1 FROM collection_record WHERE collection_id = ? LIMIT 1",
+                (int(collection_id),),
+            ).fetchone()
+            if populated is not None:
+                return False
+            conn.execute("DELETE FROM collection WHERE id = ?", (int(collection_id),))
+            return True
+    finally:
+        conn.close()
+
+
 def count_records(
     collection_id: int,
     conn: sqlite3.Connection | None = None,

--- a/vexor/collection_store.py
+++ b/vexor/collection_store.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -172,8 +173,32 @@ def _open(readonly: bool = False) -> sqlite3.Connection:
     db_path = collections_db_path()
     conn = connect(db_path, readonly=readonly)
     if not readonly:
+        # Hand transaction control to us so writes can open with BEGIN
+        # IMMEDIATE; see _write_transaction for why that matters.
+        conn.isolation_level = None
         _ensure_schema(conn)
     return conn
+
+
+@contextmanager
+def _write_transaction(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
+    """Run a write transaction that takes the write lock up front.
+
+    SQLite's default DEFERRED transaction takes a read lock on the first SELECT
+    and only tries to upgrade on the first write. Two writers that each hold a
+    read lock can never both upgrade, so SQLite returns SQLITE_BUSY immediately
+    and ``busy_timeout`` does not apply — waiting cannot resolve a deadlock.
+    ``BEGIN IMMEDIATE`` takes the write lock at the start, which ``busy_timeout``
+    does cover, so concurrent writers queue instead of failing.
+    """
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield conn
+    except BaseException:
+        conn.rollback()
+        raise
+    conn.commit()
 
 
 def _open_readonly() -> sqlite3.Connection | None:
@@ -293,7 +318,7 @@ def ensure_collection(
         raise CollectionError(Messages.ERROR_COLLECTION_DIMENSION_INVALID)
     conn = _open()
     try:
-        with conn:
+        with _write_transaction(conn):
             row = conn.execute(
                 "SELECT * FROM collection WHERE name = ?", (clean_name,)
             ).fetchone()
@@ -383,7 +408,7 @@ def drop_collection(name: str) -> bool:
         return False
     conn = _open()
     try:
-        with conn:
+        with _write_transaction(conn):
             cursor = conn.execute(
                 "DELETE FROM collection WHERE name = ?", ((name or "").strip(),)
             )
@@ -427,7 +452,7 @@ def clear_all_collections() -> None:
     # caller asked for the records to be gone, and that must succeed either way.
     conn = _open()
     try:
-        with conn:
+        with _write_transaction(conn):
             conn.execute("DELETE FROM collection")
     finally:
         conn.close()
@@ -489,7 +514,7 @@ def upsert_records(collection_id: int, records: Sequence[PreparedRecord]) -> int
     conn = _open()
     try:
         updated_at = datetime.now(timezone.utc).isoformat()
-        with conn:
+        with _write_transaction(conn):
             for record in records:
                 conn.execute(
                     """
@@ -594,7 +619,7 @@ def delete_records(collection_id: int, record_keys: Sequence[str]) -> int:
     conn = _open()
     try:
         removed = 0
-        with conn:
+        with _write_transaction(conn):
             for batch in chunk_values(keys):
                 placeholders = ", ".join("?" for _ in batch)
                 cursor = conn.execute(

--- a/vexor/collection_store.py
+++ b/vexor/collection_store.py
@@ -378,6 +378,9 @@ def list_collections() -> list[CollectionInfo]:
 def drop_collection(name: str) -> bool:
     """Delete *name* and everything under it. Returns ``False`` when absent."""
 
+    if not collections_db_path().exists():
+        # Dropping something that was never created must not create a database.
+        return False
     conn = _open()
     try:
         with conn:
@@ -417,10 +420,26 @@ def clear_all_collections() -> None:
     """
 
     db_path = collections_db_path()
+    if not db_path.exists():
+        return
+    # Empty the tables first. Unlinking alone is not enough on Windows, where an
+    # open reader anywhere in the process holds the file and unlink raises; the
+    # caller asked for the records to be gone, and that must succeed either way.
+    conn = _open()
+    try:
+        with conn:
+            conn.execute("DELETE FROM collection")
+    finally:
+        conn.close()
     for suffix in ("", "-wal", "-shm"):
         candidate = Path(f"{db_path}{suffix}")
-        if candidate.exists():
-            candidate.unlink()
+        try:
+            if candidate.exists():
+                candidate.unlink()
+        except OSError:
+            # The rows are already gone; a leftover empty file is harmless and
+            # will be reused by the next write.
+            pass
 
 
 # --------------------------------------------------------------------------

--- a/vexor/collection_store.py
+++ b/vexor/collection_store.py
@@ -1,0 +1,948 @@
+"""SQLite storage for filesystem-independent text collections.
+
+Collections live in their own ``collections.db`` next to ``index.db`` rather than
+in new tables inside it. A file index is rebuildable from disk at any time; the
+records in a collection are only recoverable by making the caller re-upsert
+everything and pay for embeddings a second time, so the two must not share a
+lifecycle. For the same reason this module never bumps ``CACHE_VERSION``: every
+table below is additive under ``CREATE TABLE IF NOT EXISTS`` and cannot
+invalidate an existing user's file index.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+from .cache import ensure_cache_dir
+from .sqlite_util import chunk_values, connect
+from .text import Messages
+
+COLLECTIONS_DB_FILENAME = "collections.db"
+COLLECTION_SCHEMA_VERSION = 1
+
+# Metadata values are restricted to flat scalars. Nested values are rejected at
+# write time rather than stored, because a value that can never be filtered on
+# surfaces later as a phantom recall bug instead of an error.
+ScalarValue = str | int | float | bool | datetime | None
+
+FILTER_OPERATORS: tuple[str, ...] = (
+    "eq",
+    "ne",
+    "in",
+    "nin",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "exists",
+)
+_SET_OPERATORS = frozenset({"in", "nin"})
+_RANGE_OPERATORS = frozenset({"gt", "gte", "lt", "lte"})
+_RANGE_SQL = {"gt": ">", "gte": ">=", "lt": "<", "lte": "<="}
+# ``ne``/``nin`` match records that lack the key entirely. Requiring the key to
+# exist would silently drop unlabeled records from a negative filter, which is
+# the phantom recall failure the metadata contract exists to prevent.
+_NEGATIVE_OPERATORS = frozenset({"ne", "nin"})
+
+
+class CollectionError(ValueError):
+    """Raised for collection contract violations (schema, metadata, filters)."""
+
+
+@dataclass(slots=True)
+class CollectionInfo:
+    """Describes one collection's pinned embedding contract."""
+
+    id: int
+    name: str
+    provider: str
+    model: str
+    dimension: int
+    schema_version: int
+    created_at: str
+
+
+@dataclass(slots=True)
+class StoredRecord:
+    """A record as persisted, without any relevance score."""
+
+    id: str
+    text: str
+    metadata: dict[str, ScalarValue]
+
+
+@dataclass(slots=True)
+class PreparedRecord:
+    """A record with everything the store needs, computed by the service layer."""
+
+    record_key: str
+    text: str
+    text_hash: str
+    metadata: dict[str, ScalarValue]
+    vector: np.ndarray | None = None
+    bm25_terms: dict[str, int] = field(default_factory=dict)
+    token_count: int = 0
+    # ``False`` when the text is unchanged and only metadata is being rewritten.
+    # Metadata always replaces wholesale (upsert replaces the record), but the
+    # embedding and postings behind an unchanged text must survive, or a pure
+    # metadata edit would silently drop the record out of lexical search.
+    refresh_embedding: bool = True
+
+
+def collections_db_path() -> Path:
+    """Return the absolute path to the collection database."""
+
+    return ensure_cache_dir() / COLLECTIONS_DB_FILENAME
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS collection (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            provider TEXT NOT NULL,
+            model TEXT NOT NULL,
+            dimension INTEGER NOT NULL,
+            schema_version INTEGER NOT NULL,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS collection_record (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collection_id INTEGER NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+            record_key TEXT NOT NULL,
+            text TEXT NOT NULL,
+            text_hash TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE(collection_id, record_key)
+        );
+
+        CREATE TABLE IF NOT EXISTS collection_embedding (
+            record_id INTEGER PRIMARY KEY
+                REFERENCES collection_record(id) ON DELETE CASCADE,
+            vector_blob BLOB NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS collection_bm25_doc (
+            record_id INTEGER PRIMARY KEY
+                REFERENCES collection_record(id) ON DELETE CASCADE,
+            token_count INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS collection_bm25_posting (
+            collection_id INTEGER NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+            record_id INTEGER NOT NULL
+                REFERENCES collection_record(id) ON DELETE CASCADE,
+            term TEXT NOT NULL,
+            tf INTEGER NOT NULL,
+            PRIMARY KEY (collection_id, term, record_id)
+        ) WITHOUT ROWID;
+
+        CREATE TABLE IF NOT EXISTS collection_meta (
+            record_id INTEGER NOT NULL
+                REFERENCES collection_record(id) ON DELETE CASCADE,
+            key TEXT NOT NULL,
+            value_text TEXT,
+            value_num REAL,
+            PRIMARY KEY (record_id, key)
+        ) WITHOUT ROWID;
+
+        CREATE INDEX IF NOT EXISTS idx_collection_meta_text
+            ON collection_meta(key, value_text);
+
+        CREATE INDEX IF NOT EXISTS idx_collection_meta_num
+            ON collection_meta(key, value_num);
+
+        CREATE INDEX IF NOT EXISTS idx_collection_bm25_posting_record
+            ON collection_bm25_posting(record_id);
+        """
+    )
+
+
+def _open(readonly: bool = False) -> sqlite3.Connection:
+    db_path = collections_db_path()
+    conn = connect(db_path, readonly=readonly)
+    if not readonly:
+        _ensure_schema(conn)
+    return conn
+
+
+def _open_readonly() -> sqlite3.Connection | None:
+    """Open the database read-only, or return ``None`` when it does not exist."""
+
+    db_path = collections_db_path()
+    if not db_path.exists():
+        return None
+    try:
+        return connect(db_path, readonly=True)
+    except sqlite3.OperationalError:
+        return None
+
+
+# --------------------------------------------------------------------------
+# Metadata encoding
+# --------------------------------------------------------------------------
+
+
+def normalize_metadata(metadata: Mapping[str, object] | None) -> dict[str, ScalarValue]:
+    """Validate that *metadata* is a flat scalar mapping and return a copy."""
+
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise CollectionError(Messages.ERROR_COLLECTION_METADATA_NOT_MAPPING)
+    normalized: dict[str, ScalarValue] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.strip():
+            raise CollectionError(Messages.ERROR_COLLECTION_METADATA_KEY_INVALID)
+        if not _is_scalar(value):
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_METADATA_VALUE_INVALID.format(
+                    key=key,
+                    type=type(value).__name__,
+                )
+            )
+        normalized[key] = value
+    return normalized
+
+
+def _is_scalar(value: object) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool, datetime))
+
+
+def _encode_value(value: ScalarValue) -> tuple[str | None, float | None]:
+    """Return the ``(value_text, value_num)`` pair stored for *value*.
+
+    Only the column a query can actually read is written. Strings compare by
+    equality on ``value_text``; numbers, booleans, and timestamps compare and
+    sort on ``value_num``. A ``datetime`` writes both so callers can filter on a
+    range and still read back the original ISO string.
+    """
+
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, 1.0 if value else 0.0
+    if isinstance(value, datetime):
+        return value.isoformat(), value.timestamp()
+    if isinstance(value, (int, float)):
+        return None, float(value)
+    return str(value), None
+
+
+def _query_column(value: object) -> tuple[str, object]:
+    """Return the column and bind parameter used to compare against *value*."""
+
+    if isinstance(value, bool):
+        return "value_num", 1.0 if value else 0.0
+    if isinstance(value, datetime):
+        return "value_num", value.timestamp()
+    if isinstance(value, (int, float)):
+        return "value_num", float(value)
+    if isinstance(value, str):
+        return "value_text", value
+    raise CollectionError(
+        Messages.ERROR_COLLECTION_FILTER_VALUE_INVALID.format(type=type(value).__name__)
+    )
+
+
+# --------------------------------------------------------------------------
+# Collection lifecycle
+# --------------------------------------------------------------------------
+
+
+def _row_to_info(row: sqlite3.Row) -> CollectionInfo:
+    return CollectionInfo(
+        id=int(row["id"]),
+        name=str(row["name"]),
+        provider=str(row["provider"]),
+        model=str(row["model"]),
+        dimension=int(row["dimension"]),
+        schema_version=int(row["schema_version"]),
+        created_at=str(row["created_at"]),
+    )
+
+
+def ensure_collection(
+    name: str,
+    *,
+    provider: str,
+    model: str,
+    dimension: int,
+) -> CollectionInfo:
+    """Create *name* if absent, else verify its pinned embedding contract.
+
+    Provider, model, and dimension are pinned together. Changing any of them
+    would mix vector widths or semantics inside one collection, so this raises
+    and tells the caller to recreate instead of migrating silently.
+    """
+
+    clean_name = (name or "").strip()
+    if not clean_name:
+        raise CollectionError(Messages.ERROR_COLLECTION_NAME_REQUIRED)
+    if dimension <= 0:
+        raise CollectionError(Messages.ERROR_COLLECTION_DIMENSION_INVALID)
+    conn = _open()
+    try:
+        with conn:
+            row = conn.execute(
+                "SELECT * FROM collection WHERE name = ?", (clean_name,)
+            ).fetchone()
+            if row is not None:
+                info = _row_to_info(row)
+                if (
+                    info.provider != provider
+                    or info.model != model
+                    or info.dimension != dimension
+                ):
+                    raise CollectionError(
+                        Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
+                            name=clean_name,
+                            stored=f"{info.provider}/{info.model}/{info.dimension}",
+                            requested=f"{provider}/{model}/{dimension}",
+                        )
+                    )
+                return info
+            created_at = datetime.now(timezone.utc).isoformat()
+            cursor = conn.execute(
+                """
+                INSERT INTO collection (
+                    name, provider, model, dimension, schema_version, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    clean_name,
+                    provider,
+                    model,
+                    int(dimension),
+                    COLLECTION_SCHEMA_VERSION,
+                    created_at,
+                ),
+            )
+            return CollectionInfo(
+                id=int(cursor.lastrowid),
+                name=clean_name,
+                provider=provider,
+                model=model,
+                dimension=int(dimension),
+                schema_version=COLLECTION_SCHEMA_VERSION,
+                created_at=created_at,
+            )
+    finally:
+        conn.close()
+
+
+def get_collection(name: str) -> CollectionInfo | None:
+    """Return the stored contract for *name*, or ``None`` when it does not exist."""
+
+    conn = _open_readonly()
+    if conn is None:
+        return None
+    try:
+        try:
+            row = conn.execute(
+                "SELECT * FROM collection WHERE name = ?", ((name or "").strip(),)
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return None
+        return _row_to_info(row) if row is not None else None
+    finally:
+        conn.close()
+
+
+def list_collections() -> list[CollectionInfo]:
+    """Return every stored collection, ordered by name."""
+
+    conn = _open_readonly()
+    if conn is None:
+        return []
+    try:
+        try:
+            rows = conn.execute("SELECT * FROM collection ORDER BY name").fetchall()
+        except sqlite3.OperationalError:
+            return []
+        return [_row_to_info(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def drop_collection(name: str) -> bool:
+    """Delete *name* and everything under it. Returns ``False`` when absent."""
+
+    conn = _open()
+    try:
+        with conn:
+            cursor = conn.execute(
+                "DELETE FROM collection WHERE name = ?", ((name or "").strip(),)
+            )
+            return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
+def count_records(collection_id: int) -> int:
+    """Return how many records *collection_id* holds."""
+
+    conn = _open_readonly()
+    if conn is None:
+        return 0
+    try:
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) AS total FROM collection_record WHERE collection_id = ?",
+                (int(collection_id),),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return 0
+        return int(row["total"]) if row is not None else 0
+    finally:
+        conn.close()
+
+
+def clear_all_collections() -> None:
+    """Remove the collection database entirely.
+
+    Deliberately not wired into ``vexor config --clear-index-all``: a file index
+    can be rebuilt from disk, but these records can only be restored by the
+    caller re-upserting everything and paying for embeddings again.
+    """
+
+    db_path = collections_db_path()
+    for suffix in ("", "-wal", "-shm"):
+        candidate = Path(f"{db_path}{suffix}")
+        if candidate.exists():
+            candidate.unlink()
+
+
+# --------------------------------------------------------------------------
+# Writes
+# --------------------------------------------------------------------------
+
+
+def load_record_hashes(
+    collection_id: int,
+    record_keys: Sequence[str],
+) -> dict[str, str]:
+    """Return ``{record_key: text_hash}`` for the keys already stored."""
+
+    keys = [key for key in dict.fromkeys(record_keys) if key]
+    if not keys:
+        return {}
+    conn = _open_readonly()
+    if conn is None:
+        return {}
+    try:
+        results: dict[str, str] = {}
+        for batch in chunk_values(keys):
+            placeholders = ", ".join("?" for _ in batch)
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT record_key, text_hash
+                    FROM collection_record
+                    WHERE collection_id = ? AND record_key IN ({placeholders})
+                    """,
+                    (int(collection_id), *batch),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return {}
+            for row in rows:
+                results[str(row["record_key"])] = str(row["text_hash"])
+        return results
+    finally:
+        conn.close()
+
+
+def upsert_records(collection_id: int, records: Sequence[PreparedRecord]) -> int:
+    """Insert or replace *records*, returning how many rows were written."""
+
+    if not records:
+        return 0
+    conn = _open()
+    try:
+        updated_at = datetime.now(timezone.utc).isoformat()
+        with conn:
+            for record in records:
+                conn.execute(
+                    """
+                    INSERT INTO collection_record (
+                        collection_id, record_key, text, text_hash,
+                        metadata_json, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(collection_id, record_key) DO UPDATE SET
+                        text = excluded.text,
+                        text_hash = excluded.text_hash,
+                        metadata_json = excluded.metadata_json,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        int(collection_id),
+                        record.record_key,
+                        record.text,
+                        record.text_hash,
+                        json.dumps(_metadata_to_json(record.metadata)),
+                        updated_at,
+                    ),
+                )
+                row = conn.execute(
+                    """
+                    SELECT id FROM collection_record
+                    WHERE collection_id = ? AND record_key = ?
+                    """,
+                    (int(collection_id), record.record_key),
+                ).fetchone()
+                record_id = int(row["id"])
+                # Metadata replaces wholesale on every upsert.
+                conn.execute(
+                    "DELETE FROM collection_meta WHERE record_id = ?", (record_id,)
+                )
+                if record.refresh_embedding:
+                    # New text means the old postings score a string that no
+                    # longer exists, so they go before the new ones land.
+                    conn.execute(
+                        "DELETE FROM collection_bm25_posting WHERE record_id = ?",
+                        (record_id,),
+                    )
+                meta_rows = []
+                for key, value in record.metadata.items():
+                    value_text, value_num = _encode_value(value)
+                    meta_rows.append((record_id, key, value_text, value_num))
+                if meta_rows:
+                    conn.executemany(
+                        """
+                        INSERT INTO collection_meta (record_id, key, value_text, value_num)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        meta_rows,
+                    )
+                if record.vector is not None:
+                    conn.execute(
+                        """
+                        INSERT OR REPLACE INTO collection_embedding (record_id, vector_blob)
+                        VALUES (?, ?)
+                        """,
+                        (
+                            record_id,
+                            np.asarray(record.vector, dtype=np.float32).tobytes(),
+                        ),
+                    )
+                if record.bm25_terms:
+                    conn.execute(
+                        """
+                        INSERT OR REPLACE INTO collection_bm25_doc (record_id, token_count)
+                        VALUES (?, ?)
+                        """,
+                        (record_id, int(record.token_count)),
+                    )
+                    conn.executemany(
+                        """
+                        INSERT OR REPLACE INTO collection_bm25_posting (
+                            collection_id, record_id, term, tf
+                        ) VALUES (?, ?, ?, ?)
+                        """,
+                        [
+                            (int(collection_id), record_id, term, int(tf))
+                            for term, tf in record.bm25_terms.items()
+                        ],
+                    )
+        return len(records)
+    finally:
+        conn.close()
+
+
+def _metadata_to_json(metadata: Mapping[str, ScalarValue]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key, value in metadata.items():
+        payload[key] = value.isoformat() if isinstance(value, datetime) else value
+    return payload
+
+
+def delete_records(collection_id: int, record_keys: Sequence[str]) -> int:
+    """Delete the named records, returning how many rows were removed."""
+
+    keys = [key for key in dict.fromkeys(record_keys) if key]
+    if not keys:
+        return 0
+    conn = _open()
+    try:
+        removed = 0
+        with conn:
+            for batch in chunk_values(keys):
+                placeholders = ", ".join("?" for _ in batch)
+                cursor = conn.execute(
+                    f"""
+                    DELETE FROM collection_record
+                    WHERE collection_id = ? AND record_key IN ({placeholders})
+                    """,
+                    (int(collection_id), *batch),
+                )
+                removed += cursor.rowcount
+        return removed
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# Reads
+# --------------------------------------------------------------------------
+
+
+def _decode_metadata(payload: str) -> dict[str, ScalarValue]:
+    try:
+        loaded = json.loads(payload)
+    except (TypeError, ValueError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def fetch_records(collection_id: int, record_keys: Sequence[str]) -> list[StoredRecord]:
+    """Return stored records for *record_keys*, skipping keys that are absent."""
+
+    keys = [key for key in dict.fromkeys(record_keys) if key]
+    if not keys:
+        return []
+    conn = _open_readonly()
+    if conn is None:
+        return []
+    try:
+        found: dict[str, StoredRecord] = {}
+        for batch in chunk_values(keys):
+            placeholders = ", ".join("?" for _ in batch)
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT record_key, text, metadata_json
+                    FROM collection_record
+                    WHERE collection_id = ? AND record_key IN ({placeholders})
+                    """,
+                    (int(collection_id), *batch),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return []
+            for row in rows:
+                found[str(row["record_key"])] = StoredRecord(
+                    id=str(row["record_key"]),
+                    text=str(row["text"]),
+                    metadata=_decode_metadata(row["metadata_json"]),
+                )
+        return [found[key] for key in keys if key in found]
+    finally:
+        conn.close()
+
+
+def _compile_filter(
+    filters: Mapping[str, object] | None,
+) -> tuple[list[str], list[object]]:
+    """Compile *filters* into SQL fragments ANDed against ``collection_record``."""
+
+    if not filters:
+        return [], []
+    clauses: list[str] = []
+    params: list[object] = []
+    for key, condition in filters.items():
+        if not isinstance(key, str) or not key.strip():
+            raise CollectionError(Messages.ERROR_COLLECTION_FILTER_KEY_INVALID)
+        operations = _normalize_condition(condition)
+        for operator, value in operations:
+            clause, clause_params = _compile_operation(key, operator, value)
+            clauses.append(clause)
+            params.extend(clause_params)
+    return clauses, params
+
+
+def _normalize_condition(condition: object) -> list[tuple[str, object]]:
+    """Return ``[(operator, value)]`` for a filter condition."""
+
+    if isinstance(condition, Mapping):
+        operations: list[tuple[str, object]] = []
+        for operator, value in condition.items():
+            normalized = str(operator).lower()
+            if normalized not in FILTER_OPERATORS:
+                raise CollectionError(
+                    Messages.ERROR_COLLECTION_FILTER_OPERATOR_INVALID.format(
+                        operator=operator,
+                        allowed=", ".join(FILTER_OPERATORS),
+                    )
+                )
+            operations.append((normalized, value))
+        if not operations:
+            raise CollectionError(Messages.ERROR_COLLECTION_FILTER_EMPTY)
+        return operations
+    # A bare value is shorthand for equality.
+    return [("eq", condition)]
+
+
+def _compile_operation(
+    key: str,
+    operator: str,
+    value: object,
+) -> tuple[str, list[object]]:
+    if operator == "exists":
+        if not isinstance(value, bool):
+            raise CollectionError(Messages.ERROR_COLLECTION_FILTER_EXISTS_INVALID)
+        predicate = "IN" if value else "NOT IN"
+        return (
+            f"r.id {predicate} (SELECT record_id FROM collection_meta WHERE key = ?)",
+            [key],
+        )
+    if operator in _SET_OPERATORS:
+        if not isinstance(value, (list, tuple, set, frozenset)):
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_FILTER_SET_INVALID.format(operator=operator)
+            )
+        members = list(value)
+        if not members:
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_FILTER_SET_EMPTY.format(operator=operator)
+            )
+        text_values: list[object] = []
+        num_values: list[object] = []
+        for member in members:
+            column, bind = _query_column(member)
+            (text_values if column == "value_text" else num_values).append(bind)
+        sub_clauses: list[str] = []
+        params: list[object] = []
+        if text_values:
+            placeholders = ", ".join("?" for _ in text_values)
+            sub_clauses.append(f"(key = ? AND value_text IN ({placeholders}))")
+            params.append(key)
+            params.extend(text_values)
+        if num_values:
+            placeholders = ", ".join("?" for _ in num_values)
+            sub_clauses.append(f"(key = ? AND value_num IN ({placeholders}))")
+            params.append(key)
+            params.extend(num_values)
+        predicate = "NOT IN" if operator == "nin" else "IN"
+        joined = " OR ".join(sub_clauses)
+        return (
+            f"r.id {predicate} (SELECT record_id FROM collection_meta WHERE {joined})",
+            params,
+        )
+    if operator in _RANGE_OPERATORS:
+        column, bind = _query_column(value)
+        if column != "value_num":
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_FILTER_RANGE_INVALID.format(operator=operator)
+            )
+        comparison = _RANGE_SQL[operator]
+        return (
+            "r.id IN (SELECT record_id FROM collection_meta "
+            f"WHERE key = ? AND value_num IS NOT NULL AND value_num {comparison} ?)",
+            [key, bind],
+        )
+    # eq / ne
+    if value is None:
+        clause = (
+            "SELECT record_id FROM collection_meta "
+            "WHERE key = ? AND value_text IS NULL AND value_num IS NULL"
+        )
+        params = [key]
+    else:
+        column, bind = _query_column(value)
+        clause = f"SELECT record_id FROM collection_meta WHERE key = ? AND {column} = ?"
+        params = [key, bind]
+    predicate = "NOT IN" if operator in _NEGATIVE_OPERATORS else "IN"
+    return (f"r.id {predicate} ({clause})", params)
+
+
+def resolve_filter_ids(
+    collection_id: int,
+    filters: Mapping[str, object] | None,
+) -> list[int]:
+    """Return the record ids matching *filters*, resolved before any scoring.
+
+    Filtering is strict and happens first: post-filtering a global top-k would
+    return nothing for a single chat whose records never reach the global head.
+    """
+
+    clauses, params = _compile_filter(filters)
+    conn = _open_readonly()
+    if conn is None:
+        return []
+    try:
+        sql = "SELECT r.id FROM collection_record AS r WHERE r.collection_id = ?"
+        if clauses:
+            sql += " AND " + " AND ".join(clauses)
+        sql += " ORDER BY r.id"
+        try:
+            rows = conn.execute(sql, (int(collection_id), *params)).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        return [int(row["id"]) for row in rows]
+    finally:
+        conn.close()
+
+
+def load_vectors(
+    collection_id: int,
+    record_ids: Sequence[int],
+    dimension: int,
+) -> tuple[list[int], np.ndarray]:
+    """Load embeddings for *record_ids*, dropping rows with no stored vector."""
+
+    ids = [int(value) for value in record_ids]
+    if not ids:
+        return [], np.empty((0, dimension), dtype=np.float32)
+    conn = _open_readonly()
+    if conn is None:
+        return [], np.empty((0, dimension), dtype=np.float32)
+    try:
+        vectors: dict[int, np.ndarray] = {}
+        for batch in chunk_values(ids):
+            placeholders = ", ".join("?" for _ in batch)
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT e.record_id, e.vector_blob
+                    FROM collection_embedding AS e
+                    JOIN collection_record AS r ON r.id = e.record_id
+                    WHERE r.collection_id = ? AND e.record_id IN ({placeholders})
+                    """,
+                    (int(collection_id), *batch),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return [], np.empty((0, dimension), dtype=np.float32)
+            for row in rows:
+                blob = row["vector_blob"]
+                if not blob:
+                    continue
+                vector = np.frombuffer(blob, dtype=np.float32)
+                if vector.size != dimension:
+                    continue
+                vectors[int(row["record_id"])] = vector
+        ordered_ids = [value for value in ids if value in vectors]
+        if not ordered_ids:
+            return [], np.empty((0, dimension), dtype=np.float32)
+        matrix = np.vstack([vectors[value] for value in ordered_ids])
+        return ordered_ids, matrix
+    finally:
+        conn.close()
+
+
+def load_bm25_stats(
+    collection_id: int,
+    record_ids: Sequence[int],
+) -> tuple[int, float]:
+    """Return BM25 corpus statistics over *record_ids* only.
+
+    The corpus is the filtered subset, not the whole collection, so idf and
+    document-length normalization agree with what is actually being scored.
+    """
+
+    ids = [int(value) for value in record_ids]
+    if not ids:
+        return 0, 0.0
+    conn = _open_readonly()
+    if conn is None:
+        return 0, 0.0
+    try:
+        total = 0
+        length_sum = 0
+        for batch in chunk_values(ids):
+            placeholders = ", ".join("?" for _ in batch)
+            try:
+                row = conn.execute(
+                    f"""
+                    SELECT COUNT(*) AS doc_count, SUM(token_count) AS length_sum
+                    FROM collection_bm25_doc
+                    WHERE record_id IN ({placeholders})
+                    """,
+                    tuple(batch),
+                ).fetchone()
+            except sqlite3.OperationalError:
+                return 0, 0.0
+            if row is None:
+                continue
+            total += int(row["doc_count"] or 0)
+            length_sum += int(row["length_sum"] or 0)
+        if total <= 0:
+            return 0, 0.0
+        return total, length_sum / total
+    finally:
+        conn.close()
+
+
+def load_bm25_postings(
+    collection_id: int,
+    record_ids: Sequence[int],
+    terms: Sequence[str],
+) -> dict[str, list[tuple[int, int, int]]]:
+    """Load posting lists restricted to *record_ids*, shaped for ``bm25``."""
+
+    ids = {int(value) for value in record_ids}
+    unique_terms = [term for term in dict.fromkeys(terms) if term]
+    if not ids or not unique_terms:
+        return {}
+    conn = _open_readonly()
+    if conn is None:
+        return {}
+    try:
+        results: dict[str, list[tuple[int, int, int]]] = {}
+        for batch in chunk_values(unique_terms):
+            placeholders = ", ".join("?" for _ in batch)
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT p.term, p.record_id, p.tf, d.token_count
+                    FROM collection_bm25_posting AS p
+                    JOIN collection_bm25_doc AS d ON d.record_id = p.record_id
+                    WHERE p.collection_id = ? AND p.term IN ({placeholders})
+                    """,
+                    (int(collection_id), *batch),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return {}
+            for row in rows:
+                record_id = int(row["record_id"])
+                if record_id not in ids:
+                    continue
+                results.setdefault(str(row["term"]), []).append(
+                    (record_id, int(row["tf"]), int(row["token_count"]))
+                )
+        return results
+    finally:
+        conn.close()
+
+
+def fetch_by_ids(collection_id: int, record_ids: Sequence[int]) -> dict[int, StoredRecord]:
+    """Return ``{record_id: StoredRecord}`` for the given internal ids."""
+
+    ids = [int(value) for value in dict.fromkeys(record_ids)]
+    if not ids:
+        return {}
+    conn = _open_readonly()
+    if conn is None:
+        return {}
+    try:
+        results: dict[int, StoredRecord] = {}
+        for batch in chunk_values(ids):
+            placeholders = ", ".join("?" for _ in batch)
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT id, record_key, text, metadata_json
+                    FROM collection_record
+                    WHERE collection_id = ? AND id IN ({placeholders})
+                    """,
+                    (int(collection_id), *batch),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return {}
+            for row in rows:
+                results[int(row["id"])] = StoredRecord(
+                    id=str(row["record_key"]),
+                    text=str(row["text"]),
+                    metadata=_decode_metadata(row["metadata_json"]),
+                )
+        return results
+    finally:
+        conn.close()

--- a/vexor/services/collection_service.py
+++ b/vexor/services/collection_service.py
@@ -1,0 +1,377 @@
+"""Orchestration for filesystem-independent text collections.
+
+The retrieval core Vexor already had is source-agnostic: ``bm25`` holds pure
+functions over ids, the embedding cache is keyed by ``(model, text_hash)``, and
+``VexorSearcher.embed_texts`` L2-normalizes any text you hand it. This module is
+the second consumer of that core — records arrive from a caller's database
+instead of from disk, so results carry a record id and metadata instead of a
+path and line range.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+from .. import bm25, collection_store
+from ..cache import embedding_cache_key
+from ..collection_store import (
+    CollectionError,
+    CollectionInfo,
+    PreparedRecord,
+    ScalarValue,
+    StoredRecord,
+)
+from ..text import Messages
+from .embedding_service import embed_texts_with_cache
+
+# v1 deliberately ships two ranking modes. ``hybrid`` already fuses dense and
+# BM25 over persisted postings whose idf is computed on the filtered subset,
+# which is strictly better information than the legacy ``bm25`` reranker's
+# second pass over a truncated candidate list — that reranker exists to
+# compensate for file search predating the inverted index, and a collection has
+# one from its first write. FlashRank and remote reranking are additive and can
+# land later without a schema change.
+SUPPORTED_COLLECTION_RERANKERS: tuple[str, ...] = ("off", "hybrid")
+DEFAULT_COLLECTION_RERANK = "off"
+
+
+@dataclass(slots=True)
+class RecordResult:
+    """One scored record: the caller's id and text, never a path."""
+
+    id: str
+    text: str
+    metadata: dict[str, ScalarValue]
+    score: float
+
+
+@dataclass(slots=True)
+class UpsertReport:
+    """What an upsert actually did, so callers can see cache hits."""
+
+    written: int
+    embedded: int
+    skipped: int
+
+
+def _require_collection(name: str) -> CollectionInfo:
+    info = collection_store.get_collection(name)
+    if info is None:
+        raise CollectionError(Messages.ERROR_COLLECTION_NOT_FOUND.format(name=name))
+    return info
+
+
+def _normalize_records(
+    records: Sequence[Mapping[str, object]],
+    *,
+    embedding_dimension: int | None,
+) -> list[tuple[str, str, str, dict[str, ScalarValue]]]:
+    """Validate raw records into ``(key, text, text_hash, metadata)`` tuples."""
+
+    seen: set[str] = set()
+    normalized: list[tuple[str, str, str, dict[str, ScalarValue]]] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise CollectionError(Messages.ERROR_COLLECTION_RECORD_NOT_MAPPING)
+        raw_key = record.get("id")
+        key = str(raw_key).strip() if raw_key is not None else ""
+        if not key:
+            raise CollectionError(Messages.ERROR_COLLECTION_RECORD_KEY_REQUIRED)
+        if key in seen:
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_DUPLICATE_KEY.format(key=key)
+            )
+        seen.add(key)
+        text = record.get("text")
+        text_value = str(text) if text is not None else ""
+        if not text_value.strip():
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_TEXT_EMPTY.format(key=key)
+            )
+        metadata = collection_store.normalize_metadata(
+            record.get("metadata")  # type: ignore[arg-type]
+        )
+        text_hash = embedding_cache_key(text_value, dimension=embedding_dimension)
+        normalized.append((key, text_value, text_hash, metadata))
+    return normalized
+
+
+def upsert_records(
+    *,
+    name: str,
+    records: Sequence[Mapping[str, object]],
+    searcher,
+    model_name: str,
+    provider: str,
+    embedding_dimension: int | None = None,
+    no_cache: bool = False,
+) -> UpsertReport:
+    """Insert or replace *records*, embedding only the texts that changed."""
+
+    if not records:
+        return UpsertReport(written=0, embedded=0, skipped=0)
+    normalized = _normalize_records(records, embedding_dimension=embedding_dimension)
+
+    info = collection_store.get_collection(name)
+    existing_hashes: dict[str, str] = {}
+    if info is not None:
+        if info.provider != provider or info.model != model_name:
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
+                    name=name,
+                    stored=f"{info.provider}/{info.model}/{info.dimension}",
+                    requested=f"{provider}/{model_name}/{info.dimension}",
+                )
+            )
+        existing_hashes = collection_store.load_record_hashes(
+            info.id, [key for key, _, _, _ in normalized]
+        )
+
+    pending = [
+        entry for entry in normalized if existing_hashes.get(entry[0]) != entry[2]
+    ]
+    unchanged = [
+        entry for entry in normalized if existing_hashes.get(entry[0]) == entry[2]
+    ]
+
+    vectors: np.ndarray | None = None
+    if pending:
+        vectors = embed_texts_with_cache(
+            searcher=searcher,
+            model_name=model_name,
+            labels=[text for _, text, _, _ in pending],
+            no_cache=no_cache,
+            embedding_dimension=embedding_dimension,
+        )
+        if vectors.size == 0 or vectors.ndim != 2:
+            raise CollectionError(Messages.ERROR_COLLECTION_EMBED_FAILED)
+
+    if info is None:
+        if vectors is None:
+            # Every record was unchanged, which cannot happen before the
+            # collection exists; guard anyway so a future caller gets an error
+            # rather than a collection pinned to a guessed dimension.
+            raise CollectionError(Messages.ERROR_COLLECTION_EMBED_FAILED)
+        dimension = int(vectors.shape[1])
+    else:
+        dimension = info.dimension
+        if vectors is not None and int(vectors.shape[1]) != dimension:
+            raise CollectionError(
+                Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
+                    name=name,
+                    stored=f"{info.provider}/{info.model}/{dimension}",
+                    requested=f"{provider}/{model_name}/{int(vectors.shape[1])}",
+                )
+            )
+
+    info = collection_store.ensure_collection(
+        name,
+        provider=provider,
+        model=model_name,
+        dimension=dimension,
+    )
+
+    prepared: list[PreparedRecord] = []
+    for offset, (key, text, text_hash, metadata) in enumerate(pending):
+        vector = np.asarray(vectors[offset], dtype=np.float32)
+        tokens = bm25.tokenize(text)
+        prepared.append(
+            PreparedRecord(
+                record_key=key,
+                text=text,
+                text_hash=text_hash,
+                metadata=metadata,
+                vector=vector,
+                bm25_terms=bm25.term_frequencies(tokens),
+                token_count=len(tokens),
+                refresh_embedding=True,
+            )
+        )
+    for key, text, text_hash, metadata in unchanged:
+        prepared.append(
+            PreparedRecord(
+                record_key=key,
+                text=text,
+                text_hash=text_hash,
+                metadata=metadata,
+                vector=None,
+                bm25_terms={},
+                token_count=0,
+                refresh_embedding=False,
+            )
+        )
+
+    written = collection_store.upsert_records(info.id, prepared)
+    return UpsertReport(
+        written=written,
+        embedded=len(pending),
+        skipped=len(unchanged),
+    )
+
+
+def search_records(
+    *,
+    name: str,
+    query: str,
+    searcher,
+    model_name: str,
+    top_k: int = 10,
+    filters: Mapping[str, object] | None = None,
+    rerank: str = DEFAULT_COLLECTION_RERANK,
+    embedding_dimension: int | None = None,
+    no_cache: bool = False,
+) -> list[RecordResult]:
+    """Search *name*, applying metadata filters before anything is scored."""
+
+    clean_query = (query or "").strip()
+    if not clean_query:
+        raise CollectionError(Messages.ERROR_COLLECTION_QUERY_EMPTY)
+    rerank_value = (rerank or DEFAULT_COLLECTION_RERANK).strip().lower()
+    if rerank_value not in SUPPORTED_COLLECTION_RERANKERS:
+        raise CollectionError(
+            Messages.ERROR_COLLECTION_RERANK_UNSUPPORTED.format(
+                value=rerank_value,
+                allowed=", ".join(SUPPORTED_COLLECTION_RERANKERS),
+            )
+        )
+    if top_k <= 0:
+        return []
+    info = _require_collection(name)
+
+    candidate_ids = collection_store.resolve_filter_ids(info.id, filters)
+    if not candidate_ids:
+        return []
+    record_ids, matrix = collection_store.load_vectors(
+        info.id, candidate_ids, info.dimension
+    )
+    if not record_ids:
+        return []
+
+    query_matrix = embed_texts_with_cache(
+        searcher=searcher,
+        model_name=model_name,
+        labels=[clean_query],
+        no_cache=no_cache,
+        embedding_dimension=embedding_dimension,
+    )
+    if query_matrix.size == 0:
+        raise CollectionError(Messages.ERROR_COLLECTION_EMBED_FAILED)
+    query_vector = np.asarray(query_matrix[0], dtype=np.float32).ravel()
+    if query_vector.shape[0] != info.dimension:
+        raise CollectionError(
+            Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
+                name=name,
+                stored=f"{info.provider}/{info.model}/{info.dimension}",
+                requested=f"{info.provider}/{model_name}/{query_vector.shape[0]}",
+            )
+        )
+
+    # Both sides are L2-normalized, so the dot product is cosine similarity.
+    scores = np.asarray(matrix @ query_vector, dtype=np.float32)
+    if rerank_value == "hybrid":
+        scores = _fuse_hybrid(
+            collection_id=info.id,
+            query=clean_query,
+            record_ids=record_ids,
+            dense_scores=scores,
+        )
+
+    order = sorted(range(len(record_ids)), key=lambda idx: (-scores[idx], idx))
+    top_rows = order[: int(top_k)]
+    selected_ids = [record_ids[row] for row in top_rows]
+    stored = collection_store.fetch_by_ids(info.id, selected_ids)
+    results: list[RecordResult] = []
+    for row in top_rows:
+        record = stored.get(record_ids[row])
+        if record is None:
+            continue
+        results.append(
+            RecordResult(
+                id=record.id,
+                text=record.text,
+                metadata=record.metadata,
+                score=float(scores[row]),
+            )
+        )
+    return results
+
+
+def _fuse_hybrid(
+    *,
+    collection_id: int,
+    query: str,
+    record_ids: Sequence[int],
+    dense_scores: np.ndarray,
+) -> np.ndarray:
+    """Fuse dense similarity with BM25 over the filtered subset only."""
+
+    query_terms = list(dict.fromkeys(bm25.tokenize(query)))[: bm25.MAX_QUERY_TERMS]
+    if not query_terms:
+        return dense_scores
+    doc_count, avg_doc_len = collection_store.load_bm25_stats(collection_id, record_ids)
+    if doc_count <= 0 or avg_doc_len <= 0:
+        return dense_scores
+    postings = collection_store.load_bm25_postings(
+        collection_id, record_ids, query_terms
+    )
+    if not postings:
+        return dense_scores
+    scores_by_record = bm25.score_postings(
+        query_terms, postings, doc_count, avg_doc_len
+    )
+    row_by_record = {record_id: row for row, record_id in enumerate(record_ids)}
+    scores_by_row = {
+        row_by_record[record_id]: value
+        for record_id, value in scores_by_record.items()
+        if record_id in row_by_record
+    }
+    dense_order = np.argsort(-dense_scores, kind="stable")
+    return bm25.rrf_fuse(dense_order, scores_by_row, len(record_ids))
+
+
+def delete_records(*, name: str, record_keys: Sequence[str]) -> int:
+    """Delete records by id, returning how many existed."""
+
+    info = collection_store.get_collection(name)
+    if info is None:
+        return 0
+    return collection_store.delete_records(info.id, record_keys)
+
+
+def get_records(*, name: str, record_keys: Sequence[str]) -> list[StoredRecord]:
+    """Return stored records by id, skipping ids that are absent."""
+
+    info = collection_store.get_collection(name)
+    if info is None:
+        return []
+    return collection_store.fetch_records(info.id, record_keys)
+
+
+def count_records(*, name: str) -> int:
+    """Return how many records *name* holds, or 0 when it does not exist."""
+
+    info = collection_store.get_collection(name)
+    if info is None:
+        return 0
+    return collection_store.count_records(info.id)
+
+
+def drop_collection(*, name: str) -> bool:
+    """Delete a collection and everything under it."""
+
+    return collection_store.drop_collection(name)
+
+
+def collection_info(*, name: str) -> CollectionInfo | None:
+    """Return the pinned contract for *name*, or ``None``."""
+
+    return collection_store.get_collection(name)
+
+
+def list_collections() -> list[CollectionInfo]:
+    """Return every stored collection."""
+
+    return collection_store.list_collections()

--- a/vexor/services/collection_service.py
+++ b/vexor/services/collection_service.py
@@ -147,6 +147,7 @@ def upsert_records(
     normalized = _normalize_records(records, embedding_dimension=embedding_dimension)
 
     info = collection_store.get_collection(name)
+    existed_before = info is not None
     existing_hashes: dict[str, str] = {}
     if info is not None:
         _verify_contract(info, name=name, provider=provider, model_name=model_name)
@@ -228,7 +229,16 @@ def upsert_records(
             )
         )
 
-    written = collection_store.upsert_records(info.id, prepared)
+    try:
+        written = collection_store.upsert_records(info.id, prepared)
+    except BaseException:
+        # Creating the collection and writing its first records are separate
+        # transactions. If the write fails, a collection this call brought into
+        # existence would linger holding a pinned contract the caller never
+        # successfully used — and block retrying the name under another one.
+        if not existed_before and collection_store.count_records(info.id) == 0:
+            collection_store.drop_collection(name)
+        raise
     return UpsertReport(
         written=written,
         embedded=len(pending),
@@ -264,17 +274,11 @@ def search_records(
         )
     if top_k <= 0:
         return []
+    # Resolve the contract and embed the query before opening the snapshot:
+    # embedding can be a network round trip, and holding a read transaction open
+    # across it would pin the WAL for the whole call.
     info = _require_collection(name)
     _verify_contract(info, name=name, provider=provider, model_name=model_name)
-
-    candidate_ids = collection_store.resolve_filter_ids(info.id, filters)
-    if not candidate_ids:
-        return []
-    record_ids, matrix = collection_store.load_vectors(
-        info.id, candidate_ids, info.dimension
-    )
-    if not record_ids:
-        return []
 
     query_matrix = embed_texts_with_cache(
         searcher=searcher,
@@ -286,30 +290,53 @@ def search_records(
     if query_matrix.size == 0:
         raise CollectionError(Messages.ERROR_COLLECTION_EMBED_FAILED)
     query_vector = np.asarray(query_matrix[0], dtype=np.float32).ravel()
-    # Same provider and model can still yield a different width when the
-    # configured embedding_dimensions changed since the collection was pinned.
-    _verify_contract(
-        info,
-        name=name,
-        provider=provider,
-        model_name=model_name,
-        dimension=int(query_vector.shape[0]),
-    )
 
-    # Both sides are L2-normalized, so the dot product is cosine similarity.
-    scores = np.asarray(matrix @ query_vector, dtype=np.float32)
-    if rerank_value == "hybrid":
-        scores = _fuse_hybrid(
-            collection_id=info.id,
-            query=clean_query,
-            record_ids=record_ids,
-            dense_scores=scores,
+    # Every read below shares one snapshot. Filtering, vector loading, posting
+    # loading, and the final record fetch must observe the same data: a writer
+    # moving a record out of the filtered set between two of those steps would
+    # otherwise let the result reach a caller whose filter excludes it.
+    with collection_store.read_snapshot() as snapshot:
+        if snapshot is None:
+            raise CollectionError(Messages.ERROR_COLLECTION_NOT_FOUND.format(name=name))
+        info = collection_store.get_collection(name, snapshot)
+        if info is None:
+            raise CollectionError(Messages.ERROR_COLLECTION_NOT_FOUND.format(name=name))
+        # Same provider and model can still yield a different width when the
+        # configured embedding_dimensions changed since the collection was
+        # pinned, so the width is checked against the snapshot's contract.
+        _verify_contract(
+            info,
+            name=name,
+            provider=provider,
+            model_name=model_name,
+            dimension=int(query_vector.shape[0]),
         )
 
-    order = sorted(range(len(record_ids)), key=lambda idx: (-scores[idx], idx))
-    top_rows = order[: int(top_k)]
-    selected_ids = [record_ids[row] for row in top_rows]
-    stored = collection_store.fetch_by_ids(info.id, selected_ids)
+        candidate_ids = collection_store.resolve_filter_ids(info.id, filters, snapshot)
+        if not candidate_ids:
+            return []
+        record_ids, matrix = collection_store.load_vectors(
+            info.id, candidate_ids, info.dimension, snapshot
+        )
+        if not record_ids:
+            return []
+
+        # Both sides are L2-normalized, so the dot product is cosine similarity.
+        scores = np.asarray(matrix @ query_vector, dtype=np.float32)
+        if rerank_value == "hybrid":
+            scores = _fuse_hybrid(
+                collection_id=info.id,
+                query=clean_query,
+                record_ids=record_ids,
+                dense_scores=scores,
+                conn=snapshot,
+            )
+
+        order = sorted(range(len(record_ids)), key=lambda idx: (-scores[idx], idx))
+        top_rows = order[: int(top_k)]
+        selected_ids = [record_ids[row] for row in top_rows]
+        stored = collection_store.fetch_by_ids(info.id, selected_ids, snapshot)
+
     results: list[RecordResult] = []
     for row in top_rows:
         record = stored.get(record_ids[row])
@@ -332,17 +359,20 @@ def _fuse_hybrid(
     query: str,
     record_ids: Sequence[int],
     dense_scores: np.ndarray,
+    conn=None,
 ) -> np.ndarray:
     """Fuse dense similarity with BM25 over the filtered subset only."""
 
     query_terms = list(dict.fromkeys(bm25.tokenize(query)))[: bm25.MAX_QUERY_TERMS]
     if not query_terms:
         return dense_scores
-    doc_count, avg_doc_len = collection_store.load_bm25_stats(collection_id, record_ids)
+    doc_count, avg_doc_len = collection_store.load_bm25_stats(
+        collection_id, record_ids, conn
+    )
     if doc_count <= 0 or avg_doc_len <= 0:
         return dense_scores
     postings = collection_store.load_bm25_postings(
-        collection_id, record_ids, query_terms
+        collection_id, record_ids, query_terms, conn
     )
     if not postings:
         return dense_scores

--- a/vexor/services/collection_service.py
+++ b/vexor/services/collection_service.py
@@ -64,6 +64,37 @@ def _require_collection(name: str) -> CollectionInfo:
     return info
 
 
+def _verify_contract(
+    info: CollectionInfo,
+    *,
+    name: str,
+    provider: str,
+    model_name: str,
+    dimension: int | None = None,
+) -> None:
+    """Raise unless the caller's embedding contract matches what is pinned.
+
+    This has to guard reads as well as writes. Two different models can share a
+    vector width, so a dimension check alone lets a query embedded by one model
+    score vectors produced by another: the arithmetic succeeds and the ranking
+    is meaningless. Silently wrong results are worse than an error.
+    """
+
+    effective_dimension = info.dimension if dimension is None else dimension
+    if (
+        info.provider != provider
+        or info.model != model_name
+        or info.dimension != effective_dimension
+    ):
+        raise CollectionError(
+            Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
+                name=name,
+                stored=f"{info.provider}/{info.model}/{info.dimension}",
+                requested=f"{provider}/{model_name}/{effective_dimension}",
+            )
+        )
+
+
 def _normalize_records(
     records: Sequence[Mapping[str, object]],
     *,
@@ -118,14 +149,7 @@ def upsert_records(
     info = collection_store.get_collection(name)
     existing_hashes: dict[str, str] = {}
     if info is not None:
-        if info.provider != provider or info.model != model_name:
-            raise CollectionError(
-                Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
-                    name=name,
-                    stored=f"{info.provider}/{info.model}/{info.dimension}",
-                    requested=f"{provider}/{model_name}/{info.dimension}",
-                )
-            )
+        _verify_contract(info, name=name, provider=provider, model_name=model_name)
         existing_hashes = collection_store.load_record_hashes(
             info.id, [key for key, _, _, _ in normalized]
         )
@@ -158,13 +182,13 @@ def upsert_records(
         dimension = int(vectors.shape[1])
     else:
         dimension = info.dimension
-        if vectors is not None and int(vectors.shape[1]) != dimension:
-            raise CollectionError(
-                Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
-                    name=name,
-                    stored=f"{info.provider}/{info.model}/{dimension}",
-                    requested=f"{provider}/{model_name}/{int(vectors.shape[1])}",
-                )
+        if vectors is not None:
+            _verify_contract(
+                info,
+                name=name,
+                provider=provider,
+                model_name=model_name,
+                dimension=int(vectors.shape[1]),
             )
 
     info = collection_store.ensure_collection(
@@ -218,6 +242,7 @@ def search_records(
     query: str,
     searcher,
     model_name: str,
+    provider: str,
     top_k: int = 10,
     filters: Mapping[str, object] | None = None,
     rerank: str = DEFAULT_COLLECTION_RERANK,
@@ -240,6 +265,7 @@ def search_records(
     if top_k <= 0:
         return []
     info = _require_collection(name)
+    _verify_contract(info, name=name, provider=provider, model_name=model_name)
 
     candidate_ids = collection_store.resolve_filter_ids(info.id, filters)
     if not candidate_ids:
@@ -260,14 +286,15 @@ def search_records(
     if query_matrix.size == 0:
         raise CollectionError(Messages.ERROR_COLLECTION_EMBED_FAILED)
     query_vector = np.asarray(query_matrix[0], dtype=np.float32).ravel()
-    if query_vector.shape[0] != info.dimension:
-        raise CollectionError(
-            Messages.ERROR_COLLECTION_CONTRACT_MISMATCH.format(
-                name=name,
-                stored=f"{info.provider}/{info.model}/{info.dimension}",
-                requested=f"{info.provider}/{model_name}/{query_vector.shape[0]}",
-            )
-        )
+    # Same provider and model can still yield a different width when the
+    # configured embedding_dimensions changed since the collection was pinned.
+    _verify_contract(
+        info,
+        name=name,
+        provider=provider,
+        model_name=model_name,
+        dimension=int(query_vector.shape[0]),
+    )
 
     # Both sides are L2-normalized, so the dot product is cosine similarity.
     scores = np.asarray(matrix @ query_vector, dtype=np.float32)

--- a/vexor/services/collection_service.py
+++ b/vexor/services/collection_service.py
@@ -11,6 +11,7 @@ path and line range.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
 
 import numpy as np
@@ -236,8 +237,17 @@ def upsert_records(
         # transactions. If the write fails, a collection this call brought into
         # existence would linger holding a pinned contract the caller never
         # successfully used — and block retrying the name under another one.
-        if not existed_before and collection_store.count_records(info.id) == 0:
-            collection_store.drop_collection(name)
+        #
+        # The drop is conditional on the row still being this exact collection
+        # and still being empty, decided inside one transaction, so a concurrent
+        # writer that populated it in the meantime keeps its records.
+        #
+        # Best-effort on purpose: whatever goes wrong while cleaning up matters
+        # far less than the error the caller is about to see, and must not
+        # replace it.
+        if not existed_before:
+            with suppress(Exception):
+                collection_store.drop_collection_if_empty(name, info.id)
         raise
     return UpsertReport(
         written=written,

--- a/vexor/services/embedding_service.py
+++ b/vexor/services/embedding_service.py
@@ -1,0 +1,64 @@
+"""Cached embedding helper shared by the file index and the collection store.
+
+Both consumers key the shared ``embedding_cache`` table by ``(model, text_hash)``
+so a text embedded once is never paid for twice, whichever entry point saw it
+first. ``embedding_dimension`` is the *configured* dimension used to segment the
+cache, not the width of the returned vectors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+
+def embed_texts_with_cache(
+    *,
+    searcher,
+    model_name: str,
+    labels: Sequence[str],
+    no_cache: bool = False,
+    embedding_dimension: int | None = None,
+) -> np.ndarray:
+    """Embed labels with caching support.
+
+    Args:
+        searcher: The embedding searcher instance
+        model_name: Name of the embedding model
+        labels: Sequence of label strings to embed
+        no_cache: If True, bypass cache entirely
+        embedding_dimension: Embedding dimension for cache segmentation (prevents
+            cross-dimension cache pollution when dimension settings change)
+    """
+    if not labels:
+        return np.empty((0, 0), dtype=np.float32)
+    if no_cache:
+        vectors = searcher.embed_texts(labels)
+        return np.asarray(vectors, dtype=np.float32)
+    from ..cache import embedding_cache_key, load_embedding_cache, store_embedding_cache
+
+    # Include dimension in cache key to prevent cross-dimension cache pollution
+    hashes = [embedding_cache_key(label, dimension=embedding_dimension) for label in labels]
+    cached = load_embedding_cache(model_name, hashes, dimension=embedding_dimension)
+    missing: dict[str, str] = {}
+    for label, text_hash in zip(labels, hashes, strict=True):
+        vector = cached.get(text_hash)
+        if (vector is None or vector.size == 0) and text_hash not in missing:
+            missing[text_hash] = label
+
+    if missing:
+        missing_items = list(missing.items())
+        missing_labels = [label for _, label in missing_items]
+        new_vectors = searcher.embed_texts(missing_labels)
+        stored: dict[str, np.ndarray] = {}
+        for idx, (text_hash, _) in enumerate(missing_items):
+            vector = np.asarray(new_vectors[idx], dtype=np.float32)
+            cached[text_hash] = vector
+            stored[text_hash] = vector
+        store_embedding_cache(
+            model=model_name, embeddings=stored, dimension=embedding_dimension
+        )
+
+    vectors = [cached[text_hash] for text_hash in hashes]
+    return np.vstack([np.asarray(vector, dtype=np.float32) for vector in vectors])

--- a/vexor/services/index_service.py
+++ b/vexor/services/index_service.py
@@ -24,6 +24,7 @@ from ..config import (
 from ..modes import ModePayload, get_strategy
 from .cache_service import load_index_metadata_safe
 from .content_extract_service import TEXT_EXTENSIONS
+from .embedding_service import embed_texts_with_cache
 from .js_parser import JSTS_EXTENSIONS
 
 INCREMENTAL_CHANGE_THRESHOLD = 0.5
@@ -709,55 +710,8 @@ def _apply_incremental_update(
     return cache_path
 
 
-def _embed_labels_with_cache(
-    *,
-    searcher,
-    model_name: str,
-    labels: Sequence[str],
-    no_cache: bool = False,
-    embedding_dimension: int | None = None,
-) -> np.ndarray:
-    """Embed labels with caching support.
-
-    Args:
-        searcher: The embedding searcher instance
-        model_name: Name of the embedding model
-        labels: Sequence of label strings to embed
-        no_cache: If True, bypass cache entirely
-        embedding_dimension: Embedding dimension for cache segmentation (prevents
-            cross-dimension cache pollution when dimension settings change)
-    """
-    if not labels:
-        return np.empty((0, 0), dtype=np.float32)
-    if no_cache:
-        vectors = searcher.embed_texts(labels)
-        return np.asarray(vectors, dtype=np.float32)
-    from ..cache import embedding_cache_key, load_embedding_cache, store_embedding_cache
-
-    # Include dimension in cache key to prevent cross-dimension cache pollution
-    hashes = [embedding_cache_key(label, dimension=embedding_dimension) for label in labels]
-    cached = load_embedding_cache(model_name, hashes, dimension=embedding_dimension)
-    missing: dict[str, str] = {}
-    for label, text_hash in zip(labels, hashes, strict=True):
-        vector = cached.get(text_hash)
-        if (vector is None or vector.size == 0) and text_hash not in missing:
-            missing[text_hash] = label
-
-    if missing:
-        missing_items = list(missing.items())
-        missing_labels = [label for _, label in missing_items]
-        new_vectors = searcher.embed_texts(missing_labels)
-        stored: dict[str, np.ndarray] = {}
-        for idx, (text_hash, _) in enumerate(missing_items):
-            vector = np.asarray(new_vectors[idx], dtype=np.float32)
-            cached[text_hash] = vector
-            stored[text_hash] = vector
-        store_embedding_cache(
-            model=model_name, embeddings=stored, dimension=embedding_dimension
-        )
-
-    vectors = [cached[text_hash] for text_hash in hashes]
-    return np.vstack([np.asarray(vector, dtype=np.float32) for vector in vectors])
+# Shared with the collection store; see services/embedding_service.py.
+_embed_labels_with_cache = embed_texts_with_cache
 
 
 def _relative_to_root(path: Path, root: Path) -> str:

--- a/vexor/sqlite_util.py
+++ b/vexor/sqlite_util.py
@@ -17,6 +17,36 @@ from pathlib import Path
 MAX_SQL_PARAMS = 900
 
 
+def _ensure_wal(conn: sqlite3.Connection) -> None:
+    """Put *conn* in WAL mode without fighting other connections over the switch.
+
+    Changing ``journal_mode`` needs a brief exclusive lock, and SQLite does not
+    run the busy handler for it: a concurrent switch returns SQLITE_BUSY
+    immediately no matter what ``busy_timeout`` says. Reading the current mode
+    takes no lock, so the overwhelmingly common case — a database already in WAL
+    — never contends at all.
+
+    Losing the race on a freshly created database is deliberately tolerated.
+    WAL is a concurrency optimization, not a correctness requirement; whichever
+    connection won the switch leaves the database in WAL for everyone after it,
+    and a connection that stayed on the rollback journal still reads and writes
+    correctly. Any other operational error still propagates.
+    """
+
+    try:
+        row = conn.execute("PRAGMA journal_mode;").fetchone()
+    except sqlite3.OperationalError:
+        return
+    if row is not None and str(row[0]).lower() == "wal":
+        return
+    try:
+        conn.execute("PRAGMA journal_mode = WAL;")
+    except sqlite3.OperationalError as exc:
+        message = str(exc).lower()
+        if not any(token in message for token in ("readonly", "locked", "busy")):
+            raise
+
+
 def connect(
     db_path: Path,
     *,
@@ -31,14 +61,14 @@ def connect(
     else:
         conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
-    try:
-        conn.execute("PRAGMA journal_mode = WAL;")
-    except sqlite3.OperationalError as exc:
-        if "readonly" not in str(exc).lower():
-            raise
+    # busy_timeout must come first. Switching journal_mode needs a brief
+    # exclusive lock even when the database is already in WAL, so setting the
+    # timeout afterwards leaves that one statement unprotected: concurrent
+    # openers get SQLITE_BUSY immediately instead of waiting their turn.
+    conn.execute("PRAGMA busy_timeout = 5000;")
+    _ensure_wal(conn)
     conn.execute("PRAGMA synchronous = NORMAL;")
     conn.execute("PRAGMA temp_store = MEMORY;")
-    conn.execute("PRAGMA busy_timeout = 5000;")
     conn.execute("PRAGMA foreign_keys = ON;")
     if readonly or query_only:
         conn.execute("PRAGMA query_only = ON;")

--- a/vexor/sqlite_util.py
+++ b/vexor/sqlite_util.py
@@ -1,0 +1,55 @@
+"""Shared SQLite connection and batching helpers.
+
+Extracted from ``cache.py`` so the file index and the collection store open
+databases with identical WAL, ``busy_timeout``, and foreign-key behavior. Two
+stores writing under the same pragmas is the whole point: a divergence here
+shows up as a lock error under concurrent writers, not as a test failure.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+# SQLite's default host parameter limit is 999; stay under it with room for the
+# fixed parameters callers prepend to a batch.
+MAX_SQL_PARAMS = 900
+
+
+def connect(
+    db_path: Path,
+    *,
+    readonly: bool = False,
+    query_only: bool = False,
+) -> sqlite3.Connection:
+    """Open *db_path* with Vexor's standard pragmas."""
+
+    if readonly:
+        db_uri = f"file:{db_path.as_posix()}?mode=ro"
+        conn = sqlite3.connect(db_uri, uri=True)
+    else:
+        conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA journal_mode = WAL;")
+    except sqlite3.OperationalError as exc:
+        if "readonly" not in str(exc).lower():
+            raise
+    conn.execute("PRAGMA synchronous = NORMAL;")
+    conn.execute("PRAGMA temp_store = MEMORY;")
+    conn.execute("PRAGMA busy_timeout = 5000;")
+    conn.execute("PRAGMA foreign_keys = ON;")
+    if readonly or query_only:
+        conn.execute("PRAGMA query_only = ON;")
+    return conn
+
+
+def chunk_values(
+    values: Sequence[object],
+    size: int = MAX_SQL_PARAMS,
+) -> Iterable[Sequence[object]]:
+    """Yield *values* in slices that fit SQLite's host parameter limit."""
+
+    for idx in range(0, len(values), size):
+        yield values[idx : idx + size]

--- a/vexor/sqlite_util.py
+++ b/vexor/sqlite_util.py
@@ -17,8 +17,15 @@ from pathlib import Path
 MAX_SQL_PARAMS = 900
 
 
-def _ensure_wal(conn: sqlite3.Connection) -> None:
-    """Put *conn* in WAL mode without fighting other connections over the switch.
+def _is_lock_contention(exc: sqlite3.OperationalError) -> bool:
+    """True when *exc* means "someone else holds it", not "something is broken"."""
+
+    message = str(exc).lower()
+    return any(token in message for token in ("readonly", "locked", "busy"))
+
+
+def _ensure_wal(conn: sqlite3.Connection) -> bool:
+    """Try to put *conn* in WAL mode. Returns whether the database ended up there.
 
     Changing ``journal_mode`` needs a brief exclusive lock, and SQLite does not
     run the busy handler for it: a concurrent switch returns SQLITE_BUSY
@@ -26,25 +33,31 @@ def _ensure_wal(conn: sqlite3.Connection) -> None:
     takes no lock, so the overwhelmingly common case — a database already in WAL
     — never contends at all.
 
-    Losing the race on a freshly created database is deliberately tolerated.
-    WAL is a concurrency optimization, not a correctness requirement; whichever
-    connection won the switch leaves the database in WAL for everyone after it,
-    and a connection that stayed on the rollback journal still reads and writes
-    correctly. Any other operational error still propagates.
+    Failing to switch is deliberately tolerated rather than raised. WAL is a
+    concurrency optimization, not a correctness requirement: a database left on
+    the rollback journal still reads and writes correctly, it just serializes
+    readers against writers. Note that an unsuccessful switch does *not* raise —
+    SQLite reports the mode still in force — so the result is inspected rather
+    than assumed. Errors that are not lock contention do propagate; a disk or
+    corruption failure here is real and must not be deferred to some later,
+    less obviously related query.
     """
 
     try:
         row = conn.execute("PRAGMA journal_mode;").fetchone()
-    except sqlite3.OperationalError:
-        return
-    if row is not None and str(row[0]).lower() == "wal":
-        return
-    try:
-        conn.execute("PRAGMA journal_mode = WAL;")
     except sqlite3.OperationalError as exc:
-        message = str(exc).lower()
-        if not any(token in message for token in ("readonly", "locked", "busy")):
+        if not _is_lock_contention(exc):
             raise
+        return False
+    if row is not None and str(row[0]).lower() == "wal":
+        return True
+    try:
+        result = conn.execute("PRAGMA journal_mode = WAL;").fetchone()
+    except sqlite3.OperationalError as exc:
+        if not _is_lock_contention(exc):
+            raise
+        return False
+    return result is not None and str(result[0]).lower() == "wal"
 
 
 def connect(

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -593,3 +593,57 @@ class Messages:
 
     INFO_STAR_SUCCESS = "Thank you for starring the Vexor repository!"
     INFO_STAR_BROWSER = "Opening {url} in your browser to star the repository..."
+
+    # --- Collections (filesystem-independent record store) -------------------
+    ERROR_COLLECTION_NAME_REQUIRED = "Collection name must not be empty."
+    ERROR_COLLECTION_DIMENSION_INVALID = (
+        "Collection embedding dimension must be a positive integer."
+    )
+    ERROR_COLLECTION_CONTRACT_MISMATCH = (
+        "Collection '{name}' is pinned to {stored} (provider/model/dimension) but the "
+        "call requested {requested}. Vectors of different widths or models must not be "
+        "mixed; recreate the collection instead."
+    )
+    ERROR_COLLECTION_NOT_FOUND = "Collection '{name}' does not exist."
+    ERROR_COLLECTION_RECORD_KEY_REQUIRED = "Every record needs a non-empty 'id'."
+    ERROR_COLLECTION_RECORD_NOT_MAPPING = (
+        "Each record must be a mapping with 'id' and 'text' keys."
+    )
+    ERROR_COLLECTION_TEXT_EMPTY = (
+        "Record '{key}' has empty text. Embedding an empty string is undefined across "
+        "providers, so it is rejected rather than stored."
+    )
+    ERROR_COLLECTION_DUPLICATE_KEY = (
+        "Record id '{key}' appears more than once in the same call."
+    )
+    ERROR_COLLECTION_METADATA_NOT_MAPPING = "Record metadata must be a mapping."
+    ERROR_COLLECTION_METADATA_KEY_INVALID = "Metadata keys must be non-empty strings."
+    ERROR_COLLECTION_METADATA_VALUE_INVALID = (
+        "Metadata field '{key}' holds an unsupported {type}. Only str, int, float, "
+        "bool, datetime, and None can be filtered on."
+    )
+    ERROR_COLLECTION_FILTER_KEY_INVALID = "Filter keys must be non-empty strings."
+    ERROR_COLLECTION_FILTER_EMPTY = "Filter conditions must not be empty."
+    ERROR_COLLECTION_FILTER_OPERATOR_INVALID = (
+        "Unsupported filter operator '{operator}'. Use one of: {allowed}."
+    )
+    ERROR_COLLECTION_FILTER_VALUE_INVALID = (
+        "Filter values must be str, int, float, bool, or datetime, not {type}."
+    )
+    ERROR_COLLECTION_FILTER_EXISTS_INVALID = "The 'exists' operator takes a boolean."
+    ERROR_COLLECTION_FILTER_SET_INVALID = (
+        "The '{operator}' operator takes a list, tuple, or set of values."
+    )
+    ERROR_COLLECTION_FILTER_SET_EMPTY = (
+        "The '{operator}' operator needs at least one value."
+    )
+    ERROR_COLLECTION_FILTER_RANGE_INVALID = (
+        "The '{operator}' operator only compares numbers, booleans, and datetimes."
+    )
+    ERROR_COLLECTION_RERANK_UNSUPPORTED = (
+        "Collection search does not support rerank '{value}' yet. Use one of: {allowed}."
+    )
+    ERROR_COLLECTION_QUERY_EMPTY = "Search query must not be empty."
+    ERROR_COLLECTION_EMBED_FAILED = (
+        "The embedding provider returned no vectors for this batch."
+    )

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -622,6 +622,10 @@ class Messages:
         "Metadata field '{key}' holds an unsupported {type}. Only str, int, float, "
         "bool, datetime, and None can be filtered on."
     )
+    ERROR_COLLECTION_FILTER_NOT_MAPPING = (
+        "Filters must be a mapping of field names to values or operator mappings, "
+        "not {type}. Pass None to search without filtering."
+    )
     ERROR_COLLECTION_FILTER_KEY_INVALID = "Filter keys must be non-empty strings."
     ERROR_COLLECTION_FILTER_EMPTY = "Filter conditions must not be empty."
     ERROR_COLLECTION_FILTER_OPERATOR_INVALID = (


### PR DESCRIPTION
## Motivation

Vexor's retrieval core was already source-agnostic — `bm25.py` is pure functions
over ids, `embedding_cache` is keyed by `(model, text_hash)`, `embed_texts`
accepts any text, and #51 already extracted the reranker seam. The only thing
tying it to disk was the storage schema and `SearchResult.path`.

This adds a second consumer of that core: callers submit records straight from
their own database, with no temporary file export and no parallel file tree. The
motivating case from the roadmap is a bot whose chat history lives in
MySQL/Postgres/SQLite and needs semantic + keyword recall scoped to one chat.

## What shipped

`VexorClient.collection(name)` → `upsert` / `upsert_many`, `get` / `get_many`,
`delete` / `delete_many`, `search`, `count`, `info`, `drop`. Results are
`RecordResult(id, text, metadata, score)` — no path, no line numbers.

- `vexor/collection_store.py` — `collections.db` beside `index.db`, holding
  records, embeddings, BM25 postings, and an EAV metadata table.
- `vexor/services/collection_service.py` — validation, incremental embedding,
  ranking.
- `vexor/sqlite_util.py`, `vexor/services/embedding_service.py` — connection,
  batching, and cached-embedding helpers extracted out of `cache.py` and
  `index_service.py` so both stores share one code path instead of two copies
  that drift.

## Design decisions worth reviewing

**Parallel store, not a unified one.** Unifying would mean bumping
`CACHE_VERSION` (forcing every existing user to rebuild) and changing
`SearchResult`, a porcelain/CLI/MCP contract. `CACHE_VERSION` is untouched; every
new table is additive under `CREATE TABLE IF NOT EXISTS`.

**`ne` / `nin` match records that lack the key.** Requiring the key to exist
silently drops every unlabeled record from a negative filter: filtering
`{"status": {"ne": "closed"}}` over chat turns that mostly carry no `status`
looks like excluding closed items and actually loses all untagged ones.
`exists: True` is how you require a key.

**Filtering resolves before scoring.** Conditions compile to SQL and produce a
candidate id set first. Post-filtering a global top-k returns nothing for a chat
whose records never reach the global head.

**Metadata-only edits keep the vector.** `text_hash` gates re-embedding, but
metadata is always rewritten. Dropping the postings on a metadata edit would
silently remove the record from lexical search.

**Search ships `off` and `hybrid` only.** `hybrid` fuses dense and BM25 over
persisted postings whose idf is computed on the *filtered subset*. The legacy
`bm25` reranker compensates for file search predating the inverted index; a
collection has one from its first write. FlashRank and remote reranking are
additive later, no schema change needed.

**`vexor config --clear-index-all` does not touch `collections.db`.** A file
index rebuilds from disk; collection records only come back by re-upserting
everything and paying for embeddings again. `clear_all_collections()` is the
separate explicit exit. **This is the one decision I'd like your call on** — a
deliberate asymmetry, not an oversight.

## Bugs found and fixed

Two review passes ran over this branch. Every finding below was reproduced
before being fixed and has a regression test.

**Silently wrong results**

1. **Search did not verify the pinned contract**, only the query-vector width.
   Two models can share a vector width while embedding into unrelated spaces, so
   querying with a different provider or model scored stored vectors against a
   query from another space — the arithmetic succeeds and the ranking is
   meaningless.
2. **A falsey non-mapping filter was treated as "no filter".** `filters=[]` or a
   mis-decoded `0` widened a tenant-scoped search to the whole collection.
3. **Search read across four connections, so it saw no single snapshot.** A
   writer moving a record between filter resolution and vector loading could
   hand tenant B's record to a caller filtering for tenant A. Reads now share one
   connection inside an explicit read transaction; WAL only guarantees a stable
   snapshot while one is open.
4. **A metadata-only upsert decided "unchanged" before taking the write lock**,
   so a concurrent text change left the row claiming the old text while the
   embedding described the new one. The update is now guarded on `text_hash`.
5. **A text that tokenizes to nothing left its old `token_count` behind**,
   skewing `avg_doc_len` for every later hybrid query.

**Concurrency — pre-existing, and reachable from the file index path too**

6. **`PRAGMA busy_timeout` was set after `PRAGMA journal_mode`**, leaving the one
   statement that needs an exclusive lock unprotected. Moving it first is not
   sufficient: SQLite does not run the busy handler for a journal_mode switch at
   all. The mode is now read before it is written, so a database already in WAL
   never contends. Opening a database from 8 threads previously failed about a
   quarter of the time.
7. **`PRAGMA journal_mode` does not raise when a switch fails** — it returns the
   mode still in force. The result was ignored, so a database left on the
   rollback journal was treated as if it had reached WAL.
8. **The same helper swallowed every `OperationalError`** while its docstring
   promised non-contention failures propagate, deferring a disk or corruption
   error to some later unrelated query.
9. **A half-built schema was mistaken for a stale one.** `_schema_needs_reset`
   treated "`indexed_chunk` missing while another index table is present" as the
   pre-chunk layout — but `executescript` creates `index_metadata` and
   `indexed_file` first, so a second connection arriving in that window dropped
   the tables the first was still building. Any two writers initializing the
   index database at once can hit it; the collection tests are just the first
   thing in the suite that does, since every upsert writes the shared
   `embedding_cache`. Now keyed on `file_embedding`, which only existed before
   chunked indexing and is never created again. This one surfaced as a CI
   failure on Python 3.10 and reproduces deterministically without threads.
10. **Collection writes now open with `BEGIN IMMEDIATE`.** A DEFERRED transaction
   takes a read lock on its first SELECT and upgrades on the first write; two
   writers holding read locks can never both upgrade, so SQLite returns BUSY
   without consulting `busy_timeout`.

**Error handling and lifecycle**

11. **Read failures were converted into empty results.** Right for the file
    index, which rebuilds from disk; wrong here, where records only come back if
    the caller re-upserts everything. A missing database file still reads as
    empty; every other error propagates.
12. **A failed first write left an empty collection pinned to a contract the
    caller never successfully used**, blocking retries of that name under a
    different provider. Cleanup is now conditional on the row still being the
    same collection and still empty, decided in one transaction so a concurrent
    writer's records survive, and best-effort so it cannot mask the original
    error.
13. Dropping a collection that never existed created an empty database file, and
    `clear_all_collections()` raised `PermissionError` on Windows when any reader
    held the file.

## Boundaries (deliberate, recorded in the roadmap)

No CLI command, no MCP tool (the server is path-scoped; which collection an agent
may reach is a separate authorization question), no chunking (one vector per
record; over-long text surfaces the provider error rather than being truncated),
no caller-supplied vectors, no OR in filters. No ANN index — scoring is a
brute-force matrix product over the filtered candidate set, so cost tracks one
filtered slice, not the whole collection.

Two known issues left open, both recorded rather than fixed:

- **`datetime` metadata reads back as an ISO string.** Filtering is correct
  (ranges use the epoch seconds stored alongside the ISO text), but the read path
  returns the JSON payload, which cannot carry the type. Documented.
- **The shared `embedding_cache` is not namespaced by provider.** Two providers
  configured with the same model name and width share vectors. Pre-existing,
  affects the file index equally, and fixing it means changing a shared cache
  key — out of scope here.

## Verification

- `python -m pytest` — **740 passed**, and CI is green on Python 3.10. `python -m ruff check .` — clean.
- Coverage: `collection_store` 95%, `collection_service` 94%,
  `embedding_service` 97%, `sqlite_util` 98% (95% combined).
- **Concurrency**: 25 rounds × 8 concurrent upserts, 0 failures (before: ~2 in 8
  rounds failed). Concurrent first-writes, concurrent upserts, and
  readers-during-writes all clean, repeated 8×.
- **Transaction integrity**: a batch failing partway leaves zero rows behind,
  verified by injecting a binding error into the third record of a batch.
- **Positional mapping**: embedding rows map back to the right records when a
  batch contains duplicate texts and when cache hits mix with misses.
- **Real end-to-end run** against a live local model
  (`intfloat/multilingual-e5-small`, dim 384, provider `local`), not mocks:

```
== first upsert ==
   UpsertReport(written=5, embedded=5, skipped=0) in 2.7s
   pinned contract: local/intfloat/multilingual-e5-small/dim=384

== semantic recall: query shares no keyword with the target ==
   +0.8262  c2-t2  user: any good pasta nearby
   +0.8235  c1-t2  user: what was that restaurant you mentioned

== tenant isolation: same query, scoped to chat 2 ==
   +0.8674  c2-t1  chat=2
   +0.7860  c2-t2  chat=2

== the globally best match is excluded by the filter ==
   global winner: c1-t1
   inside chat 2: ['c2-t1', 'c2-t2']

== datetime range filter ==
   on/after 2026-08-03: ['c1-t3', 'c2-t2']

== re-upsert identical payload ==
   UpsertReport(written=5, embedded=0, skipped=5) in 1.56s

== metadata-only edit keeps the vector ==
   kind=pinned -> ['c1-t2']

== ne includes records that lack the key ==
   kind != turn -> ['c1-t2', 'no-kind']

ALL CHECKS PASSED
```

- The worked example in `docs/api/collections.md` was extracted and executed
  verbatim against the same local model (only the client constructor was
  substituted for a temp cache directory and a pinned local model).

## Compatibility

Additive, with one behavior change to a shared path: `sqlite_util.connect` sets
`busy_timeout` first, reads `journal_mode` before writing it, and no longer
swallows non-contention errors. That affects the file index too — it is the
concurrency fix above, and the full suite passes.

A damaged database surfaces as a raw `sqlite3` exception rather than being
wrapped in `VexorError`: corruption is not an input error, and flattening it into
the input-validation type would hide what actually went wrong.

No `CACHE_VERSION` bump, no change to `SearchResult`, porcelain, CLI, MCP
schemas, or the bundled skill. The skill is deliberately untouched: this release
adds no command and no tool for it to describe. New public exports:
`CollectionHandle`, `CollectionInfo`, `CollectionError`, `RecordResult`,
`StoredRecord`, `UpsertReport`.
