### PR TITLE
chore(release): bump version to 0.28.0

### DIFF
--- a/docs/release-notes/0.28.0.md
+++ b/docs/release-notes/0.28.0.md
@@ -1,0 +1,24 @@
+## Collections API
+
+Vexor 0.28.0 adds persistent record collections to the Python API. Applications
+can send records from MySQL, Postgres, SQLite, a message store, or any other
+database directly to Vexor with their existing IDs, text, and metadata.
+
+`VexorClient.collection(name)` returns a handle with `upsert`, `upsert_many`,
+`get`, `get_many`, `delete`, `delete_many`, `search`, `count`, `info`, and
+`drop`. Collections live in their own `collections.db`, separately from file
+indexes, and unchanged text keeps its existing embedding when metadata is
+updated.
+
+Search supports dense similarity and hybrid dense + BM25 ranking. Metadata
+filters resolve before scoring, so a query scoped to one chat, tenant, or time
+range only ranks records inside that slice. The first successful write pins the
+embedding provider, model, and vector dimension for the collection, and later
+writes and searches must use the same contract.
+
+Collections are available through the Python API in this release. Each record
+maps to one vector, and search scores the filtered candidate set directly, so
+selective metadata is useful for large collections. See the
+[Collections API guide](https://github.com/scarletkc/vexor/blob/v0.28.0/docs/api/collections.md)
+for the complete record schema, filter operators, and a database-backed chat
+history example.

--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/scarletkc/vexor",
     "source": "github"
   },
-  "version": "0.27.2",
+  "version": "0.28.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vexor",
-      "version": "0.27.2",
+      "version": "0.28.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -38,7 +38,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.27.2"
+__version__ = "0.28.0"
 
 _API_EXPORTS = frozenset(
     {


### PR DESCRIPTION
## Motivation

Collections shipped on main after v0.27.2 and need a feature release. This release uses the latest main commit as its base and gives Collections API the hand-written lead section in the GitHub Release.

## What changed

- Bump the Python package, bundled plugin, and MCP server manifest to 0.28.0.
- Add the 0.28.0 release note covering persistent records, CRUD, dense and hybrid search, pre-scoring metadata filters, and the pinned embedding contract.
- Link the release note to the versioned Collections API guide.

The Collections implementation and its real local-provider end-to-end evidence are in #59.

## Verification

- python -m pytest --cov=vexor --cov-report=term-missing: 744 passed, 91% total coverage
- python -m ruff check .: passed
- python -m vexor --help: passed
- python -m vexor --version: Vexor v0.28.0
- python -m build --no-isolation: built vexor-0.28.0.tar.gz and vexor-0.28.0-py3-none-any.whl
- Wheel and sdist metadata: Version 0.28.0, Requires-Python >=3.10
