### PR TITLE
chore: release 0.29.0

### DIFF
--- a/docs/release-notes/0.29.0.md
+++ b/docs/release-notes/0.29.0.md
@@ -1,0 +1,12 @@
+## Collection rerankers
+
+Vexor 0.29.0 brings the full reranking set to the Collections API.
+`CollectionHandle.search()` now supports `off`, `bm25`, `flashrank`, `remote`,
+and `hybrid`, giving database-backed records the same ranking choices as
+indexed files.
+
+Collection filters are applied before candidates are selected or sent to a
+reranker. Searches inherit the client's resolved reranker settings by default,
+while `flashrank_model` and `remote_rerank` allow per-call overrides. See the
+[Collections API guide](https://github.com/scarletkc/vexor/blob/v0.29.0/docs/api/collections.md)
+for configuration and usage details.

--- a/plugins/vexor/.claude-plugin/plugin.json
+++ b/plugins/vexor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vexor",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "A semantic search engine for files and code (Vexor skill bundle).",
   "author": {
     "name": "scarletkc"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/scarletkc/vexor",
     "source": "github"
   },
-  "version": "0.28.0",
+  "version": "0.29.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vexor",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/vexor/__init__.py
+++ b/vexor/__init__.py
@@ -38,7 +38,7 @@ __all__ = [
     "set_data_dir",
 ]
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"
 
 _API_EXPORTS = frozenset(
     {


### PR DESCRIPTION
## Why

Vexor 0.29.0 releases the Collection API reranker support merged in #66. Collection searches can now use the same full set of reranking strategies as indexed-file searches while applying metadata filters before candidate selection and reranking.

## Changes

- bump the Python package, Claude plugin, and MCP Registry manifest versions to 0.29.0
- add concise release notes for Collection rerankers and per-call overrides

## Verification

- `uv sync --locked`
- `python -m ruff check .`
- `python -m pytest --cov=vexor --cov-report=term-missing` — 749 passed, 91% coverage
- `python -m vexor --help`
- `python -m vexor --version` — `Vexor v0.29.0`
- `python -m build --no-isolation` — built wheel and sdist
- `python -m twine check` — both artifacts passed
