### PR TITLE
fix(init): skip setup wizard for config commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ pip install vexor  # also works with pipx, uv
 ```bash
 vexor init
 ```
-The wizard also runs automatically on first use when no config exists.
+The wizard also runs automatically before the first interactive operational
+command when no config exists. Configuration-management (`vexor config`), MCP,
+help, and version commands run directly.
 
 ### 1. Search
 ```bash

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -210,6 +210,33 @@ def test_should_offer_update_notice_gating(monkeypatch):
     assert cli_module.should_offer_update_notice(["search", "q"]) is False
 
 
+def test_run_dispatches_config_without_starting_init_wizard(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    original_should_auto_run_init = cli.should_auto_run_init
+
+    def should_auto_run_init_interactively(args, *, config_path):
+        return original_should_auto_run_init(
+            args,
+            config_path=config_path,
+            is_tty=True,
+        )
+
+    dispatched: list[list[str]] = []
+    monkeypatch.setattr(cli.config_module, "CONFIG_FILE", config_path)
+    monkeypatch.setattr(cli, "should_auto_run_init", should_auto_run_init_interactively)
+    monkeypatch.setattr(
+        cli,
+        "run_init_wizard",
+        lambda: (_ for _ in ()).throw(AssertionError("init wizard must not run")),
+    )
+    monkeypatch.setattr(cli, "should_offer_update_notice", lambda _args: False)
+    monkeypatch.setattr(cli, "app", lambda *, args: dispatched.append(args))
+
+    cli.run(["config", "--show"])
+
+    assert dispatched == [["config", "--show"]]
+
+
 def test_print_update_notice_reads_cache_only(monkeypatch):
     from rich.console import Console
 

--- a/tests/unit/test_init_service.py
+++ b/tests/unit/test_init_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from vexor.services import init_service
 from vexor.services.init_service import should_auto_run_init
 from vexor.text import Messages
@@ -29,6 +31,19 @@ def test_should_auto_run_init_runs_when_missing_config(tmp_path):
 def test_should_auto_run_init_skips_mcp_command(tmp_path):
     config_path = tmp_path / "config.json"
     assert should_auto_run_init(["mcp"], config_path=config_path, is_tty=True) is False
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ["config"],
+        ["config", "--show"],
+        ["config", "--set-api-key", "secret"],
+    ),
+)
+def test_should_auto_run_init_skips_config_commands(tmp_path, args):
+    config_path = tmp_path / "config.json"
+    assert should_auto_run_init(args, config_path=config_path, is_tty=True) is False
 
 
 def test_collect_remote_settings_voyageai_prompts_voyage_api_key(monkeypatch):

--- a/vexor/services/init_service.py
+++ b/vexor/services/init_service.py
@@ -66,7 +66,7 @@ def should_auto_run_init(
     if not is_tty:
         return False
     tokens = list(args or [])
-    if tokens and tokens[0] in {"init", "mcp"}:
+    if tokens and tokens[0] in {"init", "config", "mcp"}:
         return False
     skip_flags = {
         "-h",


### PR DESCRIPTION
Fixes #60

## Summary

- skip the first-run setup wizard for `vexor config` commands
- add service-level and CLI dispatch regression coverage
- clarify which first-run commands bypass onboarding in the README

## Verification

- `.venv\Scripts\python.exe -m pytest tests\unit\test_init_service.py tests\unit\test_cli_helpers.py -q` (`22 passed`)
- `.venv\Scripts\python.exe -m pytest -k "not test_alias_helpers_and_prompt_alias_setup"` (`743 passed, 1 deselected`)
- `.venv\Scripts\python.exe -m pytest -k "not test_alias_helpers_and_prompt_alias_setup" --cov=vexor --cov-report=term-missing` (`91%` total coverage)
- `.venv\Scripts\python.exe -m ruff check .`
- `.venv\Scripts\python.exe -m vexor --help`

The deselected pre-existing test changes global `os.name` to `posix` while running on Windows and then constructs `pathlib.Path`, which causes pytest itself to fail with `NotImplementedError: cannot instantiate 'PosixPath' on your system`. It is unrelated to this change.