### PR TITLE
feat(collection): support all rerankers

### DIFF
--- a/docs/api/collections.md
+++ b/docs/api/collections.md
@@ -15,8 +15,8 @@ Call `VexorClient(...).collection("name")` to get a `CollectionHandle`. Getting
 the handle does not touch the database; the named collection is created by its
 first successful non-empty write.
 
-The handle uses the client's resolved embedding configuration unless you pass
-overrides to `collection(...)`.
+The handle uses the client's resolved embedding and reranker configuration
+unless you pass overrides to `collection(...)` or `search(...)`.
 
 The provider, model, and vector dimension are fixed when the collection is
 created. Later writes **and searches** configured differently are rejected, with
@@ -72,15 +72,29 @@ with `exists: True` when the key itself is required.
 
 Filters resolve to record IDs before query scoring. An unknown key therefore
 produces no matches for a positive condition, and a record excluded by a filter
-cannot re-enter through dense or hybrid ranking.
+cannot re-enter through dense retrieval or reranking.
 
 ## Search and scale
 
-`search(query, *, top_k=10, filters=None, rerank="off")` returns
-`RecordResult` objects with `id`, `text`, `metadata`, and `score`. Collection
-search accepts only `rerank="off"` for dense similarity or `rerank="hybrid"`
-to fuse dense and BM25 scores. Filters resolve before either mode scores
-candidates.
+`search(query, *, top_k=10, filters=None, rerank=None, flashrank_model=None,
+remote_rerank=None)` returns `RecordResult` objects with `id`, `text`,
+`metadata`, and `score`. When `rerank` is omitted, the handle uses the resolved
+Vexor configuration; the default configuration is `off`. An explicit argument
+overrides the configured strategy for that call.
+
+Collection search supports the same strategies as file search:
+
+- `off` ranks the filtered records by dense similarity.
+- `hybrid` fuses the full dense and BM25 rankings over the filtered records.
+- `bm25`, `flashrank`, and `remote` rerank an expanded dense candidate window,
+  then return its top results. These rerankers receive each candidate's full
+  record text rather than a file path or preview.
+
+FlashRank requires `pip install "vexor[flashrank]"`. Pass `flashrank_model` to
+override its configured model for one search. Remote reranking uses the
+configured endpoint, model, and API key; pass a `RemoteRerankConfig` as
+`remote_rerank` to override them for one search. Filters always resolve before
+the candidate window is selected or sent to a reranker.
 
 Dense scoring is a brute-force matrix product over the filtered candidate set;
 collections do not have an approximate nearest-neighbor index. Search cost

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,13 +60,10 @@ never leaving the machine.
   - MCP exposure is deferred. The server is path-scoped today, and deciding
     which collection an agent may reach is a separate authorization design
     question.
-  - Collection search supports `rerank="off"` and `rerank="hybrid"` only;
-    FlashRank and remote reranking are deferred. `hybrid` already fuses dense
-    and BM25 scores over persisted postings whose idf is computed on the
-    filtered subset. That is better information than the legacy `bm25`
-    reranker's second pass over a truncated candidate list: the reranker
-    compensates for file search predating the inverted index, while a
-    collection has one from its first write.
+  - Collection search supports `off`, `bm25`, `flashrank`, `remote`, and
+    `hybrid`. Filters resolve before ranking; `hybrid` scores persisted BM25
+    postings over the full filtered subset, while the candidate rerankers use
+    the same expanded dense window as file search and score full record text.
   - Caller-supplied vectors and a custom embedding function are deferred.
     Their design must revisit the `text_hash` skip, which currently assumes
     that identical text always produces an identical vector; externally

--- a/tests/unit/test_collection_service.py
+++ b/tests/unit/test_collection_service.py
@@ -11,6 +11,7 @@ import vexor
 import vexor.api as api_module
 import vexor.cache as cache
 from vexor.collection_store import CollectionError
+from vexor.config import RemoteRerankConfig
 from vexor.search import VexorSearcher
 from vexor.services import collection_service
 
@@ -104,8 +105,135 @@ def test_empty_search_query_raises_collection_error(isolated_cache):
 
 def test_unsupported_rerank_value_raises_collection_error(isolated_cache):
     backend = CountingBackend({})
-    with pytest.raises(CollectionError):
-        _search("missing", "query", backend, rerank="flashrank")
+    with pytest.raises(CollectionError, match="bogus"):
+        _search("missing", "query", backend, rerank="bogus")
+
+
+def test_bm25_reranks_dense_candidates_from_record_text(isolated_cache, monkeypatch):
+    backend = CountingBackend(
+        {
+            "first full record": [1.0, 0.0, 0.0],
+            "second full record": [0.8, 0.2, 0.0],
+            "query": [1.0, 0.0, 0.0],
+        }
+    )
+    _upsert(
+        "records",
+        [
+            {"id": "first", "text": "first full record"},
+            {"id": "second", "text": "second full record"},
+        ],
+        backend,
+    )
+    captured: dict[str, object] = {}
+
+    def fake_rank(query, documents, base_scores):
+        captured.update(query=query, documents=documents, base_scores=base_scores)
+        return [(1, 0.95), (0, 0.25)]
+
+    monkeypatch.setattr(collection_service, "_rank_documents_bm25", fake_rank)
+
+    results = _search("records", "query", backend, top_k=1, rerank="bm25")
+
+    assert [result.id for result in results] == ["second"]
+    assert results[0].score == pytest.approx(0.95)
+    assert captured["query"] == "query"
+    assert captured["documents"] == ["first full record", "second full record"]
+    assert captured["base_scores"] == pytest.approx([1.0, 0.9701425])
+
+
+def test_flashrank_uses_configured_model_and_record_text(isolated_cache, monkeypatch):
+    backend = CountingBackend(
+        {
+            "first full record": [1.0, 0.0, 0.0],
+            "second full record": [0.8, 0.2, 0.0],
+            "query": [1.0, 0.0, 0.0],
+        }
+    )
+    _upsert(
+        "records",
+        [
+            {"id": "first", "text": "first full record"},
+            {"id": "second", "text": "second full record"},
+        ],
+        backend,
+    )
+    captured: dict[str, object] = {}
+
+    def fake_rank(query, documents, model_name):
+        captured.update(query=query, documents=documents, model_name=model_name)
+        return [(1, 0.9), (0, 0.4)]
+
+    monkeypatch.setattr(collection_service, "_rank_documents_flashrank", fake_rank)
+
+    results = _search(
+        "records",
+        "query",
+        backend,
+        top_k=1,
+        rerank="flashrank",
+        flashrank_model="ranker-model",
+    )
+
+    assert [result.id for result in results] == ["second"]
+    assert captured == {
+        "query": "query",
+        "documents": ["first full record", "second full record"],
+        "model_name": "ranker-model",
+    }
+
+
+def test_remote_rerank_only_receives_filtered_candidates(isolated_cache, monkeypatch):
+    backend = CountingBackend(
+        {
+            "allowed record": [1.0, 0.0, 0.0],
+            "also allowed": [0.8, 0.2, 0.0],
+            "excluded record": [0.9, 0.1, 0.0],
+            "query": [1.0, 0.0, 0.0],
+        }
+    )
+    _upsert(
+        "records",
+        [
+            {"id": "a", "text": "allowed record", "metadata": {"tenant": "a"}},
+            {"id": "b", "text": "also allowed", "metadata": {"tenant": "a"}},
+            {
+                "id": "excluded",
+                "text": "excluded record",
+                "metadata": {"tenant": "b"},
+            },
+        ],
+        backend,
+    )
+    remote = RemoteRerankConfig(
+        base_url="https://rerank.example.test/v1/rerank",
+        api_key="secret",
+        model="rerank-model",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_rank(query, documents, config):
+        captured.update(query=query, documents=documents, config=config)
+        return [(1, 0.85), (0, None)]
+
+    monkeypatch.setattr(collection_service, "_rank_documents_remote", fake_rank)
+
+    results = _search(
+        "records",
+        "query",
+        backend,
+        top_k=2,
+        filters={"tenant": "a"},
+        rerank="remote",
+        remote_rerank=remote,
+    )
+
+    assert [result.id for result in results] == ["b", "a"]
+    assert captured == {
+        "query": "query",
+        "documents": ["allowed record", "also allowed"],
+        "config": remote,
+    }
 
 
 def test_non_positive_top_k_returns_empty_without_embedding(isolated_cache):
@@ -223,3 +351,62 @@ def test_collection_handle_translates_contract_errors_to_vexor_error(
             handle.upsert("", "body")
 
     assert not isinstance(excinfo.value, CollectionError)
+
+
+def test_collection_handle_uses_configured_reranker(tmp_path: Path, monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_search_records(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(collection_service, "search_records", fake_search_records)
+    config = {
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "api_key": "embedding-key",
+        "rerank": "remote",
+        "remote_rerank": {
+            "base_url": "https://rerank.example.test/v1",
+            "api_key": "remote-key",
+            "model": "rerank-model",
+        },
+    }
+
+    with api_module.VexorClient(cache_dir=tmp_path / "api-cache") as client:
+        client.collection("api-records", config=config).search("query")
+
+    assert captured["rerank"] == "remote"
+    remote = captured["remote_rerank"]
+    assert isinstance(remote, RemoteRerankConfig)
+    assert remote.base_url == "https://rerank.example.test/v1/rerank"
+    assert remote.model == "rerank-model"
+
+
+def test_collection_handle_per_call_reranker_overrides_config(
+    tmp_path: Path,
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    def fake_search_records(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(collection_service, "search_records", fake_search_records)
+    config = {
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "api_key": "embedding-key",
+        "rerank": "remote",
+    }
+
+    with api_module.VexorClient(cache_dir=tmp_path / "api-cache") as client:
+        client.collection("api-records", config=config).search(
+            "query",
+            rerank="flashrank",
+            flashrank_model="ranker-model",
+        )
+
+    assert captured["rerank"] == "flashrank"
+    assert captured["flashrank_model"] == "ranker-model"

--- a/tests/unit/test_collection_service.py
+++ b/tests/unit/test_collection_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -109,7 +110,10 @@ def test_unsupported_rerank_value_raises_collection_error(isolated_cache):
         _search("missing", "query", backend, rerank="bogus")
 
 
-def test_bm25_reranks_dense_candidates_from_record_text(isolated_cache, monkeypatch):
+def test_bm25_reranks_dense_candidates_from_record_text(
+    isolated_cache: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     backend = CountingBackend(
         {
             "first full record": [1.0, 0.0, 0.0],
@@ -127,7 +131,11 @@ def test_bm25_reranks_dense_candidates_from_record_text(isolated_cache, monkeypa
     )
     captured: dict[str, object] = {}
 
-    def fake_rank(query, documents, base_scores):
+    def fake_rank(
+        query: str,
+        documents: Sequence[str],
+        base_scores: Sequence[float],
+    ) -> list[tuple[int, float]]:
         captured.update(query=query, documents=documents, base_scores=base_scores)
         return [(1, 0.95), (0, 0.25)]
 
@@ -142,7 +150,10 @@ def test_bm25_reranks_dense_candidates_from_record_text(isolated_cache, monkeypa
     assert captured["base_scores"] == pytest.approx([1.0, 0.9701425])
 
 
-def test_flashrank_uses_configured_model_and_record_text(isolated_cache, monkeypatch):
+def test_flashrank_uses_configured_model_and_record_text(
+    isolated_cache: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     backend = CountingBackend(
         {
             "first full record": [1.0, 0.0, 0.0],
@@ -160,7 +171,11 @@ def test_flashrank_uses_configured_model_and_record_text(isolated_cache, monkeyp
     )
     captured: dict[str, object] = {}
 
-    def fake_rank(query, documents, model_name):
+    def fake_rank(
+        query: str,
+        documents: Sequence[str],
+        model_name: str | None,
+    ) -> list[tuple[int, float]]:
         captured.update(query=query, documents=documents, model_name=model_name)
         return [(1, 0.9), (0, 0.4)]
 
@@ -183,7 +198,10 @@ def test_flashrank_uses_configured_model_and_record_text(isolated_cache, monkeyp
     }
 
 
-def test_remote_rerank_only_receives_filtered_candidates(isolated_cache, monkeypatch):
+def test_remote_rerank_only_receives_filtered_candidates(
+    isolated_cache: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     backend = CountingBackend(
         {
             "allowed record": [1.0, 0.0, 0.0],
@@ -212,7 +230,11 @@ def test_remote_rerank_only_receives_filtered_candidates(isolated_cache, monkeyp
     )
     captured: dict[str, object] = {}
 
-    def fake_rank(query, documents, config):
+    def fake_rank(
+        query: str,
+        documents: Sequence[str],
+        config: RemoteRerankConfig | None,
+    ) -> list[tuple[int, float | None]]:
         captured.update(query=query, documents=documents, config=config)
         return [(1, 0.85), (0, None)]
 
@@ -353,10 +375,13 @@ def test_collection_handle_translates_contract_errors_to_vexor_error(
     assert not isinstance(excinfo.value, CollectionError)
 
 
-def test_collection_handle_uses_configured_reranker(tmp_path: Path, monkeypatch):
+def test_collection_handle_uses_configured_reranker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, object] = {}
 
-    def fake_search_records(**kwargs):
+    def fake_search_records(**kwargs: object) -> list[object]:
         captured.update(kwargs)
         return []
 
@@ -380,16 +405,17 @@ def test_collection_handle_uses_configured_reranker(tmp_path: Path, monkeypatch)
     remote = captured["remote_rerank"]
     assert isinstance(remote, RemoteRerankConfig)
     assert remote.base_url == "https://rerank.example.test/v1/rerank"
+    assert remote.api_key == "remote-key"
     assert remote.model == "rerank-model"
 
 
 def test_collection_handle_per_call_reranker_overrides_config(
     tmp_path: Path,
-    monkeypatch,
-):
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, object] = {}
 
-    def fake_search_records(**kwargs):
+    def fake_search_records(**kwargs: object) -> list[object]:
         captured.update(kwargs)
         return []
 
@@ -399,14 +425,34 @@ def test_collection_handle_per_call_reranker_overrides_config(
         "model": "text-embedding-3-small",
         "api_key": "embedding-key",
         "rerank": "remote",
+        "remote_rerank": {
+            "base_url": "https://configured.example.test/v1",
+            "api_key": "configured-key",
+            "model": "configured-model",
+        },
     }
 
     with api_module.VexorClient(cache_dir=tmp_path / "api-cache") as client:
-        client.collection("api-records", config=config).search(
+        handle = client.collection("api-records", config=config)
+        handle.search(
             "query",
             rerank="flashrank",
             flashrank_model="ranker-model",
         )
 
-    assert captured["rerank"] == "flashrank"
-    assert captured["flashrank_model"] == "ranker-model"
+        assert captured["rerank"] == "flashrank"
+        assert captured["flashrank_model"] == "ranker-model"
+
+        per_call_remote = RemoteRerankConfig(
+            base_url="https://override.example.test/v1/rerank",
+            api_key="override-key",
+            model="override-model",
+        )
+        handle.search(
+            "query",
+            rerank="remote",
+            remote_rerank=per_call_remote,
+        )
+
+    assert captured["rerank"] == "remote"
+    assert captured["remote_rerank"] is per_call_remote

--- a/vexor/api.py
+++ b/vexor/api.py
@@ -1447,7 +1447,9 @@ class CollectionHandle:
         *,
         top_k: int = 10,
         filters: Mapping[str, object] | None = None,
-        rerank: str = DEFAULT_COLLECTION_RERANK,
+        rerank: str | None = None,
+        flashrank_model: str | None = None,
+        remote_rerank: RemoteRerankConfig | None = None,
     ) -> list[RecordResult]:
         """Search this collection, applying *filters* before anything is scored.
 
@@ -1466,7 +1468,17 @@ class CollectionHandle:
                 provider=settings.provider,
                 top_k=top_k,
                 filters=filters,
-                rerank=rerank,
+                rerank=rerank or settings.rerank or DEFAULT_COLLECTION_RERANK,
+                flashrank_model=(
+                    flashrank_model
+                    if flashrank_model is not None
+                    else settings.flashrank_model
+                ),
+                remote_rerank=(
+                    remote_rerank
+                    if remote_rerank is not None
+                    else settings.remote_rerank
+                ),
                 embedding_dimension=settings.embedding_dimensions,
                 no_cache=self._no_cache,
             )

--- a/vexor/services/collection_service.py
+++ b/vexor/services/collection_service.py
@@ -25,18 +25,19 @@ from ..collection_store import (
     ScalarValue,
     StoredRecord,
 )
+from ..config import DEFAULT_RERANK, SUPPORTED_RERANKERS, RemoteRerankConfig
 from ..text import Messages
 from .embedding_service import embed_texts_with_cache
+from .search_service import (
+    _apply_ranking,
+    _rank_documents_bm25,
+    _rank_documents_flashrank,
+    _rank_documents_remote,
+    _resolve_rerank_candidates,
+)
 
-# v1 deliberately ships two ranking modes. ``hybrid`` already fuses dense and
-# BM25 over persisted postings whose idf is computed on the filtered subset,
-# which is strictly better information than the legacy ``bm25`` reranker's
-# second pass over a truncated candidate list — that reranker exists to
-# compensate for file search predating the inverted index, and a collection has
-# one from its first write. FlashRank and remote reranking are additive and can
-# land later without a schema change.
-SUPPORTED_COLLECTION_RERANKERS: tuple[str, ...] = ("off", "hybrid")
-DEFAULT_COLLECTION_RERANK = "off"
+SUPPORTED_COLLECTION_RERANKERS = SUPPORTED_RERANKERS
+DEFAULT_COLLECTION_RERANK = DEFAULT_RERANK
 
 
 @dataclass(slots=True)
@@ -266,6 +267,8 @@ def search_records(
     top_k: int = 10,
     filters: Mapping[str, object] | None = None,
     rerank: str = DEFAULT_COLLECTION_RERANK,
+    flashrank_model: str | None = None,
+    remote_rerank: RemoteRerankConfig | None = None,
     embedding_dimension: int | None = None,
     no_cache: bool = False,
 ) -> list[RecordResult]:
@@ -343,16 +346,20 @@ def search_records(
             )
 
         order = sorted(range(len(record_ids)), key=lambda idx: (-scores[idx], idx))
-        top_rows = order[: int(top_k)]
-        selected_ids = [record_ids[row] for row in top_rows]
+        use_candidate_rerank = rerank_value in {"bm25", "flashrank", "remote"}
+        candidate_limit = (
+            _resolve_rerank_candidates(top_k) if use_candidate_rerank else top_k
+        )
+        candidate_rows = order[: int(candidate_limit)]
+        selected_ids = [record_ids[row] for row in candidate_rows]
         stored = collection_store.fetch_by_ids(info.id, selected_ids, snapshot)
 
-    results: list[RecordResult] = []
-    for row in top_rows:
+    candidates: list[RecordResult] = []
+    for row in candidate_rows:
         record = stored.get(record_ids[row])
         if record is None:
             continue
-        results.append(
+        candidates.append(
             RecordResult(
                 id=record.id,
                 text=record.text,
@@ -360,7 +367,35 @@ def search_records(
                 score=float(scores[row]),
             )
         )
-    return results
+    # Model loading and remote calls can be slow, so rerank only after the read
+    # snapshot closes instead of pinning the collection WAL for their duration.
+    if rerank_value == "bm25":
+        ranking = _rank_documents_bm25(
+            clean_query,
+            [result.text for result in candidates],
+            [result.score for result in candidates],
+        )
+        if ranking is not None:
+            candidates = _apply_ranking(candidates, ranking)
+    elif rerank_value == "flashrank":
+        candidates = _apply_ranking(
+            candidates,
+            _rank_documents_flashrank(
+                clean_query,
+                [result.text for result in candidates],
+                flashrank_model,
+            ),
+        )
+    elif rerank_value == "remote":
+        candidates = _apply_ranking(
+            candidates,
+            _rank_documents_remote(
+                clean_query,
+                [result.text for result in candidates],
+                remote_rerank,
+            ),
+        )
+    return candidates[: int(top_k)]
 
 
 def _fuse_hybrid(

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, TypeVar
 from urllib import error as urlerror
 from urllib import request as urlrequest
 
@@ -353,10 +353,17 @@ def _build_rerank_documents(results: Sequence[SearchResult]) -> list[str]:
     return [_build_rerank_document(result) for result in results]
 
 
+class _ScoredResult(Protocol):
+    score: float
+
+
+_ScoredResultT = TypeVar("_ScoredResultT", bound=_ScoredResult)
+
+
 def _apply_ranking(
-    results: Sequence[SearchResult],
+    results: Sequence[_ScoredResultT],
     ranking: Sequence[tuple[int, float | None]],
-) -> list[SearchResult]:
+) -> list[_ScoredResultT]:
     """Reorder *results* by a reranker's ``(index, score)`` pairs.
 
     Unknown, duplicate, and out-of-range indices are dropped, and anything the

--- a/vexor/services/search_service.py
+++ b/vexor/services/search_service.py
@@ -371,7 +371,7 @@ def _apply_ranking(
     response degrades to "reranked head, dense tail" instead of losing results.
     """
 
-    ordered: list[SearchResult] = []
+    ordered: list[_ScoredResultT] = []
     seen: set[int] = set()
     for index, score in ranking:
         if index < 0 or index >= len(results) or index in seen:

--- a/vexor/text.py
+++ b/vexor/text.py
@@ -645,7 +645,7 @@ class Messages:
         "The '{operator}' operator only compares numbers, booleans, and datetimes."
     )
     ERROR_COLLECTION_RERANK_UNSUPPORTED = (
-        "Collection search does not support rerank '{value}' yet. Use one of: {allowed}."
+        "Collection search does not support rerank '{value}'. Use one of: {allowed}."
     )
     ERROR_COLLECTION_QUERY_EMPTY = "Search query must not be empty."
     ERROR_COLLECTION_EMBED_FAILED = (


### PR DESCRIPTION
## Summary

- reuse Vexor's existing BM25, FlashRank, and remote reranker seams for Collection API searches
- share the global reranker allowlist, expand dense candidates consistently, and keep metadata filters ahead of every ranking path
- resolve the configured reranker for collection handles while allowing per-call FlashRank and remote overrides
- document the full Collection API ranking contract and cover reranker delegation, filtering, scores, and config precedence

## Compatibility

The default remains `off` when no reranker is configured. Collection searches now honor an existing configured reranker, and `CollectionHandle.search()` adds optional `flashrank_model` and `remote_rerank` overrides. Candidate rerankers score full record text; `hybrid` continues to fuse dense and persisted BM25 rankings over the full filtered subset.

Remote and model-backed reranking runs after the collection read snapshot closes, so slow calls do not pin the SQLite WAL.

## Verification

- `.\.venv\Scripts\python.exe -m pytest --cov=vexor --cov-report=term-missing` — 749 passed, 91% total coverage
- `.\.venv\Scripts\python.exe -m ruff check .` — passed
- `git diff --check` — passed
- real temporary-collection end-to-end check with configured embeddings: `off`, `hybrid`, `bm25`, `flashrank`, and `remote` all completed upsert, search, and drop successfully
