### PR TITLE
docs(readme): add CodeRabbit reviews badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![PyPI](https://img.shields.io/pypi/v/vexor.svg)](https://pypi.org/project/vexor/)
 [![CI](https://img.shields.io/github/actions/workflow/status/scarletkc/vexor/publish.yml?branch=main)](https://github.com/scarletkc/vexor/actions/workflows/publish.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/scarletkc/vexor/main)](https://codecov.io/github/scarletkc/vexor)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/scarletkc/vexor?utm_source=oss&utm_medium=github&utm_campaign=scarletkc%2Fvexor&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 [![License](https://img.shields.io/github/license/scarletkc/vexor.svg)](https://github.com/scarletkc/vexor/blob/main/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/scarletkc/vexor)
 


### PR DESCRIPTION
## Motivation

The repository now has the CodeRabbit app installed for automated PR reviews. This adds the corresponding shields.io badge to the README badge row, next to CI and Codecov.

The badge is wrapped in a link to https://coderabbit.ai to match the surrounding badges (the shields `link=` parameter has no effect in Markdown).

## Verification

- Documentation-only change; no code, tests, or bundled skill affected.
- This PR also doubles as a live check that CodeRabbit auto-triggers on new pull requests.